### PR TITLE
Add support for NTMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,11 +584,19 @@ The direction `N` (for no movement) is also supported.
 
 #### DTM.read_input(self, input_str)
 
-Returns a tuple containing the final state the machine stopped on, as well as a
+Returns a `TMConfiguration`. This is basically a tuple containing the final state the machine stopped on, as well as a
 `TMTape` object representing the DTM's internal tape (if the input is accepted).
 
 ```python
-dtm.read_input('01')  # returns ('q4', TMTape('xy.'))
+dtm.read_input('01')  # returns TMConfiguration('q4', TMTape('xy..', 3))
+```
+
+Calling `config.print()` will produce a more readable output:
+
+```python
+dtm.read_input('01').print()
+# q4: xy..
+#        ^
 ```
 
 ```python
@@ -597,24 +605,18 @@ dtm.read_input('011')  # raises RejectionException
 
 #### DTM.read_input_stepwise(self, input_str)
 
-Yields a tuple containing the current state and the current tape as a `TMTape`
-object.
+Yields `TMConfiguration`s. Those are basically tuples containing the current state and the current tape as a `TMTape` object.
 
 ```python
-(state, tape.copy()) for state, tape in dtm.read_input_stepwise('01')
+dtm.read_input_stepwise('01')
 # yields:
-# ('q0', TMTape('01'))
-# ('q1', TMTape('x1'))
-# ('q2', TMTape('xy'))
-# ('q0', TMTape('xy'))
-# ('q3', TMTape('xy'))
-# ('q3', TMTape('xy.'))
+# TMConfiguration('q0', TMTape('01', 0))
+# TMConfiguration('q1', TMTape('x1', 1))
+# TMConfiguration('q2', TMTape('xy', 0))
+# TMConfiguration('q0', TMTape('xy', 1))
+# TMConfiguration('q3', TMTape('xy.', 2))
+# TMConfiguration('q4', TMTape('xy..', 3))
 ```
-
-Please note that each tuple contains a reference to (not a copy of) the current
-`TMTape` object. Therefore, if you wish to store the tape at every step, you
-must copy the tape as you iterate over the machine configurations (as shown
-above).
 
 #### DTM.accepts_input(self, input_str)
 

--- a/README.md
+++ b/README.md
@@ -639,6 +639,123 @@ dtm.validate()  # returns True
 dtm.copy()  # returns deep copy of dtm
 ```
 
