### PR TITLE
Make acceptance mode of PDAs configurable.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,8 +25,8 @@ but `tuple` does not.
 ## Acceptance mode of PDAs is now configurable
 
 `DPDA` and `NPDA` have a new config option which specifies when to accept.
-This has to be either `empty_stack`, `final_state` or `both`.
-The latter was the default in v2.
+This can be either `empty_stack`, `final_state` or `both`.
+The latter was the default in v2 and still is.
 
 ## Backwards-incompatible changes from v1 to v2
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,6 +22,12 @@ The `copy` methods on `TMTape` and `PDAStack` have been removed, since they are
 now immutable types. This change is similar to how `list` has a `copy()` method
 but `tuple` does not.
 
+## Acceptance mode of PDAs is now configurable
+
+`DPDA` and `NPDA` have a new config option which specifies when to accept.
+This has to be either `empty_stack`, `final_state` or `both`.
+The latter was the default in v2.
+
 ## Backwards-incompatible changes from v1 to v2
 
 There have been a number of backwards-incompatible changes from Automata v1 to

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,9 +24,8 @@ but `tuple` does not.
 
 ## Acceptance mode of PDAs is now configurable
 
-`DPDA` and `NPDA` have a new config option which specifies when to accept.
-This can be either `empty_stack`, `final_state` or `both`.
-The latter was the default in v2 and still is.
+`DPDA` and `NPDA` have a new config option which specifies when to accept. This
+can be either `empty_stack`, `final_state` or `both`. The default is `both`.
 
 ## Backwards-incompatible changes from v1 to v2
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ DPDA
 
 7. `final_states`: a `set` of final states for this DPDA
 
-8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both`
+8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both` (the default)
 
 ```python
 from automata.pda.dpda import DPDA
@@ -424,7 +424,7 @@ Every NPDA has the following (required) properties:
 
 7. `final_states`: a `set` of final states for this NPDA
 
-8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both`
+8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both` (the default)
 
 ```python
 from automata.pda.npda import NPDA

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ DPDA
 
 7. `final_states`: a `set` of final states for this DPDA
 
+8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both`
+
 ```python
 from automata.pda.dpda import DPDA
 # DPDA which which matches zero or more 'a's, followed by the same
@@ -347,7 +349,8 @@ dpda = DPDA(
     },
     initial_state='q0',
     initial_stack_symbol='0',
-    final_states={'q3'}
+    final_states={'q3'},
+    acceptance_mode='final_state'
 )
 ```
 
@@ -421,6 +424,8 @@ Every NPDA has the following (required) properties:
 
 7. `final_states`: a `set` of final states for this NPDA
 
+8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both`
+
 ```python
 from automata.pda.npda import NPDA
 # NPDA which matches palindromes consisting of 'a's and 'b's
@@ -461,7 +466,8 @@ npda = NPDA(
     },
     initial_state='q0',
     initial_stack_symbol='#',
-    final_states={'q2'}
+    final_states={'q2'},
+    acceptance_mode='final_state'
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ DPDA
 
 7. `final_states`: a `set` of final states for this DPDA
 
-8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both` (the default)
+8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack`, or `both`; the default is `both`
 
 ```python
 from automata.pda.dpda import DPDA
@@ -424,7 +424,7 @@ Every NPDA has the following (required) properties:
 
 7. `final_states`: a `set` of final states for this NPDA
 
