### PR TITLE
Minify DFAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ dfa.validate()  # returns True
 dfa.copy()  # returns deep copy of dfa
 ```
 
+#### DFA.minify(self)
+
+Creates a minimal DFA which accepts the same inputs as the old one.
+Unreachable states are removed and equivalent states are merged.
+
+```python
+minimal_dfa = dfa.minify()
+```
+
 #### DFA.from_nfa(cls, nfa)
 
 Creates a DFA that is equivalent to the given NFA.

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -195,11 +195,11 @@ class DFA(fa.FA):
                     continue
                 # merge them!
                 s3 = s.union(s2)
-                # add the new one
-                non_marked_states.add(s3)
                 # remove the old ones
                 non_marked_states.remove(s)
                 non_marked_states.remove(s2)
+                # add the new one
+                non_marked_states.add(s3)
                 # set the changed flag
                 changed = True
                 break

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -232,9 +232,9 @@ class DFA(fa.FA):
 
     @staticmethod
     def _stringify_states(states):
-        if isinstance(states, set):
-            states = sorted(states)
         """Stringify the given set of states as a single state name."""
+        if isinstance(states, (set, frozenset)):
+            states = sorted(states)
         return '{{{}}}'.format(','.join(states))
 
     @classmethod

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -3,6 +3,7 @@
 
 import copy
 import queue
+import itertools
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
@@ -102,6 +103,132 @@ class DFA(fa.FA):
             yield current_state
 
         self._check_for_input_rejection(current_state)
+
+    def minify(self):
+        """
+        Create a minimal DFA which accepts the same inputs as this DFA.
+
+        First, non-reachable states are removed.
+        Then, similiar states are merged.
+        """
+        new_dfa = self.copy()
+        new_dfa._remove_unreachable_states()
+        states_table = new_dfa._create_markable_states_table()
+        new_dfa._mark_states_table_first(states_table)
+        new_dfa._mark_states_table_second(states_table)
+        new_dfa._join_non_marked_states(states_table)
+        assert new_dfa.validate()
+        return new_dfa
+
+    def _remove_unreachable_states(self):
+        """Remove states which are not reachable from the initial state."""
+        assert self.validate()
+        reachable_states = self._compute_reachable_states()
+        unreachable_states = self.states - reachable_states
+        for state in unreachable_states:
+            self.states.remove(state)
+            del self.transitions[state]
+        assert self.validate()
+
+    def _compute_reachable_states(self):
+        """Compute the states which are reachable from the initial state."""
+        assert self.validate()
+        reachable_states = set()
+        states_to_check = queue.Queue()
+        states_checked = set()
+        states_to_check.put(self.initial_state)
+        while not states_to_check.empty():
+            state = states_to_check.get()
+            reachable_states.add(state)
+            for symbol, dst_state in self.transitions[state].items():
+                if dst_state not in states_checked:
+                    states_to_check.put(dst_state)
+            states_checked.add(state)
+        return reachable_states
+
+    def _create_markable_states_table(self):
+        """
+        Create a "markable table" with all combinatations of two states.
+
+        This is a dict with frozensets of states as keys and `False` as value.
+        """
+        assert self.validate()
+        table = {
+            frozenset(c): False
+            for c in itertools.combinations(self.states, 2)
+        }
+        return table
+
+    def _mark_states_table_first(self, table):
+        """Mark pairs of states if one is final and one is not."""
+        for s in table.keys():
+            if any((x in self.final_states for x in s)):
+                if any((x not in self.final_states for x in s)):
+                    table[s] = True
+
+    def _mark_states_table_second(self, table):
+        """
+        Mark additional state pairs.
+
+        A non-marked pair of two states q, q_ will be marked
+        if there is an input_symbol a for which the pair
+        transition(q, a), transition(q_, a) is marked.
+        """
+        changed = True
+        while changed:
+            changed = False
+            for s in filter(lambda s: not table[s], table.keys()):
+                s_ = tuple(s)
+                for a in self.input_symbols:
+                    s2 = frozenset({
+                        self._get_next_current_state(s_[0], a),
+                        self._get_next_current_state(s_[1], a)
+                    })
+                    if s2 in table and table[s2]:
+                        table[s] = True
+                        changed = True
+                        break
+
+    def _join_non_marked_states(self, table):
+        """Join all overlapping non-marked pairs of states to a new state."""
+        non_marked_states = set(filter(lambda s: not table[s], table.keys()))
+        changed = True
+        while changed:
+            changed = False
+            for s, s2 in itertools.combinations(non_marked_states, 2):
+                if s2.isdisjoint(s):
+                    continue
+                # merge them!
+                s3 = s.union(s2)
+                # add the new one
+                non_marked_states.add(s3)
+                # remove the old ones
+                non_marked_states.remove(s)
+                non_marked_states.remove(s2)
+                # set the changed flag
+                changed = True
+                break
+        # finally adjust the DFA
+        for s in non_marked_states:
+            stringified = DFA._stringify_states(s)
+            # add the new state
+            self.states.add(stringified)
+            # copy the transitions from one of the states
+            self.transitions[stringified] = self.transitions[tuple(s)[0]]
+            # replace all occurrences of the old states
+            for state in s:
+                self.states.remove(state)
+                del self.transitions[state]
+                for src_state, transition in self.transitions.items():
+                    for symbol in transition.keys():
+                        if transition[symbol] == state:
+                            transition[symbol] = stringified
+                if state in self.final_states:
+                    self.final_states.add(stringified)
+                    self.final_states.remove(state)
+                if state == self.initial_state:
+                    self.initial_state = stringified
+        assert self.validate()
 
     @staticmethod
     def _stringify_states(states):

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -117,22 +117,18 @@ class DFA(fa.FA):
         new_dfa._mark_states_table_first(states_table)
         new_dfa._mark_states_table_second(states_table)
         new_dfa._join_non_marked_states(states_table)
-        assert new_dfa.validate()
         return new_dfa
 
     def _remove_unreachable_states(self):
         """Remove states which are not reachable from the initial state."""
-        assert self.validate()
         reachable_states = self._compute_reachable_states()
         unreachable_states = self.states - reachable_states
         for state in unreachable_states:
             self.states.remove(state)
             del self.transitions[state]
-        assert self.validate()
 
     def _compute_reachable_states(self):
         """Compute the states which are reachable from the initial state."""
-        assert self.validate()
         reachable_states = set()
         states_to_check = queue.Queue()
         states_checked = set()
@@ -152,7 +148,6 @@ class DFA(fa.FA):
 
         This is a dict with frozensets of states as keys and `False` as value.
         """
-        assert self.validate()
         table = {
             frozenset(c): False
             for c in itertools.combinations(self.states, 2)
@@ -228,7 +223,6 @@ class DFA(fa.FA):
                     self.final_states.remove(state)
                 if state == self.initial_state:
                     self.initial_state = stringified
-        assert self.validate()
 
     @staticmethod
     def _stringify_states(states):

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -170,6 +170,29 @@ class TestDFA(test_fa.TestFA):
         nose.assert_equal(minimal_dfa.initial_state, dfa.initial_state)
         nose.assert_equal(minimal_dfa.final_states, dfa.final_states)
 
+    def test_minify_dfa_initial_state(self):
+        """Should minify a DFA where the initial state is being changed."""
+        # This DFA accepts all words with ones and zeroes.
+        # The two states can be merged into one.
+        dfa = DFA(
+            states={'q0', 'q1'},
+            input_symbols={'0', '1'},
+            transitions={
+                'q0': {'0': 'q1', '1': 'q1'},
+                'q1': {'0': 'q0', '1': 'q0'},
+            },
+            initial_state='q0',
+            final_states={'q0', 'q1'},
+        )
+        minimal_dfa = dfa.minify()
+        nose.assert_equal(minimal_dfa.states, {'{q0,q1}'})
+        nose.assert_equal(minimal_dfa.input_symbols, {'0', '1'})
+        nose.assert_equal(minimal_dfa.transitions, {
+            '{q0,q1}': {'0': '{q0,q1}', '1': '{q0,q1}'},
+        })
+        nose.assert_equal(minimal_dfa.initial_state, '{q0,q1}')
+        nose.assert_equal(minimal_dfa.final_states, {'{q0,q1}'})
+
     def test_init_nfa_simple(self):
         """Should convert to a DFA a simple NFA."""
         nfa = NFA(

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -118,6 +118,58 @@ class TestDFA(test_fa.TestFA):
             'q0', 'q0', 'q1', 'q2', 'q1'
         ])
 
+    def test_minify_dfa(self):
+        """Should minify a given DFA."""
+        # This DFA accepts all words which are at least two characters long.
+        # The states q1/q2 and q3/q4/q5/q6 are redundant.
+        # The state q7 is not reachable.
+        dfa = DFA(
+            states={'q0', 'q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7'},
+            input_symbols={'0', '1'},
+            transitions={
+                'q0': {'0': 'q1', '1': 'q2'},
+                'q1': {'0': 'q3', '1': 'q4'},
+                'q2': {'0': 'q5', '1': 'q6'},
+                'q3': {'0': 'q3', '1': 'q3'},
+                'q4': {'0': 'q4', '1': 'q4'},
+                'q5': {'0': 'q5', '1': 'q5'},
+                'q6': {'0': 'q6', '1': 'q6'},
+                'q7': {'0': 'q7', '1': 'q7'},
+            },
+            initial_state='q0',
+            final_states={'q3', 'q4', 'q5', 'q6'}
+        )
+        minimal_dfa = dfa.minify()
+        nose.assert_equal(minimal_dfa.states, {'q0', '{q1,q2}', '{q3,q4,q5,q6}'})
+        nose.assert_equal(minimal_dfa.input_symbols, {'0', '1'})
+        nose.assert_equal(minimal_dfa.transitions, {
+            'q0': {'0': '{q1,q2}', '1': '{q1,q2}'},
+            '{q1,q2}': {'0': '{q3,q4,q5,q6}', '1': '{q3,q4,q5,q6}'},
+            '{q3,q4,q5,q6}': {'0': '{q3,q4,q5,q6}', '1': '{q3,q4,q5,q6}'}
+        })
+        nose.assert_equal(minimal_dfa.initial_state, 'q0')
+        nose.assert_equal(minimal_dfa.final_states, {'{q3,q4,q5,q6}'})
+
+    def test_minify_minimal_dfa(self):
+        """Should minify an already minimal DFA."""
+        # This DFA just accepts words ending in 1.
+        dfa = DFA(
+            states={'q0', 'q1'},
+            input_symbols={'0', '1'},
+            transitions={
+                'q0': {'0': 'q0', '1': 'q1'},
+                'q1': {'0': 'q0', '1': 'q1'}
+            },
+            initial_state='q0',
+            final_states={'q1'}
+        )
+        minimal_dfa = dfa.minify()
+        nose.assert_equal(minimal_dfa.states, dfa.states)
+        nose.assert_equal(minimal_dfa.input_symbols, dfa.input_symbols)
+        nose.assert_equal(minimal_dfa.transitions, dfa.transitions)
+        nose.assert_equal(minimal_dfa.initial_state, dfa.initial_state)
+        nose.assert_equal(minimal_dfa.final_states, dfa.final_states)
+
     def test_init_nfa_simple(self):
         """Should convert to a DFA a simple NFA."""
         nfa = NFA(


### PR DESCRIPTION
A given DFA can be minified by first removing unreachable states and then merging equivalent states.

I've implemented `DFA.minify` (which seems to work, but I'm not exactly sure), added two tests for this (I didn't add tests for `_remove_unreachable_states`, `_compute_reachable_states`, `_create_markable_states_table`, `_mark_states_table_first`, `_mark_states_table_second` and `_join_non_marked_states`) and added a bit of documentation.