+### class NTM(TM)
+
+The `NTM` class is a subclass of `TM` and represents a nondeterministic Turing machine. It can be found under `automata/tm/ntm.py`.
+
+Every NTM has the following (required) properties:
+
+1. `states`: a `set` of the NTM's valid states, each of which must be
+represented as a string
+
+2. `input_symbols`: a `set` of the NTM's valid input symbols represented as
+strings
+
+3. `tape_symbols`: a `set` of the NTM's valid tape symbols represented as
+strings
+
+4. `transitions`: a `dict` consisting of the transitions for each state; each key is a state name and each value is a `dict` which maps a symbol (the key) to a set of states (the values)
+
+5. `initial_state`: the name of the initial state for this NTM
+
+6. `blank_symbol`: a symbol from `tape_symbols` to be used as the blank symbol for this NTM
+
+7. `final_states`: a `set` of final states for this NTM
+
+```python
+from automata.tm.ntm import NTM
+# NTM which matches all strings beginning with '0's, and followed by
+# the same number of '1's
+# Note that the nondeterminism is not really used here.
+ntm = NTM(
+    states={'q0', 'q1', 'q2', 'q3', 'q4'},
+    input_symbols={'0', '1'},
+    tape_symbols={'0', '1', 'x', 'y', '.'},
+    transitions={
+        'q0': {
+            '0': {('q1', 'x', 'R')},
+            'y': {('q3', 'y', 'R')},
+        },
+        'q1': {
+            '0': {('q1', '0', 'R')},
+            '1': {('q2', 'y', 'L')},
+            'y': {('q1', 'y', 'R')},
+        },
+        'q2': {
+            '0': {('q2', '0', 'L')},
+            'x': {('q0', 'x', 'R')},
+            'y': {('q2', 'y', 'L')},
+        },
+        'q3': {
+            'y': {('q3', 'y', 'R')},
+            '.': {('q4', '.', 'R')},
+        }
+    },
+    initial_state='q0',
+    blank_symbol='.',
+    final_states={'q4'}
+)
+```
+
+The direction `N` (for no movement) is also supported.
+
+#### NTM.read_input(self, input_str)
+
+Returns a set of `TMConfiguration`s. These are basically tuples containing the final state the machine stopped on, as well as a
+`TMTape` object representing the DTM's internal tape (if the input is accepted).
+
+```python
+ntm.read_input('01')  # returns {TMConfiguration('q4', TMTape('xy..', 3))}
+```
+
+Calling `config.print()` will produce a more readable output:
+
+```python
+ntm.read_input('01').pop().print()
+# q4: xy..
+#        ^
+```
+
+```python
+ntm.read_input('011')  # raises RejectionException
+```
+
+#### NTM.read_input_stepwise(self, input_str)
+
+Yields sets of `TMConfiguration`s. Those are basically tuples containing the current state and the current tape as a `TMTape` object.
+
+```python
+ntm.read_input_stepwise('01')
+# yields:
+# {TMConfiguration('q0', TMTape('01', 0))}
+# {TMConfiguration('q1', TMTape('x1', 1))}
+# {TMConfiguration('q2', TMTape('xy', 0))}
+# {TMConfiguration('q0', TMTape('xy', 1))}
+# {TMConfiguration('q3', TMTape('xy.', 2))}
+# {TMConfiguration('q4', TMTape('xy..', 3))}
+```
+
+#### NTM.accepts_input(self, input_str)
+
+```python
+if ntm.accepts_input(my_input_str):
+    print('accepted')
+else:
+    print('rejected')
+```
+
+#### NTM.validate(self)
+
+```python
+ntm.validate()  # returns True
+```
+
+#### NTM.copy(self)
+
+```python
+ntm.copy()  # returns deep copy of ntm
+```
+
 ### Base exception classes
 
 The library also includes a number of exception classes to ensure that errors

