### PR TITLE
Optimize and improve DFA.from_nfa (and add a test for this change).

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -143,11 +143,13 @@ class DFA(fa.FA):
 
         state_queue = queue.Queue()
         state_queue.put({nfa.initial_state})
-        max_num_dfa_states = 2**len(nfa.states)
-        for i in range(0, max_num_dfa_states):
+        while not state_queue.empty():
 
             current_states = state_queue.get()
             current_state_name = cls._stringify_states(current_states)
+            if current_state_name in dfa_states:
+                # We've been here before and nothing should have changed.
+                continue
             cls._add_nfa_states_from_queue(nfa, current_states,
                                            current_state_name, dfa_states,
                                            dfa_transitions, dfa_final_states)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -143,6 +143,31 @@ class TestDFA(test_fa.TestFA):
         nose.assert_equal(dfa.initial_state, '{q0}')
         nose.assert_equal(dfa.final_states, {'{q2}'})
 
+    def test_init_nfa_more_complex(self):
+        """Should convert to a DFA a more complex NFA."""
+        nfa = NFA(
+            states={'q0', 'q1', 'q2'},
+            input_symbols={'0', '1'},
+            transitions={
+                'q0': {'0': {'q0', 'q1'}, '1': {'q0'}},
+                'q1': {'0': {'q1'}, '1': {'q2'}},
+                'q2': {'0': {'q2'}, '1': {'q1'}}
+            },
+            initial_state='q0',
+            final_states={'q2'}
+        )
+        dfa = DFA.from_nfa(nfa)
+        nose.assert_equal(dfa.states, {'{q0}', '{q0,q1}', '{q0,q2}', '{q0,q1,q2}'})
+        nose.assert_equal(dfa.input_symbols, {'0', '1'})
+        nose.assert_equal(dfa.transitions, {
+            '{q0}': {'1': '{q0}', '0': '{q0,q1}'},
+            '{q0,q1}': {'1': '{q0,q2}', '0': '{q0,q1}'},
+            '{q0,q2}': {'1': '{q0,q1}', '0': '{q0,q1,q2}'},
+            '{q0,q1,q2}': {'1': '{q0,q1,q2}', '0': '{q0,q1,q2}'}
+        })
+        nose.assert_equal(dfa.initial_state, '{q0}')
+        nose.assert_equal(dfa.final_states, {'{q0,q1,q2}', '{q0,q2}'})
+
     def test_init_nfa_lambda_transition(self):
         """Should convert to a DFA an NFA with a lambda transition."""
         dfa = DFA.from_nfa(self.nfa)


### PR DESCRIPTION
I had an issue converting a NFA (which is a little bit complex) to a DFA, so I took a look at how the conversion works. I came up with these changes:

 * There's no need to re-compute transitions we've already done, so let's skip those.
 * Also let's rely on the queue to determine whether we're done.
   This seems to produce more correct results.

I tried to add a minimal example to the tests.