-8. `acceptance_mode`: a string defining whether this DPDA accepts by `final_state`, `empty_stack` or `both` (the default)
+8. `acceptance_mode`: a string defining whether this NPDA accepts by `final_state`, `empty_stack`, or `both`; the default is `both`
 
 ```python
 from automata.pda.npda import NPDA

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -15,7 +15,7 @@ class DPDA(pda.PDA):
 
     def __init__(self, *, states, input_symbols, stack_symbols,
                  transitions, initial_state,
-                 initial_stack_symbol, final_states, acceptance_mode):
+                 initial_stack_symbol, final_states, acceptance_mode='both'):
         """Initialize a complete DPDA."""
         self.states = states.copy()
         self.input_symbols = input_symbols.copy()

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -58,44 +58,6 @@ class DPDA(pda.PDA):
                     self._validate_transition_lambda_transition_sibling(
                         start_state, sib_path)
 
-    def _validate_transition_invalid_input_symbols(self, start_state,
-                                                   input_symbol):
-        """Raise an error if transition input symbols are invalid."""
-        if input_symbol not in self.input_symbols and input_symbol != '':
-            raise exceptions.InvalidSymbolError(
-                'state {} has invalid transition input symbol {}'.format(
-                    start_state, input_symbol))
-
-    def _validate_transition_invalid_stack_symbols(self, start_state,
-                                                   stack_symbol):
-        """Raise an error if transition stack symbols are invalid."""
-        if stack_symbol not in self.stack_symbols:
-            raise exceptions.InvalidSymbolError(
-                'state {} has invalid transition stack symbol {}'.format(
-                    start_state, stack_symbol))
-
-    def _validate_initial_stack_symbol(self):
-        """Raise an error if initial stack symbol is invalid."""
-        if self.initial_stack_symbol not in self.stack_symbols:
-            raise exceptions.InvalidSymbolError(
-                'initial stack symbol {} is invalid'.format(
-                    self.initial_stack_symbol))
-
-    def validate(self):
-        """Return True if this DPDA is internally consistent."""
-        for start_state, paths in self.transitions.items():
-            self._validate_transition_invalid_symbols(start_state, paths)
-        self._validate_initial_state()
-        self._validate_initial_stack_symbol()
-        self._validate_final_states()
-        return True
-
-    def _has_lambda_transition(self, state, stack_symbol):
-        """Return True if the current config has any lambda transitions."""
-        return (state in self.transitions and
-                '' in self.transitions[state] and
-                stack_symbol in self.transitions[state][''])
-
     def _get_transition(self, state, input_symbol, stack_symbol):
         """Get the transiton tuple for the given state and symbols."""
         if (state in self.transitions and
@@ -104,27 +66,6 @@ class DPDA(pda.PDA):
             return (
                 input_symbol,
             ) + self.transitions[state][input_symbol][stack_symbol]
-
-    def _replace_stack_top(self, stack, new_stack_top):
-        if new_stack_top == '':
-            new_stack = stack.pop()
-        else:
-            new_stack = stack.replace(new_stack_top)
-        return new_stack
-
-    def _has_accepted(self, current_configuration):
-        """Check whether the given config indicates accepted input."""
-        # If there's input left, we're not finished.
-        if current_configuration.remaining_input:
-            return False
-        # If the stack is empty, we accept.
-        if not current_configuration.stack:
-            return True
-        # If current state is a final state, we accept.
-        if current_configuration.state in self.final_states:
-            return True
-        # Otherwise, not.
-        return False
 
     def _check_for_input_rejection(self, current_configuration):
         """Raise an error if the given config indicates rejected input."""

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -15,7 +15,7 @@ class DPDA(pda.PDA):
 
     def __init__(self, *, states, input_symbols, stack_symbols,
                  transitions, initial_state,
-                 initial_stack_symbol, final_states):
+                 initial_stack_symbol, final_states, acceptance_mode):
         """Initialize a complete DPDA."""
         self.states = states.copy()
         self.input_symbols = input_symbols.copy()
@@ -24,6 +24,7 @@ class DPDA(pda.PDA):
         self.initial_state = initial_state
         self.initial_stack_symbol = initial_stack_symbol
         self.final_states = final_states.copy()
+        self.acceptance_mode = acceptance_mode
         self.validate()
 
     def _validate_transition_invalid_symbols(self, start_state, paths):

--- a/automata/pda/exceptions.py
+++ b/automata/pda/exceptions.py
@@ -16,6 +16,6 @@ class NondeterminismError(PDAException):
     pass
 
 
-class InvalidAcceptanceMode(PDAException):
+class InvalidAcceptanceModeError(PDAException):
     """The given acceptance mode is invalid."""
     pass

--- a/automata/pda/exceptions.py
+++ b/automata/pda/exceptions.py
@@ -14,3 +14,7 @@ class NondeterminismError(PDAException):
     """A DPDA is exhibiting nondeterminism."""
 
     pass
+
+class InvalidAcceptanceMode(PDAException):
+    """The given acceptance mode is invalid."""
+    pass

--- a/automata/pda/exceptions.py
+++ b/automata/pda/exceptions.py
@@ -15,6 +15,7 @@ class NondeterminismError(PDAException):
 
     pass
 
+
 class InvalidAcceptanceMode(PDAException):
     """The given acceptance mode is invalid."""
     pass

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -15,7 +15,7 @@ class NPDA(pda.PDA):
 
     def __init__(self, *, states, input_symbols, stack_symbols,
                  transitions, initial_state,
-                 initial_stack_symbol, final_states, acceptance_mode):
+                 initial_stack_symbol, final_states, acceptance_mode='both'):
         """Initialize a complete NPDA."""
         self.states = states.copy()
         self.input_symbols = input_symbols.copy()

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -35,44 +35,6 @@ class NPDA(pda.PDA):
                 self._validate_transition_invalid_stack_symbols(
                     start_state, stack_symbol)
 
-    def _validate_transition_invalid_input_symbols(self, start_state,
-                                                   input_symbol):
-        """Raise an error if transition input symbols are invalid."""
-        if input_symbol not in self.input_symbols and input_symbol != '':
-            raise exceptions.InvalidSymbolError(
-                'state {} has invalid transition input symbol {}'.format(
-                    start_state, input_symbol))
-
-    def _validate_transition_invalid_stack_symbols(self, start_state,
-                                                   stack_symbol):
-        """Raise an error if transition stack symbols are invalid."""
-        if stack_symbol not in self.stack_symbols:
-            raise exceptions.InvalidSymbolError(
-                'state {} has invalid transition stack symbol {}'.format(
-                    start_state, stack_symbol))
-
-    def _validate_initial_stack_symbol(self):
-        """Raise an error if initial stack symbol is invalid."""
-        if self.initial_stack_symbol not in self.stack_symbols:
-            raise exceptions.InvalidSymbolError(
-                'initial stack symbol {} is invalid'.format(
-                    self.initial_stack_symbol))
-
-    def validate(self):
-        """Return True if this NPDA is internally consistent."""
-        for start_state, paths in self.transitions.items():
-            self._validate_transition_invalid_symbols(start_state, paths)
-        self._validate_initial_state()
-        self._validate_initial_stack_symbol()
-        self._validate_final_states()
-        return True
-
-    def _has_lambda_transition(self, state, stack_symbol):
-        """Return True if the current config has any lambda transitions."""
-        return (state in self.transitions and
-                '' in self.transitions[state] and
-                stack_symbol in self.transitions[state][''])
-
     def _get_transitions(self, state, input_symbol, stack_symbol):
         """Get the transition tuples for the given state and symbols."""
         transitions = set()
@@ -89,27 +51,6 @@ class NPDA(pda.PDA):
                     new_stack_top
                 ))
         return transitions
-
-    def _replace_stack_top(self, stack, new_stack_top):
-        if new_stack_top == '':
-            new_stack = stack.pop()
-        else:
-            new_stack = stack.replace(new_stack_top)
-        return new_stack
-
-    def _has_accepted(self, current_configuration):
-        """Check whether the given config indicates accepted input."""
-        # If there's input left, we're not finished.
-        if current_configuration.remaining_input:
-            return False
-        # If the stack is empty, we accept.
-        if not current_configuration.stack:
-            return True
-        # If current state is a final state, we accept.
-        if current_configuration.state in self.final_states:
-            return True
-        # Otherwise, not.
-        return False
 
     def _get_next_configurations(self, old_config):
         """Advance to the next configurations."""

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -15,7 +15,7 @@ class NPDA(pda.PDA):
 
     def __init__(self, *, states, input_symbols, stack_symbols,
                  transitions, initial_state,
-                 initial_stack_symbol, final_states):
+                 initial_stack_symbol, final_states, acceptance_mode):
         """Initialize a complete NPDA."""
         self.states = states.copy()
         self.input_symbols = input_symbols.copy()
@@ -24,6 +24,7 @@ class NPDA(pda.PDA):
         self.initial_state = initial_state
         self.initial_stack_symbol = initial_stack_symbol
         self.final_states = final_states.copy()
+        self.acceptance_mode = acceptance_mode
         self.validate()
 
     def _validate_transition_invalid_symbols(self, start_state, paths):

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -3,9 +3,9 @@
 
 import abc
 
-from automata.base.automaton import Automaton
 import automata.base.exceptions as exceptions
 import automata.pda.exceptions as pda_exceptions
+from automata.base.automaton import Automaton
 
 
 class PDA(Automaton, metaclass=abc.ABCMeta):

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -4,9 +4,67 @@
 import abc
 
 from automata.base.automaton import Automaton
+import automata.base.exceptions as exceptions
 
 
 class PDA(Automaton, metaclass=abc.ABCMeta):
     """An abstract base class for pushdown automata."""
 
-    pass
+    def _validate_transition_invalid_input_symbols(self, start_state,
+                                                   input_symbol):
+        """Raise an error if transition input symbols are invalid."""
+        if input_symbol not in self.input_symbols and input_symbol != '':
+            raise exceptions.InvalidSymbolError(
+                'state {} has invalid transition input symbol {}'.format(
+                    start_state, input_symbol))
+
+    def _validate_transition_invalid_stack_symbols(self, start_state,
+                                                   stack_symbol):
+        """Raise an error if transition stack symbols are invalid."""
+        if stack_symbol not in self.stack_symbols:
+            raise exceptions.InvalidSymbolError(
+                'state {} has invalid transition stack symbol {}'.format(
+                    start_state, stack_symbol))
+
+    def _validate_initial_stack_symbol(self):
+        """Raise an error if initial stack symbol is invalid."""
+        if self.initial_stack_symbol not in self.stack_symbols:
+            raise exceptions.InvalidSymbolError(
+                'initial stack symbol {} is invalid'.format(
+                    self.initial_stack_symbol))
+
+    def validate(self):
+        """Return True if this PDA is internally consistent."""
+        for start_state, paths in self.transitions.items():
+            self._validate_transition_invalid_symbols(start_state, paths)
+        self._validate_initial_state()
+        self._validate_initial_stack_symbol()
+        self._validate_final_states()
+        return True
+
+    def _has_lambda_transition(self, state, stack_symbol):
+        """Return True if the current config has any lambda transitions."""
+        return (state in self.transitions and
+                '' in self.transitions[state] and
+                stack_symbol in self.transitions[state][''])
+
+    def _replace_stack_top(self, stack, new_stack_top):
+        if new_stack_top == '':
+            new_stack = stack.pop()
+        else:
+            new_stack = stack.replace(new_stack_top)
+        return new_stack
+
+    def _has_accepted(self, current_configuration):
+        """Check whether the given config indicates accepted input."""
+        # If there's input left, we're not finished.
+        if current_configuration.remaining_input:
+            return False
+        # If the stack is empty, we accept.
+        if not current_configuration.stack:
+            return True
+        # If current state is a final state, we accept.
+        if current_configuration.state in self.final_states:
+            return True
+        # Otherwise, not.
+        return False

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -37,7 +37,7 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
     def _validate_acceptance(self):
         """Raise an error if the acceptance mode is invalid."""
         if self.acceptance_mode not in ('final_state', 'empty_stack', 'both'):
-            raise pda_exceptions.InvalidAcceptanceMode(
+            raise pda_exceptions.InvalidAcceptanceModeError(
                 'acceptance mode {} is invalid'.format(
                     self.acceptance_mode))
 

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -49,7 +49,7 @@ class TestDPDA(test_pda.TestPDA):
         nose.assert_equal(new_dpda.acceptance_mode, 'both')
 
     def test_init_dpda_invalid_acceptance_mode(self):
-        """Should create a new DPDA."""
+        """Should raise an error if the NPDA has an invalid acceptance mode."""
         with nose.assert_raises(pda_exceptions.InvalidAcceptanceModeError):
             DPDA(
                 states={'q0'},

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -51,20 +51,8 @@ class TestDPDA(test_pda.TestPDA):
     def test_init_dpda_invalid_acceptance_mode(self):
         """Should raise an error if the NPDA has an invalid acceptance mode."""
         with nose.assert_raises(pda_exceptions.InvalidAcceptanceModeError):
-            DPDA(
-                states={'q0'},
-                input_symbols={'a', 'b'},
-                stack_symbols={'#'},
-                transitions={
-                    'q0': {
-                        'a': {'#': ('q0', '')},
-                    }
-                },
-                initial_state='q0',
-                initial_stack_symbol='#',
-                final_states={'q0'},
-                acceptance_mode='foo'
-            )
+            self.dpda.acceptance_mode = 'foo'
+            self.dpda.validate()
 
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -31,6 +31,23 @@ class TestDPDA(test_pda.TestPDA):
                 final_states={'q0'}
             )
 
+    def test_init_dpda_no_acceptance_mode(self):
+        """Should create a new DPDA."""
+        new_dpda = DPDA(
+            states={'q0'},
+            input_symbols={'a', 'b'},
+            stack_symbols={'#'},
+            transitions={
+                'q0': {
+                    'a': {'#': ('q0', '')},
+                },
+            },
+            initial_state='q0',
+            initial_stack_symbol='#',
+            final_states={'q0'}
+        )
+        nose.assert_equal(new_dpda.acceptance_mode, 'both')
+
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""
         with nose.assert_raises(exceptions.InvalidSymbolError):

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -83,6 +83,7 @@ class TestDPDA(test_pda.TestPDA):
     def test_read_input_valid_accept_by_empty_stack(self):
         """Should return correct config if DPDA accepts by empty stack."""
         self.dpda.transitions['q2']['']['0'] = ('q2', '')
+        self.dpda.acceptance_mode = 'empty_stack'
         nose.assert_equal(
             self.dpda.read_input('aabb'),
             PDAConfiguration('q2', '', PDAStack([]))
@@ -135,5 +136,6 @@ class TestDPDA(test_pda.TestPDA):
             initial_state='q0',
             initial_stack_symbol='0',
             final_states={'q0'},
+            acceptance_mode='both'
         )
         nose.assert_true(dpda.accepts_input(''))

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -40,7 +40,7 @@ class TestDPDA(test_pda.TestPDA):
             transitions={
                 'q0': {
                     'a': {'#': ('q0', '')},
-                },
+                }
             },
             initial_state='q0',
             initial_stack_symbol='#',
@@ -58,7 +58,7 @@ class TestDPDA(test_pda.TestPDA):
                 transitions={
                     'q0': {
                         'a': {'#': ('q0', '')},
-                    },
+                    }
                 },
                 initial_state='q0',
                 initial_stack_symbol='#',

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -115,6 +115,12 @@ class TestDPDA(test_pda.TestPDA):
             PDAConfiguration('q3', '', PDAStack(['0']))
         )
 
+    def test_read_input_invalid_accept_by_final_state(self):
+        """Should not accept by final state if DPDA accepts by empty stack."""
+        self.dpda.acceptance_mode = 'empty_stack'
+        with nose.assert_raises(exceptions.RejectionException):
+            self.dpda.read_input('aabb')
+
     def test_read_input_valid_accept_by_empty_stack(self):
         """Should return correct config if DPDA accepts by empty stack."""
         self.dpda.transitions['q2']['']['0'] = ('q2', '')
@@ -123,6 +129,12 @@ class TestDPDA(test_pda.TestPDA):
             self.dpda.read_input('aabb'),
             PDAConfiguration('q2', '', PDAStack([]))
         )
+
+    def test_read_input_invalid_accept_by_empty_stack(self):
+        """Should not accept by empty stack if DPDA accepts by final state."""
+        self.dpda.transitions['q2']['']['0'] = ('q2', '')
+        with nose.assert_raises(exceptions.RejectionException):
+            self.dpda.read_input('aabb')
 
     def test_read_input_valid_consecutive_lambda_transitions(self):
         """Should follow consecutive lambda transitions when validating."""

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -48,6 +48,24 @@ class TestDPDA(test_pda.TestPDA):
         )
         nose.assert_equal(new_dpda.acceptance_mode, 'both')
 
+    def test_init_dpda_invalid_acceptance_mode(self):
+        """Should create a new DPDA."""
+        with nose.assert_raises(pda_exceptions.InvalidAcceptanceModeError):
+            DPDA(
+                states={'q0'},
+                input_symbols={'a', 'b'},
+                stack_symbols={'#'},
+                transitions={
+                    'q0': {
+                        'a': {'#': ('q0', '')},
+                    },
+                },
+                initial_state='q0',
+                initial_stack_symbol='#',
+                final_states={'q0'},
+                acceptance_mode='foo'
+            )
+
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""
         with nose.assert_raises(exceptions.InvalidSymbolError):

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -103,6 +103,12 @@ class TestNPDA(test_pda.TestPDA):
             {PDAConfiguration('q2', '', PDAStack(['#']))}
         )
 
+    def test_read_input_invalid_accept_by_final_state(self):
+        """Should not accept by final state if NPDA accepts by empty stack."""
+        self.npda.acceptance_mode = 'empty_stack'
+        with nose.assert_raises(exceptions.RejectionException):
+            self.npda.read_input('abaaba'),
+
     def test_read_input_valid_accept_by_empty_stack(self):
         """Should return correct config if NPDA accepts by empty stack."""
         self.npda.transitions['q2'] = {'': {'#': {('q2', '')}}}
@@ -112,6 +118,14 @@ class TestNPDA(test_pda.TestPDA):
             self.npda.read_input('abaaba'),
             {PDAConfiguration('q2', '', PDAStack([]))}
         )
+
+    def test_read_input_invalid_accept_by_empty_stack(self):
+        """Should not accept by empty stack if NPDA accepts by final state."""
+        self.npda.acceptance_mode = 'final_state'
+        self.npda.states.add('q3')
+        self.npda.transitions['q1'][''] = {'#': {('q3', '')}}
+        with nose.assert_raises(exceptions.RejectionException):
+            self.npda.read_input('abaaba')
 
     def test_read_input_valid_consecutive_lambda_transitions(self):
         """Should follow consecutive lambda transitions when validating."""

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -30,6 +30,23 @@ class TestNPDA(test_pda.TestPDA):
                 final_states={'q0'}
             )
 
+    def test_init_npda_no_acceptance_mode(self):
+        """Should create a new NPDA."""
+        new_npda = NPDA(
+            states={'q0'},
+            input_symbols={'a', 'b'},
+            stack_symbols={'#'},
+            transitions={
+                'q0': {
+                    'a': {'#': {('q0', '')}},
+                },
+            },
+            initial_state='q0',
+            initial_stack_symbol='#',
+            final_states={'q0'}
+        )
+        nose.assert_equal(new_npda.acceptance_mode, 'both')
+
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""
         with nose.assert_raises(exceptions.InvalidSymbolError):

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -6,6 +6,7 @@
 import nose.tools as nose
 
 import automata.base.exceptions as exceptions
+import automata.pda.exceptions as pda_exceptions
 import tests.test_pda as test_pda
 from automata.pda.configuration import PDAConfiguration
 from automata.pda.npda import NPDA
@@ -46,6 +47,24 @@ class TestNPDA(test_pda.TestPDA):
             final_states={'q0'}
         )
         nose.assert_equal(new_npda.acceptance_mode, 'both')
+
+    def test_init_npda_invalid_acceptance_mode(self):
+        """Should raise an error if the NPDA has an invalid acceptance mode."""
+        with nose.assert_raises(pda_exceptions.InvalidAcceptanceModeError):
+            NPDA(
+                states={'q0'},
+                input_symbols={'a', 'b'},
+                stack_symbols={'#'},
+                transitions={
+                    'q0': {
+                        'a': {'#': {('q0', '')}},
+                    },
+                },
+                initial_state='q0',
+                initial_stack_symbol='#',
+                final_states={'q0'},
+                acceptance_mode='foo'
+            )
 
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -51,20 +51,8 @@ class TestNPDA(test_pda.TestPDA):
     def test_init_npda_invalid_acceptance_mode(self):
         """Should raise an error if the NPDA has an invalid acceptance mode."""
         with nose.assert_raises(pda_exceptions.InvalidAcceptanceModeError):
-            NPDA(
-                states={'q0'},
-                input_symbols={'a', 'b'},
-                stack_symbols={'#'},
-                transitions={
-                    'q0': {
-                        'a': {'#': {('q0', '')}},
-                    }
-                },
-                initial_state='q0',
-                initial_stack_symbol='#',
-                final_states={'q0'},
-                acceptance_mode='foo'
-            )
+            self.npda.acceptance_mode = 'foo'
+            self.npda.validate()
 
     def test_validate_invalid_input_symbol(self):
         """Should raise error if a transition has an invalid input symbol."""

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -40,7 +40,7 @@ class TestNPDA(test_pda.TestPDA):
             transitions={
                 'q0': {
                     'a': {'#': {('q0', '')}},
-                },
+                }
             },
             initial_state='q0',
             initial_stack_symbol='#',
@@ -58,7 +58,7 @@ class TestNPDA(test_pda.TestPDA):
                 transitions={
                     'q0': {
                         'a': {'#': {('q0', '')}},
-                    },
+                    }
                 },
                 initial_state='q0',
                 initial_stack_symbol='#',

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -71,6 +71,7 @@ class TestNPDA(test_pda.TestPDA):
         """Should return correct config if NPDA accepts by empty stack."""
         self.npda.transitions['q2'] = {'': {'#': {('q2', '')}}}
         self.npda.final_states = set()
+        self.npda.acceptance_mode = 'empty_stack'
         nose.assert_equal(
             self.npda.read_input('abaaba'),
             {PDAConfiguration('q2', '', PDAStack([]))}

--- a/tests/test_pda.py
+++ b/tests/test_pda.py
@@ -33,7 +33,8 @@ class TestPDA(object):
             },
             initial_state='q0',
             initial_stack_symbol='0',
-            final_states={'q3'}
+            final_states={'q3'},
+            acceptance_mode='final_state'
         )
 
         # NPDA which matches palindromes consisting of 'a's and 'b's
@@ -74,7 +75,8 @@ class TestPDA(object):
             },
             initial_state='q0',
             initial_stack_symbol='#',
-            final_states={'q2'}
+            final_states={'q2'},
+            acceptance_mode='final_state'
         )
 
     def assert_is_copy(self, first, second):
@@ -92,3 +94,4 @@ class TestPDA(object):
             first.initial_stack_symbol, second.initial_stack_symbol)
         nose.assert_is_not(first.final_states, second.final_states)
         nose.assert_equal(first.final_states, second.final_states)
+        nose.assert_equal(first.acceptance_mode, second.acceptance_mode)

--- a/tests/test_pda.py
+++ b/tests/test_pda.py
@@ -71,7 +71,7 @@ class TestPDA(object):
                     '': {'#': {('q2', '#')}},
                     'a': {'A': {('q1', '')}},
                     'b': {'B': {('q1', '')}},
-                },
+                }
             },
             initial_state='q0',
             initial_stack_symbol='#',


### PR DESCRIPTION
This is related to issue #8.

I implemented the feature (which was a small change) and adjusted the documentation and tests.
I didn't add a test for the case where one mode is specified and the other occurs, though.