--- a/automata/tm/configuration.py
+++ b/automata/tm/configuration.py
@@ -15,3 +15,15 @@ class TMConfiguration(collections.namedtuple(
         return '{}(\'{}\', \'{}\')'.format(
             self.__class__.__name__, self.state, self.tape
         )
+
+    def print(self):
+        """Print the machine's current configuration in a readable form."""
+        print('{current_state}: {tape}\n{current_position}'.format(
+            current_state=self.state,
+            tape=''.join(self.tape).rjust(
+                len(self.tape),
+                self.tape.blank_symbol),
+            current_position='^'.rjust(
+                self.tape.current_position + len(self.state) + 3
+            ),
+        ))

--- a/automata/tm/configuration.py
+++ b/automata/tm/configuration.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Classes and methods for working with Turing machine configurations."""
+
+import collections
+
+
+class TMConfiguration(collections.namedtuple(
+    'TMConfiguration',
+    ['state', 'tape']
+)):
+    """A Turing machine configuration."""
+
+    def __repr__(self):
+        """Return a string representation of the configuration."""
+        return '{}(\'{}\', \'{}\')'.format(
+            self.__class__.__name__, self.state, self.tape
+        )

--- a/automata/tm/configuration.py
+++ b/automata/tm/configuration.py
@@ -12,7 +12,7 @@ class TMConfiguration(collections.namedtuple(
 
     def __repr__(self):
         """Return a string representation of the configuration."""
-        return '{}(\'{}\', \'{}\')'.format(
+        return '{}(\'{}\', {})'.format(
             self.__class__.__name__, self.state, self.tape
         )
 

--- a/automata/tm/dtm.py
+++ b/automata/tm/dtm.py
@@ -111,7 +111,7 @@ class DTM(tm.TM):
             (current_state, new_tape_symbol,
                 current_direction) = self._get_transition(
                     current_state, input_symbol)
-            tape.write_symbol(new_tape_symbol)
-            tape.move(current_direction)
+            tape = tape.write_symbol(new_tape_symbol)
+            tape = tape.move(current_direction)
 
             yield current_state, tape

--- a/automata/tm/dtm.py
+++ b/automata/tm/dtm.py
@@ -88,10 +88,7 @@ class DTM(tm.TM):
                 tape_symbol in self.transitions[state]):
             return self.transitions[state][tape_symbol]
         else:
-            raise exceptions.RejectionException(
-                'The machine entered a non-final configuration for which no '
-                'transition is defined ({}, {})'.format(
-                    state, tape_symbol))
+            return None
 
     def _has_accepted(self, configuration):
         """Check whether the given config indicates accepted input."""
@@ -99,12 +96,20 @@ class DTM(tm.TM):
 
     def _get_next_configuration(self, old_config):
         """Advance to the next configuration."""
+        transitions = {self._get_transition(
+            old_config.state,
+            old_config.tape.read_symbol()
+        )}
+        if None in transitions:
+            transitions.remove(None)
+        if len(transitions) == 0:
+            raise exceptions.RejectionException(
+                'The machine entered a non-final configuration for which no '
+                'transition is defined ({}, {})'.format(
+                    old_config.state, old_config.tape.read_symbol()))
         tape = old_config.tape
-        input_symbol = tape.read_symbol()
         (new_state, new_tape_symbol,
-            direction) = self._get_transition(
-                old_config.state, input_symbol
-        )
+            direction) = transitions.pop()
         tape = tape.write_symbol(new_tape_symbol)
         tape = tape.move(direction)
         return TMConfiguration(new_state, tape)

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -59,7 +59,11 @@ class TMTape(collections.namedtuple(
         )
 
     def copy(self):
-        """Returns this tape."""
+        """
+        Return a deep copy of the tape.
+
+        As this class is immutable, this has no effect.
+        """
         return self
 
     def __len__(self):

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -72,5 +72,6 @@ class TMTape(collections.namedtuple(
 
     def __repr__(self):
         """Return a string representation of the tape."""
-        # TODO: represent the cursor position somehow
-        return '{}(\'{}\')'.format(self.__class__.__name__, ''.join(self.tape))
+        return '{}(\'{}\', {})'.format(
+            self.__class__.__name__, ''.join(self.tape), self.current_position
+        )

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -13,21 +13,13 @@ class TMTape(collections.namedtuple(
     def __new__(cls, tape, *, blank_symbol, current_position=0):
         """Initialize a new Turing machine tape."""
         tape = list(tape)
-        # Make sure that there's something on the tape.
-        if not tape:
-            tape.append(blank_symbol)
-        # Make sure that the tape begins and ends with the blank symbol.
-        if not tape[0] == blank_symbol:
-            tape.insert(0, blank_symbol)
-            current_position += 1
-        if not tape[-1] == blank_symbol:
+        # Make sure that there's something under the cursor.
+        while len(tape) <= current_position:
             tape.append(blank_symbol)
         tape = tuple(tape)
         return super(TMTape, cls).__new__(
             cls, tape, blank_symbol, current_position
         )
-
-    # TODO: Compaction? Remove unneeded blank symbols.
 
     def read_symbol(self):
         """Read the symbol at the current position in the tape."""
@@ -55,10 +47,10 @@ class TMTape(collections.namedtuple(
         elif direction == 'L':  # pragma: no branch
             new_position -= 1
         # Make sure that the cursor doesn't run off the end of the tape.
-        if new_position == 0:
+        if new_position == -1:
             new_tape.insert(0, self.blank_symbol)
             new_position += 1
-        if new_position == len(new_tape) - 1:
+        if new_position == len(new_tape):
             new_tape.append(self.blank_symbol)
         return TMTape(
             new_tape,

--- a/automata/tm/tools.py
+++ b/automata/tm/tools.py
@@ -2,26 +2,7 @@
 """Functions for displaying and maniuplating Turing machines."""
 
 
-def print_config(current_state, tape, max_position_offset):
-    """Print the machine's current configuration in a readable form."""
-    print('{current_state}: {tape}\n{current_position}'.format(
-        current_state=current_state,
-        tape=''.join(tape).rjust(
-            len(tape) + max_position_offset - tape.position_offset,
-            tape.blank_symbol),
-        current_position='^'.rjust(
-            tape.current_position + max_position_offset +
-            len(current_state) + 3),
-    ))
-
-
 def print_configs(validation_generator):
     """Print each machine configuration represented by the given generator."""
-    configs = []
-    for current_state, tape in validation_generator:
-        configs.append((current_state, tape.copy()))
-    # The maximum position offset is also the position offset of the last
-    # configuration's tape
-    max_position_offset = configs[-1][1].position_offset
-    for current_state, tape in configs:
-        print_config(current_state, tape, max_position_offset)
+    for config in validation_generator:
+        config.print()

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -124,7 +124,7 @@ class TestDTM(test_tm.TestTM):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.dtm1.read_input('00001111')
         nose.assert_equal(final_config[0], 'q4')
-        nose.assert_equal(str(final_config[1]), 'TMTape(\'xxxxyyyy.\')')
+        nose.assert_equal(str(final_config[1]), 'TMTape(\'xxxxyyyy..\')')
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
@@ -134,7 +134,7 @@ class TestDTM(test_tm.TestTM):
         nose.assert_equal(configs[0][0], 'q0')
         nose.assert_equal(str(configs[0][1]), 'TMTape(\'00001111\')')
         nose.assert_equal(configs[-1][0], 'q4')
-        nose.assert_equal(str(configs[-1][1]), 'TMTape(\'xxxxyyyy.\')')
+        nose.assert_equal(str(configs[-1][1]), 'TMTape(\'xxxxyyyy..\')')
 
     def test_read_input_offset(self):
         """Should valdiate input when tape is offset."""

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -130,9 +130,7 @@ class TestDTM(test_tm.TestTM):
         """Should return validation generator if step flag is supplied."""
         validation_generator = self.dtm1.read_input_stepwise('00001111')
         nose.assert_is_instance(validation_generator, types.GeneratorType)
-        configs = []
-        for current_state, tape in validation_generator:
-            configs.append((current_state, tape.copy()))
+        configs = list(validation_generator)
         nose.assert_equal(configs[0][0], 'q0')
         nose.assert_equal(str(configs[0][1]), 'TMTape(\'00001111\')')
         nose.assert_equal(configs[-1][0], 'q4')

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -124,7 +124,7 @@ class TestDTM(test_tm.TestTM):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.dtm1.read_input('00001111')
         nose.assert_equal(final_config[0], 'q4')
-        nose.assert_equal(str(final_config[1]), 'TMTape(\'xxxxyyyy..\')')
+        nose.assert_equal(str(final_config[1]), 'TMTape(\'xxxxyyyy..\', 9)')
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
@@ -132,15 +132,15 @@ class TestDTM(test_tm.TestTM):
         nose.assert_is_instance(validation_generator, types.GeneratorType)
         configs = list(validation_generator)
         nose.assert_equal(configs[0][0], 'q0')
-        nose.assert_equal(str(configs[0][1]), 'TMTape(\'00001111\')')
+        nose.assert_equal(str(configs[0][1]), 'TMTape(\'00001111\', 0)')
         nose.assert_equal(configs[-1][0], 'q4')
-        nose.assert_equal(str(configs[-1][1]), 'TMTape(\'xxxxyyyy..\')')
+        nose.assert_equal(str(configs[-1][1]), 'TMTape(\'xxxxyyyy..\', 9)')
 
     def test_read_input_offset(self):
         """Should valdiate input when tape is offset."""
         final_config = self.dtm2.read_input('01010101')
         nose.assert_equal(final_config[0], 'q4')
-        nose.assert_equal(str(final_config[1]), 'TMTape(\'yyx1010101\')')
+        nose.assert_equal(str(final_config[1]), 'TMTape(\'yyx1010101\', 3)')
 
     def test_read_input_rejection(self):
         """Should raise error if the machine halts."""

--- a/tests/test_ntm.py
+++ b/tests/test_ntm.py
@@ -124,7 +124,7 @@ class TestNTM(test_tm.TestTM):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.ntm1.read_input('00120001111').pop()
         nose.assert_equal(final_config[0], 'q3')
-        nose.assert_equal(str(final_config[1]), 'TMTape(\'00120001111.\')')
+        nose.assert_equal(str(final_config[1]), 'TMTape(\'00120001111.\', 11)')
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
@@ -133,10 +133,10 @@ class TestNTM(test_tm.TestTM):
         configs = list(validation_generator)
         first_config = configs[0].pop()
         nose.assert_equal(first_config[0], 'q0')
-        nose.assert_equal(str(first_config[1]), 'TMTape(\'00120001111\')')
+        nose.assert_equal(str(first_config[1]), 'TMTape(\'00120001111\', 0)')
         last_config = configs[-1].pop()
         nose.assert_equal(last_config[0], 'q3')
-        nose.assert_equal(str(last_config[1]), 'TMTape(\'00120001111.\')')
+        nose.assert_equal(str(last_config[1]), 'TMTape(\'00120001111.\', 11)')
 
     def test_read_input_rejection(self):
         """Should raise error if the machine halts."""

--- a/tests/test_ntm.py
+++ b/tests/test_ntm.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of NTMs."""
+
+import types
+from unittest.mock import patch
+
+import nose.tools as nose
+
+import automata.base.exceptions as exceptions
+import automata.tm.exceptions as tm_exceptions
+import tests.test_tm as test_tm
+from automata.tm.ntm import NTM
+
+
+class TestNTM(test_tm.TestTM):
+    """A test class for testing nondeterministic Turing machines."""
+
+    def test_init_ntm(self):
+        """Should copy NTM if passed into NTM constructor."""
+        new_dtm = NTM.copy(self.ntm1)
+        self.assert_is_copy(new_dtm, self.ntm1)
+
+    def test_init_ntm_missing_formal_params(self):
+        """Should raise an error if formal NTM parameters are missing."""
+        with nose.assert_raises(TypeError):
+            NTM(
+                states={'q0', 'q1', 'q2', 'q3', 'q4'},
+                input_symbols={'0', '1'},
+                tape_symbols={'0', '1', 'x', 'y', '.'},
+                initial_state='q0',
+                blank_symbol='.',
+                final_states={'q4'}
+            )
+
+    @patch('automata.tm.ntm.NTM.validate')
+    def test_init_validation(self, validate):
+        """Should validate NTM when initialized."""
+        NTM.copy(self.ntm1)
+        validate.assert_called_once_with()
+
+    def test_copy_ntm(self):
+        """Should create exact copy of NTM if copy() method is called."""
+        new_ntm = self.ntm1.copy()
+        self.assert_is_copy(new_ntm, self.ntm1)
+
+    def test_ntm_equal(self):
+        """Should correctly determine if two NTMs are equal."""
+        new_ntm = self.ntm1.copy()
+        nose.assert_true(self.ntm1 == new_ntm, 'NTMs are not equal')
+
+    def test_ntm_not_equal(self):
+        """Should correctly determine if two NTMs are not equal."""
+        new_ntm = self.ntm1.copy()
+        new_ntm.final_states.add('q2')
+        nose.assert_true(self.ntm1 != new_ntm, 'NTMs are equal')
+
+    def test_validate_input_symbol_subset(self):
+        """Should raise error if any input symbols are not tape symbols."""
+        with nose.assert_raises(exceptions.MissingSymbolError):
+            self.ntm1.input_symbols.add('3')
+            self.ntm1.validate()
+
+    def test_validate_invalid_transition_state(self):
+        """Should raise error if a transition state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.ntm1.transitions['q4'] = self.ntm1.transitions['q0']
+            self.ntm1.validate()
+
+    def test_validate_invalid_transition_symbol(self):
+        """Should raise error if a transition symbol is invalid."""
+        with nose.assert_raises(exceptions.InvalidSymbolError):
+            self.ntm1.transitions['q0']['3'] = {('q0', '0' 'R')}
+            self.ntm1.validate()
+
+    def test_validate_invalid_transition_result_state(self):
+        """Should raise error if a transition result state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.ntm1.transitions['q0']['.'] = {('q4', '.', 'R')}
+            self.ntm1.validate()
+
+    def test_validate_invalid_transition_result_symbol(self):
+        """Should raise error if a transition result symbol is invalid."""
+        with nose.assert_raises(exceptions.InvalidSymbolError):
+            self.ntm1.transitions['q0']['.'] = {('q3', '3', 'R')}
+            self.ntm1.validate()
+
+    def test_validate_invalid_transition_result_direction(self):
+        """Should raise error if a transition result direction is invalid."""
+        with nose.assert_raises(tm_exceptions.InvalidDirectionError):
+            self.ntm1.transitions['q0']['.'] = {('q3', '.', 'U')}
+            self.ntm1.validate()
+
+    def test_validate_invalid_initial_state(self):
+        """Should raise error if the initial state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.ntm1.initial_state = 'q4'
+            self.ntm1.validate()
+
+    def test_validate_initial_state_transitions(self):
+        """Should raise error if the initial state has no transitions."""
+        with nose.assert_raises(exceptions.MissingStateError):
+            del self.ntm1.transitions[self.ntm1.initial_state]
+            self.ntm1.validate()
+
+    def test_validate_nonfinal_initial_state(self):
+        """Should raise error if the initial state is a final state."""
+        with nose.assert_raises(exceptions.InitialStateError):
+            self.ntm1.final_states.add('q0')
+            self.ntm1.validate()
+
+    def test_validate_invalid_final_state(self):
+        """Should raise error if the final state is invalid."""
+        with nose.assert_raises(exceptions.InvalidStateError):
+            self.ntm1.final_states = {'q4'}
+            self.ntm1.validate()
+
+    def test_validate_final_state_transitions(self):
+        """Should raise error if a final state has any transitions."""
+        with nose.assert_raises(exceptions.FinalStateError):
+            self.ntm1.transitions['q3'] = {'0': {('q3', '0', 'L')}}
+            self.ntm1.validate()
+
+    def test_read_input_accepted(self):
+        """Should return correct state if acceptable TM input is given."""
+        final_config = self.ntm1.read_input('00120001111').pop()
+        nose.assert_equal(final_config[0], 'q3')
+        nose.assert_equal(str(final_config[1]), 'TMTape(\'00120001111.\')')
+
+    def test_read_input_step(self):
+        """Should return validation generator if step flag is supplied."""
+        validation_generator = self.ntm1.read_input_stepwise('00120001111')
+        nose.assert_is_instance(validation_generator, types.GeneratorType)
+        configs = list(validation_generator)
+        first_config = configs[0].pop()
+        nose.assert_equal(first_config[0], 'q0')
+        nose.assert_equal(str(first_config[1]), 'TMTape(\'00120001111\')')
+        last_config = configs[-1].pop()
+        nose.assert_equal(last_config[0], 'q3')
+        nose.assert_equal(str(last_config[1]), 'TMTape(\'00120001111.\')')
+
+    def test_read_input_rejection(self):
+        """Should raise error if the machine halts."""
+        with nose.assert_raises(exceptions.RejectionException):
+            self.ntm1.read_input('0')
+
+    def test_read_input_rejection_invalid_symbol(self):
+        """Should raise error if an invalid symbol is read."""
+        with nose.assert_raises(exceptions.RejectionException):
+            self.ntm1.read_input('02')
+
+    def test_accepts_input_true(self):
+        """Should return False if DTM input is not accepted."""
+        nose.assert_equal(self.dtm1.accepts_input('00001111'), True)
+
+    def test_accepts_input_false(self):
+        """Should return False if DTM input is rejected."""
+        nose.assert_equal(self.dtm1.accepts_input('000011'), False)

--- a/tests/test_tm.py
+++ b/tests/test_tm.py
@@ -4,6 +4,7 @@
 import nose.tools as nose
 
 from automata.tm.dtm import DTM
+from automata.tm.ntm import NTM
 
 
 class TestTM(object):
@@ -65,6 +66,30 @@ class TestTM(object):
             initial_state='q0',
             blank_symbol='.',
             final_states={'q4'}
+        )
+        # NTM which accepts the following:
+        # "2".join(["<one or more zeroes>" + "1"]*<one or more>)
+        # + "<any amount of ones>"
+        self.ntm1 = NTM(
+            states={'q0', 'q1', 'q2', 'q3'},
+            input_symbols={'0', '1', '2'},
+            tape_symbols={'0', '1', '2', '.'},
+            transitions={
+                'q0': {
+                    '0': {('q0', '0', 'R')},
+                    '1': {('q1', '1', 'R'), ('q2', '1', 'R')},
+                },
+                'q1': {
+                    '1': {('q1', '1', 'R')},
+                    '.': {('q3', '.', 'N')},
+                },
+                'q2': {
+                    '2': {('q0', '2', 'R')},
+                },
+            },
+            initial_state='q0',
+            blank_symbol='.',
+            final_states={'q3'}
         )
 
     def assert_is_copy(self, first, second):

--- a/tests/test_tmtools.py
+++ b/tests/test_tmtools.py
@@ -9,6 +9,7 @@ import nose.tools as nose
 
 import automata.tm.tools as tmtools
 import tests.test_tm as test_tm
+from automata.tm.configuration import TMConfiguration
 from automata.tm.tape import TMTape
 
 
@@ -18,45 +19,47 @@ class TestTMTools(test_tm.TestTM):
     def test_print_config(self):
         """Should print the given configuration to stdout."""
         out = io.StringIO()
+        config = TMConfiguration(
+            'q2',
+            TMTape(
+                tape='abcdefghij',
+                blank_symbol='.',
+                current_position=2,
+            )
+        )
         with contextlib.redirect_stdout(out):
-            tmtools.print_config(
-                current_state='q2', tape=TMTape(
-                    tape='abcdefghij', blank_symbol='.',
-                    current_position=2, position_offset=1),
-                max_position_offset=3)
+            config.print()
         nose.assert_equal(out.getvalue().rstrip(), '{}: {}\n{}'.format(
-            'q2', '..abcdefghij', '^'.rjust(10)))
+            'q2', 'abcdefghij', '^'.rjust(7)))
 
