### PR TITLE
TM: Support not moving (direction N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ dtm = DTM(
 )
 ```
 
+The direction `N` (for no movement) is also supported.
+
 #### DTM.read_input(self, input_str, step=False)
 
 Returns a tuple containing the final state the machine stopped on, as well as a

--- a/automata/tm/dtm.py
+++ b/automata/tm/dtm.py
@@ -38,7 +38,7 @@ class DTM(tm.TM):
                         tape_symbol, state))
 
     def _validate_transition_result_direction(self, result_direction):
-        if not (result_direction == 'L' or result_direction == 'R'):
+        if result_direction not in ('L', 'N', 'R'):
             raise tm_exceptions.InvalidDirectionError(
                 'result direction is not valid ({})'.format(
                     result_direction))

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -36,6 +36,8 @@ class TMTape(object):
         """Move the tape to the next symbol in the given direction."""
         if direction == 'R':
             self.current_position += 1
+        elif direction == 'N':
+            pass
         elif direction == 'L':  # pragma: no branch
             self.current_position -= 1
 

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -161,3 +161,64 @@ class TestDTM(test_tm.TestTM):
     def test_accepts_input_false(self):
         """Should return False if DTM input is rejected."""
         nose.assert_equal(self.dtm1.accepts_input('000011'), False)
+
+    def test_transition_without_movement(self):
+        """Tests transitions without movements."""
+        dtm = DTM(
+            # should accept 0^n1^n2^n for n >= 0
+            input_symbols={'0', '1', '2'},
+            tape_symbols={'0', '1', '2', '*', '.'},
+            transitions={
+                'q0': {
+                    # replace one 0 with *
+                    '0': ('q1', '*', 'N'),
+                    '*': ('q0', '*', 'R'),
+                    '.': ('qe', '.', 'N'),
+                },
+                'q1': {
+                    # replace one 1 with *
+                    '0': ('q1', '0', 'R'),
+                    '1': ('q2', '*', 'N'),
+                    '*': ('q1', '*', 'R'),
+                },
+                'q2': {
+                    # replace one 2 with *
+                    '1': ('q2', '1', 'R'),
+                    '2': ('q3', '*', 'N'),
+                    '*': ('q2', '*', 'R'),
+                },
+                'q3': {
+                    # seek to end; assert that just 2's or *'s follow
+                    '2': ('q3', '2', 'R'),
+                    '*': ('q3', '*', 'R'),
+                    '.': ('q4', '.', 'L'),
+                },
+                'q4': {
+                    # seek to the beginning; checking if everything is *
+                    '0': ('q5', '0', 'L'),
+                    '1': ('q5', '1', 'L'),
+                    '2': ('q5', '2', 'L'),
+                    '*': ('q4', '*', 'L'),
+                    '.': ('qe', '.', 'R'),
+                },
+                'q5': {
+                    # seek to the beginning
+                    '0': ('q5', '0', 'L'),
+                    '1': ('q5', '1', 'L'),
+                    '2': ('q5', '2', 'L'),
+                    '*': ('q5', '*', 'L'),
+                    '.': ('q0', '.', 'R'),
+                }
+            },
+            states={'q0', 'q1', 'q2', 'q3', 'q4', 'q5', 'qe'},
+            initial_state='q0',
+            blank_symbol='.',
+            final_states={'qe'},
+        )
+        nose.assert_true(dtm.accepts_input(''))
+        nose.assert_true(dtm.accepts_input('012'))
+        nose.assert_true(dtm.accepts_input('001122'))
+        nose.assert_false(dtm.accepts_input('0'))
+        nose.assert_false(dtm.accepts_input('01'))
+        nose.assert_false(dtm.accepts_input('0112'))
+        nose.assert_false(dtm.accepts_input('012012'))


### PR DESCRIPTION
Today, I first tried simulating a DTM. And it didn't work, because the DTM I tried had transitions which didn't move the head.

This PR quickly implements this feature.

A few thoughts:
 * I didn't change the DTM in the README to make use of this.
 * I don't know if this `elif direction == 'N': pass` makes sense.
   But because the other two cases were present in the function, I figured it would be nice.
 * I didn't add any tests. (There's just a little bit new code, if any. - Let's see if Coveralls complains.)