### PR TITLE
Add support for NDPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ nfa = NFA(
 )
 ```
 
-#### NFA.read_input(self, input_str, step=False)
+#### NFA.read_input(self, input_str)
 
 Returns a set of final states the FA stopped on, if the input is accepted.
 
@@ -350,7 +350,7 @@ dpda = DPDA(
 )
 ```
 
-#### DPDA.read_input(self, input_str, step=False)
+#### DPDA.read_input(self, input_str)
 
 Returns a `PDAConfiguration` object representing the DPDA's config.
 This is basically a tuple containing the final state the DPDA stopped on,
@@ -582,7 +582,7 @@ dtm = DTM(
 
 The direction `N` (for no movement) is also supported.
 
-#### DTM.read_input(self, input_str, step=False)
+#### DTM.read_input(self, input_str)
 
 Returns a tuple containing the final state the machine stopped on, as well as a
 `TMTape` object representing the DTM's internal tape (if the input is accepted).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install automata-lib
     - [class NFA](#class-nfafa)
   - [class PDA](#class-pdaautomatonmetaclassabcmeta)
     - [class DPDA](#class-dpdapda)
+    - [class NPDA](#class-npdapda)
   - [class TM](#class-tmautomatonmetaclassabcmeta)
     - [class DTM](#class-dtmtm)
 - [Exception classes](#base-exception-classes)
@@ -397,6 +398,120 @@ dpda.validate()  # returns True
 
 ```python
 dpda.copy()  # returns deep copy of dpda
+```
+
+### class NPDA(PDA)
+
+The `NPDA` class is a subclass of `PDA` and represents a nondeterministic pushdown automaton. It can be found under `automata/pda/npda.py`.
+
+Every NPDA has the following (required) properties:
+
+1. `states`: a `set` of the NPDA's valid states, each of which must be represented as a string
+
+2. `input_symbols`: a `set` of the NPDA's valid input symbols, each of which must also be represented as a string
+
+3. `stack_symbols`: a `set` of the NPDA's valid stack symbols
+
+4. `transitions`: a `dict` consisting of the transitions for each state; see the example below for the exact syntax
+
+5. `initial_state`: the name of the initial state for this NPDA
+
+6. `initial_stack_symbol`: the name of the initial symbol on the stack for this NPDA
+
+7. `final_states`: a `set` of final states for this NPDA
+
+```python
+from automata.pda.npda import NPDA
+# NPDA which matches palindromes consisting of 'a's and 'b's
+# (accepting by final state)
+# q0 reads the first half of the word, q1 the other half, q2 accepts.
+# But we have to guess when to switch.
+npda = NPDA(
+    states={'q0', 'q1', 'q2'},
+    input_symbols={'a', 'b'},
+    stack_symbols={'A', 'B', '#'},
+    transitions={
+        'q0': {
+            '': {
+                '#': {('q2', '#')},
+            },
+            'a': {
+                '#': {('q0', ('A', '#'))},
+                'A': {
+                    ('q0', ('A', 'A')),
+                    ('q1', ''),
+                },
+                'B': {('q0', ('A', 'B'))},
+            },
+            'b': {
+                '#': {('q0', ('B', '#'))},
+                'A': {('q0', ('B', 'A'))},
+                'B': {
+                    ('q0', ('B', 'B')),
+                    ('q1', ''),
+                },
+            },
+        },
+        'q1': {
+            '': {'#': {('q2', '#')}},
+            'a': {'A': {('q1', '')}},
+            'b': {'B': {('q1', '')}},
+        },
+    },
+    initial_state='q0',
+    initial_stack_symbol='#',
+    final_states={'q2'}
+)
+```
+
+#### NPDA.read_input(self, input_str)
+
+Returns a `set` of `PDAConfiguration`s representing all of the NPDA's configurations.
+Each of these is basically a tuple containing the final state the NPDA stopped on,
+the remaining input (an empty string) as well as a `PDAStack` object representing the NPDA's stack (if the input is accepted).
+
+```python
+npda.read_input("aaaa") # returns {PDAConfiguration('q2', '', PDAStack('#',))}
+```
+
+```python
+npda.read_input('ab')  # raises RejectionException
+```
+
+#### NPDA.read_input_stepwise(self, input_str)
+
+Yields `set`s of `PDAConfiguration` object.
+Each of these is basically a tuple containing the current state,
+the remaining input and the current stack as a `PDAStack` object, if the input is accepted.
+
+```python
+npda.read_input_stepwise('aa')
+# yields:
+# {PDAConfiguration('q0', 'aa', PDAStack('#',))}
+# {PDAConfiguration('q0', 'a', PDAStack('#', 'A')), PDAConfiguration('q2', 'aa', PDAStack('#',))}
+# {PDAConfiguration('q0', '', PDAStack('#', 'A', 'A')), PDAConfiguration('q1', '', PDAStack('#',))}
+# {PDAConfiguration('q2', '', PDAStack('#',))}
+```
+
+#### NPDA.accepts_input(self, input_str)
+
+```python
+if npda.accepts_input(my_input_str):
+    print('accepted')
+else:
+    print('rejected')
+```
+
+#### NPDA.validate(self)
+
+```python
+npda.validate()  # returns True
+```
+
+#### NPDA.copy(self)
+
+```python
+npda.copy()  # returns deep copy of npda
 ```
 
 ### class TM(Automaton, metaclass=ABCMeta)

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ the remaining input (an empty string)
 as well as a `PDAStack` object representing the DPDA's stack (if the input is accepted).
 
 ```python
-dpda.read_input('ab')  # returns PDAConfiguration('q3', , PDAStack(('0')))
+dpda.read_input('ab')  # returns PDAConfiguration('q3', '', PDAStack(('0')))
 ```
 
 ```python
@@ -373,9 +373,9 @@ the remaining input and the current stack as a `PDAStack` object, if the input i
 ```python
 dpda.read_input_stepwise('ab')
 # yields:
-# PDAConfiguration(q0, ab, PDAStack(('0')))
-# PDAConfiguration(q1, a, PDAStack(('0', '1')))
-# PDAConfiguration(q3, , PDAStack(('0')))
+# PDAConfiguration('q0', 'ab', PDAStack(('0')))
+# PDAConfiguration('q1', 'a', PDAStack(('0', '1')))
+# PDAConfiguration('q3', '', PDAStack(('0')))
 ```
 
 #### DPDA.accepts_input(self, input_str)

--- a/README.md
+++ b/README.md
@@ -351,11 +351,13 @@ dpda = DPDA(
 
 #### DPDA.read_input(self, input_str, step=False)
 
-Returns a tuple containing the final state the DPDA stopped on, as well as a
-`PDAStack` object representing the DPDA's stack (if the input is accepted).
+Returns a `PDAConfiguration` object representing the DPDA's config.
+This is basically a tuple containing the final state the DPDA stopped on,
+the remaining input (an empty string)
+as well as a `PDAStack` object representing the DPDA's stack (if the input is accepted).
 
 ```python
-dpda.read_input('ab')  # returns ('q3', PDAStack(['0']))
+dpda.read_input('ab')  # returns PDAConfiguration('q3', , PDAStack(('0')))
 ```
 
 ```python
@@ -364,21 +366,17 @@ dpda.read_input('aab')  # raises RejectionException
 
 #### DPDA.read_input_stepwise(self, input_str)
 
-Yields tuples containing the current state and the current stack as a `PDAStack`
-object, if the input is accepted.
+Yields `PDAConfiguration` objects.
+These are basically tuples containing the current state,
+the remaining input and the current stack as a `PDAStack` object, if the input is accepted.
 
 ```python
-((state, stack.copy()) for state, stack in dpda.read_input_stepwise('ab'))
+dpda.read_input_stepwise('ab')
 # yields:
-# ('q0', PDAStack(['0']))
-# ('q1', PDAStack(['0', '1']))
-# ('q3', PDAStack(['0']))
+# PDAConfiguration(q0, ab, PDAStack(('0')))
+# PDAConfiguration(q1, a, PDAStack(('0', '1')))
+# PDAConfiguration(q3, , PDAStack(('0')))
 ```
-
-Please note that each tuple contains a reference to (not a copy of) the current
-`PDAStack` object. Therefore, if you wish to store the stack at every step, you
-must copy the stack as you iterate over the automaton configurations (as shown
-above).
 
 #### DPDA.accepts_input(self, input_str)
 

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -25,7 +25,7 @@ class PDAConfiguration(collections.namedtuple(
 
     def __repr__(self):
         """Return a string representation of the configuration."""
-        return '{}({}, {}, {})'.format(
+        return '{}(\'{}\', \'{}\', {})'.format(
             self.__class__.__name__,
             self.state,
             self.remaining_input,

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -25,4 +25,9 @@ class PDAConfiguration(collections.namedtuple(
 
     def __repr__(self):
         """Return a string representation of the configuration."""
-        return '{}({})'.format(self.__class__.__name__, self.__dict__)
+        return '{}({}, {}, {})'.format(
+            self.__class__.__name__,
+            self.state,
+            self.remaining_input,
+            self.stack
+        )

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Classes and methods for working with PDA configurations."""
+
+
+class PDAConfiguration(object):
+    """
+    A configuration is a triple of current state, remaining input and stack.
+
+    It represents the complete runtime state of a PDA.
+    """
+
+    def __init__(self, state, remaining_input, stack):
+        """Initialize the new PDA configuration."""
+        self.state = state
+        self.remaining_input = remaining_input
+        self.stack = stack
+
+    def replace_stack_top(self, new_stack_top):
+        if new_stack_top == '':
+            self.stack.pop()
+        else:
+            self.stack.replace(new_stack_top)
+
+    def pop_symbol(self):
+        symbol = self.remaining_input[0]
+        self.remaining_input = self.remaining_input[1:]
+        return symbol
+
+    def copy(self):
+        """Return a deep copy of the PDA configuration."""
+        return self.__class__(
+            self.state, self.remaining_input, self.stack.copy()
+        )
+
+    def __repr__(self):
+        """Return a string representation of the configuration."""
+        return '{}({})'.format(self.__class__.__name__, self.__dict__)
+
+    def __eq__(self, other):
+        """Check if two configurations are equal."""
+        return self.__dict__ == other.__dict__

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -1,41 +1,28 @@
 #!/usr/bin/env python3
 """Classes and methods for working with PDA configurations."""
 
+import collections
 
-class PDAConfiguration(object):
+
+class PDAConfiguration(collections.namedtuple(
+    'PDAConfiguration',
+    ['state', 'remaining_input', 'stack']
+)):
     """
     A configuration is a triple of current state, remaining input and stack.
 
     It represents the complete runtime state of a PDA.
+    It is hashable and immutable.
     """
 
-    def __init__(self, state, remaining_input, stack):
-        """Initialize the new PDA configuration."""
-        self.state = state
-        self.remaining_input = remaining_input
-        self.stack = stack
-
-    def replace_stack_top(self, new_stack_top):
-        if new_stack_top == '':
-            self.stack.pop()
-        else:
-            self.stack.replace(new_stack_top)
-
-    def pop_symbol(self):
-        symbol = self.remaining_input[0]
-        self.remaining_input = self.remaining_input[1:]
-        return symbol
-
     def copy(self):
-        """Return a deep copy of the PDA configuration."""
-        return self.__class__(
-            self.state, self.remaining_input, self.stack.copy()
-        )
+        """
+        Return a deep copy of the PDA configuration.
+
+        As this class is immutable, this has no effect.
+        """
+        return self
 
     def __repr__(self):
         """Return a string representation of the configuration."""
         return '{}({})'.format(self.__class__.__name__, self.__dict__)
-
-    def __eq__(self, other):
-        """Check if two configurations are equal."""
-        return self.__dict__ == other.__dict__

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -107,11 +107,10 @@ class DPDA(pda.PDA):
             )
 
     def _replace_stack_top(self, stack, new_stack_top):
-        new_stack = stack.copy()
         if new_stack_top == '':
-            new_stack.pop()
+            new_stack = stack.pop()
         else:
-            new_stack.replace(new_stack_top)
+            new_stack = stack.replace(new_stack_top)
         return new_stack
 
     def _has_accepted(self, current_configuration):

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -106,16 +106,28 @@ class DPDA(pda.PDA):
                 *(self.transitions[state][input_symbol][stack_symbol])
             )
 
+    def _has_accepted(self, current_configuration):
+        """Check whether the given config indicates accepted input."""
+        # If there's input left, we're not finished.
+        if current_configuration.remaining_input:
+            return False
+        # If the stack is empty, we accept.
+        if not current_configuration.stack:
+            return True
+        # If current state is a final state, we accept.
+        if current_configuration.state in self.final_states:
+            return True
+        # Otherwise, not.
+        return False
+
     def _check_for_input_rejection(self, current_configuration):
         """Raise an error if the given config indicates rejected input."""
-        # If current state is not a final state and stack is not empty
-        if current_configuration.state not in self.final_states:
-            if current_configuration.stack:
-                raise exceptions.RejectionException(
-                    'the DPDA stopped in a non-accepting configuration '
-                    '({state}, {stack})'
-                    .format(**current_configuration.__dict__)
-                )
+        if not self._has_accepted(current_configuration):
+            raise exceptions.RejectionException(
+                'the DPDA stopped in a non-accepting configuration '
+                '({state}, {stack})'
+                .format(**current_configuration.__dict__)
+            )
 
     def _get_next_configuration(self, old_config):
         """Advance to the next configuration."""
@@ -182,4 +194,6 @@ class DPDA(pda.PDA):
                 current_configuration
             )
             yield current_configuration
+            if self._has_accepted(current_configuration):
+                return
         self._check_for_input_rejection(current_configuration)

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -103,8 +103,7 @@ class DPDA(pda.PDA):
                 stack_symbol in self.transitions[state][input_symbol]):
             return (
                 input_symbol,
-                *(self.transitions[state][input_symbol][stack_symbol])
-            )
+            ) + self.transitions[state][input_symbol][stack_symbol]
 
     def _replace_stack_top(self, stack, new_stack_top):
         if new_stack_top == '':

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -106,6 +106,14 @@ class DPDA(pda.PDA):
                 *(self.transitions[state][input_symbol][stack_symbol])
             )
 
+    def _replace_stack_top(self, stack, new_stack_top):
+        new_stack = stack.copy()
+        if new_stack_top == '':
+            new_stack.pop()
+        else:
+            new_stack.replace(new_stack_top)
+        return new_stack
+
     def _has_accepted(self, current_configuration):
         """Check whether the given config indicates accepted input."""
         # If there's input left, we're not finished.
@@ -126,7 +134,7 @@ class DPDA(pda.PDA):
             raise exceptions.RejectionException(
                 'the DPDA stopped in a non-accepting configuration '
                 '({state}, {stack})'
-                .format(**current_configuration.__dict__)
+                .format(**current_configuration._asdict())
             )
 
     def _get_next_configuration(self, old_config):
@@ -163,11 +171,14 @@ class DPDA(pda.PDA):
                 )
             )
         input_symbol, new_state, new_stack_top = transitions.pop()
-        new_config = old_config.copy()
-        new_config.state = new_state
-        new_config.replace_stack_top(new_stack_top)
+        remaining_input = old_config.remaining_input
         if input_symbol:
-            new_config.pop_symbol()
+            remaining_input = remaining_input[1:]
+        new_config = PDAConfiguration(
+            new_state,
+            remaining_input,
+            self._replace_stack_top(old_config.stack, new_stack_top)
+        )
         return new_config
 
     def read_input_stepwise(self, input_str):

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -90,6 +90,14 @@ class NPDA(pda.PDA):
                 ))
         return transitions
 
+    def _replace_stack_top(self, stack, new_stack_top):
+        new_stack = stack.copy()
+        if new_stack_top == '':
+            new_stack.pop()
+        else:
+            new_stack.replace(new_stack_top)
+        return new_stack
+
     def _has_accepted(self, current_configuration):
         """Check whether the given config indicates accepted input."""
         # If there's input left, we're not finished.
@@ -120,10 +128,14 @@ class NPDA(pda.PDA):
         ))
         new_configs = set()
         for input_symbol, new_state, new_stack_top in transitions:
-            new_config = old_config.copy()
-            new_config.replace_stack_top(new_stack_top)
+            remaining_input = old_config.remaining_input
             if input_symbol:
-                new_config.pop_symbol()
+                remaining_input = remaining_input[1:]
+            new_config = PDAConfiguration(
+                new_state,
+                remaining_input,
+                self._replace_stack_top(old_config.stack, new_stack_top)
+            )
             new_configs.add(new_config)
         return new_configs
 

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -91,11 +91,10 @@ class NPDA(pda.PDA):
         return transitions
 
     def _replace_stack_top(self, stack, new_stack_top):
-        new_stack = stack.copy()
         if new_stack_top == '':
-            new_stack.pop()
+            new_stack = stack.pop()
         else:
-            new_stack.replace(new_stack_top)
+            new_stack = stack.replace(new_stack_top)
         return new_stack
 
     def _has_accepted(self, current_configuration):

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -153,7 +153,7 @@ class NPDA(pda.PDA):
 
         yield current_configurations
 
-        while current_configurations:  # TODO
+        while current_configurations:
             new_configurations = set()
             for config in current_configurations:
                 if self._has_accepted(config):
@@ -170,7 +170,8 @@ class NPDA(pda.PDA):
                     new_configurations.update(
                         self._get_next_configurations(config)
                     )
-                yield current_configurations
+            current_configurations = new_configurations
+            yield current_configurations
 
         raise exceptions.RejectionException(
             'the NPDA did not reach an accepting configuration'

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Classes and methods for working with nondeterministic pushdown automata."""
+
+import copy
+
+import automata.base.exceptions as exceptions
+import automata.pda.exceptions as pda_exceptions
+import automata.pda.pda as pda
+from automata.pda.configuration import PDAConfiguration
+from automata.pda.stack import PDAStack
+
+
+class NPDA(pda.PDA):
+    """A nondeterministic pushdown automaton."""
+
+    def __init__(self, *, states, input_symbols, stack_symbols,
+                 transitions, initial_state,
+                 initial_stack_symbol, final_states):
+        """Initialize a complete NPDA."""
+        self.states = states.copy()
+        self.input_symbols = input_symbols.copy()
+        self.stack_symbols = stack_symbols.copy()
+        self.transitions = copy.deepcopy(transitions)
+        self.initial_state = initial_state
+        self.initial_stack_symbol = initial_stack_symbol
+        self.final_states = final_states.copy()
+        self.validate()
+
+    def _validate_transition_invalid_symbols(self, start_state, paths):
+        """Raise an error if transition symbols are invalid."""
+        for input_symbol, symbol_paths in paths.items():
+            self._validate_transition_invalid_input_symbols(
+                start_state, input_symbol)
+            for stack_symbol in symbol_paths:
+                self._validate_transition_invalid_stack_symbols(
+                    start_state, stack_symbol)
+
+    def _validate_transition_invalid_input_symbols(self, start_state,
+                                                   input_symbol):
+        """Raise an error if transition input symbols are invalid."""
+        if input_symbol not in self.input_symbols and input_symbol != '':
+            raise exceptions.InvalidSymbolError(
+                'state {} has invalid transition input symbol {}'.format(
+                    start_state, input_symbol))
+
+    def _validate_transition_invalid_stack_symbols(self, start_state,
+                                                   stack_symbol):
+        """Raise an error if transition stack symbols are invalid."""
+        if stack_symbol not in self.stack_symbols:
+            raise exceptions.InvalidSymbolError(
+                'state {} has invalid transition stack symbol {}'.format(
+                    start_state, stack_symbol))
+
+    def _validate_initial_stack_symbol(self):
+        """Raise an error if initial stack symbol is invalid."""
+        if self.initial_stack_symbol not in self.stack_symbols:
+            raise exceptions.InvalidSymbolError(
+                'initial stack symbol {} is invalid'.format(
+                    self.initial_stack_symbol))
+
+    def validate(self):
+        """Return True if this NPDA is internally consistent."""
+        for start_state, paths in self.transitions.items():
+            self._validate_transition_invalid_symbols(start_state, paths)
+        self._validate_initial_state()
+        self._validate_initial_stack_symbol()
+        self._validate_final_states()
+        return True
+
+    def _has_lambda_transition(self, state, stack_symbol):
+        """Return True if the current config has any lambda transitions."""
+        return (state in self.transitions and
+                '' in self.transitions[state] and
+                stack_symbol in self.transitions[state][''])
+
+    def _get_transitions(self, state, input_symbol, stack_symbol):
+        """Get the transition tuples for the given state and symbols."""
+        transitions = set()
+        if (state in self.transitions and
+                input_symbol in self.transitions[state] and
+                stack_symbol in self.transitions[state][input_symbol]):
+            for (
+                dest_state,
+                new_stack_top
+            ) in self.transitions[state][input_symbol][stack_symbol]:
+                transitions.add((
+                    input_symbol,
+                    dest_state,
+                    new_stack_top
+                ))
+        return transitions
+
+    def _has_accepted(self, current_configuration):
+        """Check whether the given config indicates accepted input."""
+        # If there's input left, we're not finished.
+        if current_configuration.remaining_input:
+            return False
+        # If the stack is empty, we accept.
+        if not current_configuration.stack:
+            return True
+        # If current state is a final state, we accept.
+        if current_configuration.state in self.final_states:
+            return True
+        # Otherwise, not.
+        return False
+
+    def _get_next_configurations(self, old_config):
+        """Advance to the next configurations."""
+        transitions = set()
+        if old_config.remaining_input:
+            transitions.update(self._get_transitions(
+                old_config.state,
+                old_config.remaining_input[0],
+                old_config.stack.top()
+            ))
+        transitions.update(self._get_transitions(
+            old_config.state,
+            '',
+            old_config.stack.top()
+        ))
+        new_configs = set()
+        for input_symbol, new_state, new_stack_top in transitions:
+            new_config = old_config.copy()
+            new_config.replace_stack_top(new_stack_top)
+            if input_symbol:
+                new_config.pop_symbol()
+            new_configs.add(new_config)
+        return new_configs
+
+    def read_input_stepwise(self, input_str):
+        """
+        Check if the given string is accepted by this NPDA.
+
+        Yield the NPDA's current configurations at each step.
+        """
+        current_configurations = set()
+        current_configurations.add(PDAConfiguration(
+            self.initial_state,
+            input_str,
+            PDAStack([self.initial_stack_symbol])
+        ))
+
+        yield current_configurations
+
+        while current_configurations:  # TODO
+            new_configurations = set()
+            for config in current_configurations:
+                if self._has_accepted(config):
+                    # One accepting configuration is enough.
+                    return
+                if config.remaining_input:
+                    new_configurations.update(
+                        self._get_next_configurations(config)
+                    )
+                elif self._has_lambda_transition(
+                    config.state,
+                    config.stack.top()
+                ):
+                    new_configurations.update(
+                        self._get_next_configurations(config)
+                    )
+                yield current_configurations
+
+        raise exceptions.RejectionException(
+            'the NPDA did not reach an accepting configuration'
+        )

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -60,4 +60,4 @@ class PDAStack(collections.namedtuple('PDAStack', ['stack'])):
 
     def __repr__(self):
         """Return a string representation of the stack."""
-        return '{}({})'.format(self.__class__.__name__, self.stack)
+        return '{}{}'.format(self.__class__.__name__, self.stack)

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -7,10 +7,12 @@ import collections
 class PDAStack(collections.namedtuple('PDAStack', ['stack'])):
     """A PDA stack."""
 
-    def __new__(cls, stack):
+    def __new__(cls, *elements):
         """Create the new PDA stack."""
-        if not isinstance(stack, tuple):
-            stack = tuple(stack)
+        if len(elements) == 1:
+            stack = tuple(elements[0])
+        else:
+            stack = elements
         return super(PDAStack, cls).__new__(cls, stack)
 
     def top(self):

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 """Classes and methods for working with PDA stacks."""
 
+import collections
 
-class PDAStack(object):
+
+class PDAStack(collections.namedtuple('PDAStack', ['stack'])):
     """A PDA stack."""
 
-    def __init__(self, stack):
-        """Initialize the new PDA stack."""
-        self.stack = list(stack)
+    def __new__(cls, stack):
+        """Create the new PDA stack."""
+        if not isinstance(stack, tuple):
+            stack = tuple(stack)
+        return super(PDAStack, cls).__new__(cls, stack)
 
     def top(self):
         """Return the symbol at the top of the stack."""
@@ -17,21 +21,34 @@ class PDAStack(object):
             return ''
 
     def pop(self):
-        """Pop the stack top from the stack."""
-        self.stack.pop()
+        """
+        Pop the stack top from the stack.
+
+        Return a new PDAStack with the new content.
+        """
+        l = list(self.stack)
+        l.pop()
+        return self.__class__(l)
 
     def replace(self, symbols):
         """
         Replace the top of the stack with the given symbols.
 
+        Return a new PDAStack with the new content.
         The first symbol in the given sequence becomes the new stack top.
         """
-        self.stack.pop()
-        self.stack.extend(reversed(symbols))
+        l = list(self.stack)
+        l.pop()
+        l.extend(reversed(symbols))
+        return self.__class__(l)
 
     def copy(self):
-        """Return a deep copy of the stack."""
-        return self.__class__(**self.__dict__)
+        """
+        Return a deep copy of the stack.
+
+        As this class is immutable, this has no effect.
+        """
+        return self
 
     def __len__(self):
         """Return the number of symbols on the stack."""
@@ -44,7 +61,3 @@ class PDAStack(object):
     def __repr__(self):
         """Return a string representation of the stack."""
         return '{}({})'.format(self.__class__.__name__, self.stack)
-
-    def __eq__(self, other):
-        """Check if two stacks are equal."""
-        return self.__dict__ == other.__dict__

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -28,9 +28,9 @@ class PDAStack(collections.namedtuple('PDAStack', ['stack'])):
 
         Return a new PDAStack with the new content.
         """
-        l = list(self.stack)
-        l.pop()
-        return self.__class__(l)
+        stack_contents = list(self.stack)
+        stack_contents.pop()
+        return self.__class__(stack_contents)
 
     def replace(self, symbols):
         """
@@ -39,10 +39,10 @@ class PDAStack(collections.namedtuple('PDAStack', ['stack'])):
         Return a new PDAStack with the new content.
         The first symbol in the given sequence becomes the new stack top.
         """
-        l = list(self.stack)
-        l.pop()
-        l.extend(reversed(symbols))
-        return self.__class__(l)
+        stack_contents = list(self.stack)
+        stack_contents.pop()
+        stack_contents.extend(reversed(symbols))
+        return self.__class__(stack_contents)
 
     def copy(self):
         """

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -123,7 +123,7 @@ class TestDPDA(test_pda.TestPDA):
         """Should create an exact of the PDA stack."""
         stack = PDAStack(['a', 'b'])
         stack_copy = stack.copy()
-        nose.assert_is_not(stack, stack_copy)
+        nose.assert_is(stack, stack_copy)
         nose.assert_equal(stack, stack_copy)
 
     def test_stack_iter(self):
@@ -133,4 +133,4 @@ class TestDPDA(test_pda.TestPDA):
     def test_stack_repr(self):
         """Should create proper string representation of PDA stack."""
         stack = PDAStack(['a', 'b'])
-        nose.assert_equal(repr(stack), 'PDAStack([\'a\', \'b\'])')
+        nose.assert_equal(repr(stack), 'PDAStack((\'a\', \'b\'))')

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -118,19 +118,3 @@ class TestDPDA(test_pda.TestPDA):
     def test_accepts_input_false(self):
         """Should return False if DPDA input is rejected."""
         nose.assert_equal(self.dpda.accepts_input('aab'), False)
-
-    def test_stack_copy(self):
-        """Should create an exact of the PDA stack."""
-        stack = PDAStack(['a', 'b'])
-        stack_copy = stack.copy()
-        nose.assert_is(stack, stack_copy)
-        nose.assert_equal(stack, stack_copy)
-
-    def test_stack_iter(self):
-        """Should loop through the PDA stack in some manner."""
-        nose.assert_equal(list(PDAStack(['a', 'b'])), ['a', 'b'])
-
-    def test_stack_repr(self):
-        """Should create proper string representation of PDA stack."""
-        stack = PDAStack(['a', 'b'])
-        nose.assert_equal(repr(stack), 'PDAStack((\'a\', \'b\'))')

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -9,6 +9,7 @@ import automata.base.exceptions as exceptions
 import automata.pda.exceptions as pda_exceptions
 import tests.test_pda as test_pda
 from automata.pda.dpda import DPDA
+from automata.pda.configuration import PDAConfiguration
 from automata.pda.stack import PDAStack
 
 
@@ -69,13 +70,17 @@ class TestDPDA(test_pda.TestPDA):
     def test_read_input_valid_accept_by_final_state(self):
         """Should return correct config if DPDA accepts by final state."""
         nose.assert_equal(
-            self.dpda.read_input('aabb'), ('q3', PDAStack(['0'])))
+            self.dpda.read_input('aabb'),
+            PDAConfiguration('q3', '', PDAStack(['0']))
+        )
 
     def test_read_input_valid_accept_by_empty_stack(self):
         """Should return correct config if DPDA accepts by empty stack."""
         self.dpda.transitions['q2']['']['0'] = ('q2', '')
         nose.assert_equal(
-            self.dpda.read_input('aabb'), ('q2', PDAStack([])))
+            self.dpda.read_input('aabb'),
+            PDAConfiguration('q2', '', PDAStack([]))
+        )
 
     def test_read_input_valid_consecutive_lambda_transitions(self):
         """Should follow consecutive lambda transitions when validating."""
@@ -86,7 +91,9 @@ class TestDPDA(test_pda.TestPDA):
             '': {'0': ('q4', ('0',))}
         }
         nose.assert_equal(
-            self.dpda.read_input('aabb'), ('q4', PDAStack(['0'])))
+            self.dpda.read_input('aabb'),
+            PDAConfiguration('q4', '', PDAStack(['0']))
+        )
 
     def test_read_input_rejected_accept_by_final_state(self):
         """Should reject strings if DPDA accepts by final state."""

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -49,6 +49,12 @@ class TestDPDA(test_pda.TestPDA):
             self.dpda.transitions['q2']['b']['0'] = ('q2', '0')
             self.dpda.validate()
 
+    def test_read_input_rejected_nondeterministic_transition(self):
+        """Should raise error if DPDA exhibits nondeterminism."""
+        with nose.assert_raises(pda_exceptions.NondeterminismError):
+            self.dpda.transitions['q2']['b']['0'] = ('q2', '0')
+            self.dpda.read_input("abb")
+
     def test_validate_invalid_initial_state(self):
         """Should raise error if the initial state is invalid."""
         with nose.assert_raises(exceptions.InvalidStateError):

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -124,3 +124,16 @@ class TestDPDA(test_pda.TestPDA):
     def test_accepts_input_false(self):
         """Should return False if DPDA input is rejected."""
         nose.assert_equal(self.dpda.accepts_input('aab'), False)
+
+    def test_empty_dpda(self):
+        """Should accept an empty input if the DPDA is empty."""
+        dpda = DPDA(
+            states={'q0'},
+            input_symbols=set(),
+            stack_symbols={'0'},
+            transitions=dict(),
+            initial_state='q0',
+            initial_stack_symbol='0',
+            final_states={'q0'},
+        )
+        nose.assert_true(dpda.accepts_input(''))

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of NPDAs."""
+
+# from unittest.mock import patch
+
+import nose.tools as nose
+
+import automata.base.exceptions as exceptions
+import tests.test_pda as test_pda
+from automata.pda.npda import NPDA
+from automata.pda.configuration import PDAConfiguration
+from automata.pda.stack import PDAStack
+
+
+class TestNPDA(test_pda.TestPDA):
+    """A test class for testing nondeterministic finite automata."""
+
+    def test_init_npda(self):
+        """Should copy NPDA if passed into NPDA constructor."""
+        new_npda = NPDA.copy(self.npda)
+        self.assert_is_copy(new_npda, self.npda)
+
+    def test_init_npda_missing_formal_params(self):
+        """Should raise an error if formal NPDA parameters are missing."""
+        with nose.assert_raises(TypeError):
+            NPDA(
+                states={'q0', 'q1', 'q2'},
+                input_symbols={'a', 'b'},
+                initial_state='q0',
+                final_states={'q0'}
+            )
+
+    def test_validate_invalid_input_symbol(self):
+        """Should raise error if a transition has an invalid input symbol."""
+        with nose.assert_raises(exceptions.InvalidSymbolError):
+            self.npda.transitions['q1']['c'] = 'q2'
+            self.npda.validate()
+
+    def test_validate_invalid_stack_symbol(self):
+        """Should raise error if a transition has an invalid stack symbol."""
+        with nose.assert_raises(exceptions.InvalidSymbolError):
+            self.npda.transitions['q1']['a']['2'] = {('q1', ('1', '1'))}
+            self.npda.validate()
+
+    def test_validate_invalid_initial_state(self):
+        """Should raise error if the initial state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.npda.initial_state = 'q4'
+            self.npda.validate()
+
+    def test_validate_invalid_initial_stack_symbol(self):
+        """Should raise error if the initial stack symbol is invalid."""
+        with nose.assert_raises(exceptions.InvalidSymbolError):
+            self.npda.initial_stack_symbol = '2'
+            self.npda.validate()
+
+    def test_validate_invalid_final_state(self):
+        """Should raise error if the final state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.npda.final_states = {'q4'}
+            self.npda.validate()
+
+    def test_read_input_valid_accept_by_final_state(self):
+        """Should return correct config if NPDA accepts by final state."""
+        nose.assert_equal(
+            self.npda.read_input('abaaba'),
+            {PDAConfiguration('q2', '', PDAStack(['#']))}
+        )
+
+    def test_read_input_valid_accept_by_empty_stack(self):
+        """Should return correct config if NPDA accepts by empty stack."""
+        self.npda.transitions['q2'] = {'': {'#': {('q2', '')}}}
+        self.npda.final_states = set()
+        nose.assert_equal(
+            self.npda.read_input('abaaba'),
+            {PDAConfiguration('q2', '', PDAStack([]))}
+        )
+
+    def test_read_input_valid_consecutive_lambda_transitions(self):
+        """Should follow consecutive lambda transitions when validating."""
+        self.npda.states.update({'q3', 'q4'})
+        self.npda.final_states = {'q4'}
+        self.npda.transitions['q2'] = {'': {'#': {('q3', '#')}}}
+        self.npda.transitions['q3'] = {'': {'#': {('q4', '#')}}}
+        nose.assert_equal(
+            self.npda.read_input('abaaba'),
+            {PDAConfiguration('q4', '', PDAStack(['#']))}
+        )
+
+    def test_read_input_rejected_accept_by_final_state(self):
+        """Should reject strings if NPDA accepts by final state."""
+        with nose.assert_raises(exceptions.RejectionException):
+            self.npda.read_input('aaba')
+
+    def test_read_input_rejected_accept_by_empty_stack(self):
+        """Should reject strings if NPDA accepts by empty stack."""
+        self.npda.transitions['q2'] = {'': {'#': {('q2', '')}}}
+        self.npda.final_states = set()
+        with nose.assert_raises(exceptions.RejectionException):
+            self.npda.read_input('aaba')
+
+    def test_read_input_rejected_undefined_transition(self):
+        """Should reject strings which lead to an undefined transition."""
+        with nose.assert_raises(exceptions.RejectionException):
+            self.npda.read_input('01')
+
+    def test_accepts_input_true(self):
+        """Should return True if NPDA input is accepted."""
+        nose.assert_equal(self.npda.accepts_input('abaaba'), True)
+
+    def test_accepts_input_false(self):
+        """Should return False if NPDA input is rejected."""
+        nose.assert_equal(self.npda.accepts_input('aaba'), False)

--- a/tests/test_pda.py
+++ b/tests/test_pda.py
@@ -4,6 +4,7 @@
 import nose.tools as nose
 
 from automata.pda.dpda import DPDA
+from automata.pda.npda import NPDA
 
 
 class TestPDA(object):
@@ -33,6 +34,47 @@ class TestPDA(object):
             initial_state='q0',
             initial_stack_symbol='0',
             final_states={'q3'}
+        )
+
+        # NPDA which matches palindromes consisting of 'a's and 'b's
+        # (accepting by final state)
+        # q0 reads the first half of the word, q1 the other half, q2 accepts.
+        # But we have to guess when to switch.
+        self.npda = NPDA(
+            states={'q0', 'q1', 'q2'},
+            input_symbols={'a', 'b'},
+            stack_symbols={'A', 'B', '#'},
+            transitions={
+                'q0': {
+                    '': {
+                        '#': {('q2', '#')},
+                    },
+                    'a': {
+                        '#': {('q0', ('A', '#'))},
+                        'A': {
+                            ('q0', ('A', 'A')),
+                            ('q1', ''),
+                        },
+                        'B': {('q0', ('A', 'B'))},
+                    },
+                    'b': {
+                        '#': {('q0', ('B', '#'))},
+                        'A': {('q0', ('B', 'A'))},
+                        'B': {
+                            ('q0', ('B', 'B')),
+                            ('q1', ''),
+                        },
+                    },
+                },
+                'q1': {
+                    '': {'#': {('q2', '#')}},
+                    'a': {'A': {('q1', '')}},
+                    'b': {'B': {('q1', '')}},
+                },
+            },
+            initial_state='q0',
+            initial_stack_symbol='#',
+            final_states={'q2'}
         )
 
     def assert_is_copy(self, first, second):

--- a/tests/test_pdaconfiguration.py
+++ b/tests/test_pdaconfiguration.py
@@ -25,5 +25,5 @@ class TestPDAConfiguration(test_pda.TestPDA):
         config = PDAConfiguration('q0', 'ab', PDAStack(['a', 'b']))
         nose.assert_equal(
             repr(config),
-            'PDAConfiguration(q0, ab, PDAStack((\'a\', \'b\')))'
+            'PDAConfiguration(\'q0\', \'ab\', PDAStack((\'a\', \'b\')))'
         )

--- a/tests/test_pdaconfiguration.py
+++ b/tests/test_pdaconfiguration.py
@@ -25,5 +25,5 @@ class TestPDAConfiguration(test_pda.TestPDA):
         config = PDAConfiguration('q0', 'ab', PDAStack(['a', 'b']))
         nose.assert_equal(
             repr(config),
-            'PDAConfiguration(\'q0\', \'ab\', PDAStack((\'a\', \'b\')))'
+            'PDAConfiguration(\'q0\', \'ab\', PDAStack(\'a\', \'b\'))'
         )

--- a/tests/test_pdaconfiguration.py
+++ b/tests/test_pdaconfiguration.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of PDAConfigurations."""
+
+# from unittest.mock import patch
+
+import nose.tools as nose
+
+import tests.test_pda as test_pda
+from automata.pda.configuration import PDAConfiguration
+from automata.pda.stack import PDAStack
+
+
+class TestPDAConfiguration(test_pda.TestPDA):
+    """A test class for testing configurations of pushdown automata."""
+
+    def test_config_copy(self):
+        """Should create an exact copy of the PDA config."""
+        config = PDAConfiguration('q0', 'ab', PDAStack(['a', 'b']))
+        config_copy = config.copy()
+        nose.assert_is(config, config_copy)
+        nose.assert_equal(config, config_copy)
+
+    def test_config_repr(self):
+        """Should create proper string representation of PDA stack."""
+        config = PDAConfiguration('q0', 'ab', PDAStack(['a', 'b']))
+        nose.assert_equal(
+            repr(config),
+            'PDAConfiguration(q0, ab, PDAStack((\'a\', \'b\')))'
+        )

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -19,6 +19,11 @@ class TestPDAStack(test_pda.TestPDA):
         nose.assert_is(stack, stack_copy)
         nose.assert_equal(stack, stack_copy)
 
+    def test_create_with_multiple_parameters(self):
+        """Should create a new PDA stack with elements passed as parameters."""
+        stack = PDAStack('a', 'b')
+        nose.assert_equal(stack, PDAStack(('a', 'b')))
+
     def test_stack_iter(self):
         """Should loop through the PDA stack in some manner."""
         nose.assert_equal(list(PDAStack(['a', 'b'])), ['a', 'b'])

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -26,4 +26,4 @@ class TestPDAStack(test_pda.TestPDA):
     def test_stack_repr(self):
         """Should create proper string representation of PDA stack."""
         stack = PDAStack(['a', 'b'])
-        nose.assert_equal(repr(stack), 'PDAStack((\'a\', \'b\'))')
+        nose.assert_equal(repr(stack), 'PDAStack(\'a\', \'b\')')

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of PDAStacks."""
+
+# from unittest.mock import patch
+
+import nose.tools as nose
+
+import tests.test_pda as test_pda
+from automata.pda.stack import PDAStack
+
+
+class TestPDAStack(test_pda.TestPDA):
+    """A test class for testing stacks of pushdown automata."""
+
+    def test_stack_copy(self):
+        """Should create an exact of the PDA stack."""
+        stack = PDAStack(['a', 'b'])
+        stack_copy = stack.copy()
+        nose.assert_is(stack, stack_copy)
+        nose.assert_equal(stack, stack_copy)
+
+    def test_stack_iter(self):
+        """Should loop through the PDA stack in some manner."""
+        nose.assert_equal(list(PDAStack(['a', 'b'])), ['a', 'b'])
+
+    def test_stack_repr(self):
+        """Should create proper string representation of PDA stack."""
+        stack = PDAStack(['a', 'b'])
+        nose.assert_equal(repr(stack), 'PDAStack((\'a\', \'b\'))')


### PR DESCRIPTION
This pull request adds a new class `NPDA` which represents nondeterministic pushdown automata.

**It will probably break existing code using DPDAs.** Sorry about that.

So, what it does is basically the following:
 * `PDAStack` becomes immutable and hashable. It still represents the current stack of a PDA.
 * `PDAConfiguration` is new. This is a (immutable and hashable) class representing the current configuration of a PDA. It is basically a tuple of state, remaining input and stack. `DPDA` has been changed to use it.
 * `DPDA._get_next_configuration` is the main thing, now.
 * A step in `read_input_stepwise` is now one transition and not one read symbol.
 * `DPDA._has_accepted` is new. (It does what the name says it does.)
 * `NPDA` is new. It is very similar to `DPDA`; the main difference is that it holds a set of current configurations instead of just one.
* Tests and documentation for all of this have been added.

This code still exhibits issue #8.

I figured having `DPDA` and `NPDA` very similar would be worth the breakage of `DPDA` (see the changes in README for details), but YMMV.

(I'd like to add support for nondeterministic Turing machines, but I'm not sure about when I'll get to it. But it will probably cause similar breakage.)