-    @patch('automata.tm.tools.print_config')
+    @patch('automata.tm.configuration.TMConfiguration.print')
     def test_print_configs(self, print_config):
         """Should print each machine configuration to stdout."""
         tape1 = TMTape(
             tape='01010101',
             blank_symbol='.',
             current_position=0,
-            position_offset=0
         )
         tape2 = TMTape(
             tape='x1010101',
             blank_symbol='.',
             current_position=-1,
-            position_offset=0
         )
         tape3 = TMTape(
             tape='yx1010101',
             blank_symbol='.',
             current_position=-2,
-            position_offset=1
         )
-        tmtools.print_configs([
-            ('q0', tape1),
-            ('q1', tape2),
-            ('q2', tape3)
-        ])
+        configs = [
+            TMConfiguration(tape1, 'q0'),
+            TMConfiguration(tape2, 'q1'),
+            TMConfiguration(tape3, 'q2')
+        ]
+        tmtools.print_configs(configs)
         nose.assert_equal(print_config.call_args_list, [
-            call('q0', tape1, 1),
-            call('q1', tape2, 1),
-            call('q2', tape3, 1)
+            call(),
+            call(),
+            call()
         ])
 
     def test_tape_iteration(self):
@@ -65,6 +68,5 @@ class TestTMTools(test_tm.TestTM):
             tape='abcdef',
             blank_symbol='.',
             current_position=2,
-            position_offset=1
         )
         nose.assert_equal(tuple(tape), ('a', 'b', 'c', 'd', 'e', 'f'))

--- a/tests/test_tmtools.py
+++ b/tests/test_tmtools.py
@@ -16,10 +16,9 @@ from automata.tm.tape import TMTape
 class TestTMTools(test_tm.TestTM):
     """A test class for testing Turing machine utility functions."""
 
-    def test_print_config(self):
-        """Should print the given configuration to stdout."""
-        out = io.StringIO()
-        config = TMConfiguration(
+    def setup(self):
+        """Provide a configuration for testing."""
+        self.config = TMConfiguration(
             'q2',
             TMTape(
                 tape='abcdefghij',
@@ -27,8 +26,19 @@ class TestTMTools(test_tm.TestTM):
                 current_position=2,
             )
         )
+
+    def test_repr_config(self):
+        """Should return a string representation ot the given configuration."""
+        nose.assert_equal(
+            repr(self.config),
+            'TMConfiguration(\'q2\', TMTape(\'abcdefghij\', 2))'
+        )
+
+    def test_print_config(self):
+        """Should print the given configuration to stdout."""
+        out = io.StringIO()
         with contextlib.redirect_stdout(out):
-            config.print()
+            self.config.print()
         nose.assert_equal(out.getvalue().rstrip(), '{}: {}\n{}'.format(
             'q2', 'abcdefghij', '^'.rjust(7)))
 

--- a/tests/test_tmtools.py
+++ b/tests/test_tmtools.py
@@ -34,6 +34,11 @@ class TestTMTools(test_tm.TestTM):
             'TMConfiguration(\'q2\', TMTape(\'abcdefghij\', 2))'
         )
 
+    def test_copy_tape(self):
+        """Should copy the tape (this has no effect)."""
+        new_tape = self.config.tape.copy()
+        nose.assert_is(new_tape, self.config.tape)
+
     def test_print_config(self):
         """Should print the given configuration to stdout."""
         out = io.StringIO()


### PR DESCRIPTION
This pull request adds a new class `NTM` which represents nondeterministic Turing machines. It is conceptually very similar to #9.

This might break code which relies on the string representations of the tape or configuration of Turing machines. Otherwise, it should be fine, I think.

So, what it does is basically the following:
 * `TMTape` becomes immutable and hashable. It still represents the tape of a TM and the current cursor position. (I've removed the offset stuff; I'm not sure about this.)
 * `TMConfiguration` is new. This is a (immutable and hashable) class representing the current configuration of a TM. It is basically a tuple of state and tape. Also, `tmtools.print_config` has been moved here.
 * `DTM` has been adjusted to these changes.
 * `DTM._get_next_configuration` is the main thing, now.
 * `DTM._has_accepted` is new. (It does what the name says it does.)
 * `NTM` is new. It is very similar to `DTM`; the main difference is that it holds a set of current configurations instead of just one.
 * Tests and documentation for all of this have been added.

One thing that came to my mind during this is that the `copy` method on now-immutable types (such as `TMTape`) should probably be removed, because they have no effect and might cause confusion.
But this also affects #9 - so this probably warrants a new pull request?