### PR TITLE
Regular Expression conversions in both direction + NFA.eliminate_labmda + some other functions and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,8 +465,9 @@ regex = nfa1.to_regex()
 ```
 
 #### show_diagram(self, path=None)
+
 ```python
-nfa1.show_diagram(path = './abc.png')
+nfa1.show_diagram(path='./abc.png')
 ```
 
 ### class GNFA(FA)
@@ -486,7 +487,8 @@ is not the same has `initial_state`.
 state and also from each state to itself. To accommodate this, transitions can be
 regular expressions and `None` also in addition to normal symbols.
 
-`GNFA` is modified with respect to `NFA` in the following parameters.
+`GNFA` is modified with respect to `NFA` in the following parameters:
+
 1. `final_state`: a string (single state).
 2. `transitions`: (its structure is changed from `NFA`) a `dict` consisting of the transitions
 for each state except `final_state`. Each key is a state name and each value is `dict`
@@ -511,8 +513,11 @@ gnfa = GNFA(
     final_state='q_f'
 )
 ```
+
 #### GNFA.from_dfa(self, dfa)
+
 Initialize this GNFA as one equivalent to the given DFA.
+
 ```python
 from automata.fa.gnfa import GNFA
 from automata.fa.dfa import DFA
@@ -520,7 +525,9 @@ gnfa = GNFA.from_dfa(dfa) # returns an equivalent GNFA
 ```
 
 #### GNFA.from_nfa(self, nfa)
+
 Initialize this GNFA as one equivalent to the given NFA.
+
 ```python
 from automata.fa.gnfa import GNFA
 from automata.fa.nfa import NFA
@@ -528,27 +535,35 @@ gnfa = GNFA.from_nfa(nfa) # returns an equivalent GNFA
 ```
 
 #### GNFA.validate(self)
-Validates GNFA
+
+Returns `True` if the GNFA instance is valid; raises an exception otherwise.
+
 ```python
 gnfa.validate()
 ```
 
 #### GNFA.copy()
-Returns a deep copy of GNFA
+
+Returns a deep copy of GNFA.
+
 ```python
 gnfa2 = gnfa1.copy()
 ```
 
 #### GNFA.to_regex(self)
+
 Convert GNFA to regular expression.
+
 ```python
 gnfa.to_regex() # returns a regular expression (string)
 ```
 
-#### GNFA.show_diagram(self, path=None, show_None = True):
-`path`: path for saving image
+#### GNFA.show_diagram(self, path=None, show_None=True):
 
-`show_None`: Boolean, show or hide `None` transitions.
+Writes a visual diagram of the GNFA to an image file. 
+
+1. `path`: the path of the image to be saved
+2. `show_None`: A boolean indicating when to show or hide `None` transitions; defaults to `True`.
 
 ```python
 gnfa.show_diagram(path='./gnfa.png', show_None=False)
@@ -1152,11 +1167,11 @@ ntm.copy()  # returns deep copy of ntm
 ```
 
 ### Regular Expressions
+
 A set of tools for working with regular languages. These can be found under
 `automata/base/regex.py`
 
 A regular expression with the following operations only are supported in this library:
-
 
 - `*`: Kleene star operation. language repeated zero or more times. Ex: `a*`,`(ab)*`
 - `?`: Language repeated zero or one time. Ex: `a?`
@@ -1167,32 +1182,41 @@ A regular expression with the following operations only are supported in this li
 This is similar to the python RE module but this library does not support any other
 special character than given above. All regular languages can be written with these.
 
-Preferably the tools for the same can be imported as
+Preferably the tools for the same can be imported as:
+
 ```python
 import automata.base.regex as re
 ```
 
 #### automata.base.regex.validate(regex)
-Return True if the regular expression is valid. Otherwise, raise an `InvalidRegexError`.
+
+Returns True if the regular expression is valid. Otherwise, raise an
+`InvalidRegexError`.
 
 ```python
 re.validate('ab(c|d)*ba?')
 ```
 
 #### automata.base.regex.isequal(re1, re2)
-Return True if both regular expressions are equivalent
+
+Returns True if both regular expressions are equivalent.
+
 ```python
 re.isequal('aa?', 'a|aa')
 ```
 
 #### automata.base.regex.issubset(re1, re2)
-Return True if re1 is a subset of re2
+
+Returns True if re1 is a subset of re2.
+
 ```python
 re.issubset('aa?', 'a*')
 ```
 
 #### autumata.issuperset(re1, re2)
-Return True if re1 is a subset of re2
+
+Returns True if re1 is a subset of re2.
+
 ```python
 re.issuperset('a*', 'a?')
 ```

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,7 @@ import automata.base.regex as re
 ```
 
 #### automata.base.regex.validate(regex)
-Raise an error(`InvalidRegexError`) if the regular expression is invalid.
+Return True if the regular expression is valid. Otherwise, raise an `InvalidRegexError`.
 
 ```python
 re.validate('ab(c|d)*ba?')

--- a/README.md
+++ b/README.md
@@ -437,6 +437,80 @@ from automata.fa.dfa import DFA
 nfa = NFA.from_dfa(dfa)  # returns an equivalent NFA
 ```
 
+### class GNFA(FA)
+
+The `GNFA` class is a subclass of `FA` and represents a generalized
+nondeterministic finite automaton. It can be found under `automata/fa/gnfa.py`.
+Its main usage is for conversion of DFAs and NFAs to regular expressions. 
+
+Every `GNFA` has the same five NFA properties: `states`, `input_sympols`, `transitions`,
+`initial_state`, and `final_state`. However a `GNFA` has several differences with respect to `NFA`
+- The `initial_state` has transitions going to every other state but no transitions
+coming in from any other state.
+- There is only a single `final_state`, and it has transitions coming in from every
+other state but no transitions going to any other state. Futhermore, the `final_state`
+is not the same has `initial_state`.
+- Except for `initial_state` and `final_state`, one transition arrow goes from every state to every other
+state and also from each state to itself. To accommodate this, transitions can be
+regular expressions and `None` also in addition to normal symbols.
+
+`GNFA` is modified with respect to `NFA` in the following parameters.
+1. `final_state`: a string (single state).
+2. `transitions`: (its structure is changed from `NFA`) a `dict` consisting of the transitions
+for each state except `final_state`. Each key is a state name and each value is `dict`
+which maps a state (the key) to the transition expression (the value).
+    - value: a regular expression (string) consisting of `input_symbols` and the following symbols only:
+    `|` - Either or ; `*` - star: zero or more occurrences of previous symbol. `()` - 
+   parenthesis: Capture and group. Rest any of the characters and sequences as in the python module RegEx are not supported here.
+
+```python
+from automata.fa.gnfa import GNFA
+# GNFA which matches strings beginning with 'a', ending with 'a', and containing
+# no consecutive 'b's
+gnfa = GNFA(
+    states={'q_in', 'q_f', 'q0', 'q1', 'q2'},
+    input_symbols={'a', 'b'},
+    transitions={
+        'q0': {'q1': 'a', 'q_f': None, 'q2': None, 'q0': None},
+        'q1': {'q1': 'a', 'q2': '', 'q_f': '', 'q0': None},
+        'q2': {'q0': 'b', 'q_f': None, 'q2': None, 'q1': None},
+        'q_in': {'q0': '', 'q_f': None, 'q2': None, 'q1': None}
+    },
+    initial_state='q_in',
+    final_state='q_f'
+)
+```
+#### GNFA.from_dfa(self, dfa)
+Initialize this GNFA as one equivalent to the given DFA.
+```python
+from automata.fa.gnfa import GNFA
+from automata.fa.dfa import DFA
+gnfa = GNFA.from_dfa(dfa) # returns an equivalent GNFA
+```
+#### GNFA.from_nfa(self, nfa)
+Initialize this GNFA as one equivalent to the given NFA.
+```python
+from automata.fa.gnfa import GNFA
+from automata.fa.nfa import NFA
+gnfa = GNFA.from_nfa(nfa) # returns an equivalent GNFA
+```
+
+#### GNFA.to_regex(self)
+Convert GNFA to regular expression.
+```python
+gnfa.to_regex() # returns a regular expression
+```
+
+#### GNFA.show_diagram(self, path=None, show_None = True):
+`path`: path for saving image
+
+`show_None`: Boolean, show or hide `None` transitions.
+
+```python
+gnfa.show_diagram(path='./gnfa.png', show_None=False)
+```
+
+
 ### class PDA(Automaton, metaclass=ABCMeta)
 
 The `PDA` class is an abstract base class from which all pushdown automata

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,7 @@ import automata.base.regex as re
 ```
 
 #### automata.base.regex.validate(regex)
-Raise an error(`InvalidRegExError`) if the regular expression is invalid.
+Raise an error(`InvalidRegexError`) if the regular expression is invalid.
 
 ```python
 re.validate('ab(c|d)*ba?')
@@ -1254,11 +1254,11 @@ prohibited for Turing machines).
 Raised if the automaton did not accept the input string after validating (e.g.
 the automaton stopped on a non-final state after validating input).
 
-#### class RegExException
+#### class RegexException
 
 A base class for all regular expression related errors.
 
-#### class InvalidRegExError
+#### class InvalidRegexError
 Raised if the input regular expression is invalid.
 
 ### Turing machine exception classes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ pip install automata-lib
     - [Deterministic (DFA)](#class-dfafa)
     - [Non-Deterministic (NFA)](#class-nfafa)
     - [Generalised Non-Deterministic (GNFA)](#class-gnfafa)
-    - [Regular Expressions](#regular-expressions)
   - [Pushdown Automaton (PDA)](#class-pdaautomaton-metaclassabcmeta)
     - [Deterministic (DPDA)](#class-dpdapda)
     - [Non-Deterministic (NPDA)](#class-npdapda)
@@ -49,6 +48,7 @@ pip install automata-lib
     - [Deterministic (DTM)](#class-dtmtm)
     - [Non-Deterministic (NTM)](#class-ntmtm)
     - [Multi-Tape Non-Deterministic (MNTM)](#class-mntmtm)
+- [Regular Expressions](#regular-expressions)
 - [Base exception classes](#base-exception-classes)
 - [Turing machine exceptions](#turing-machine-exception-classes)
 
@@ -429,6 +429,15 @@ nfa1.concatenate(nfa2)
 nfa1.kleene_star()
 ```
 
+#### NFA.union(self, other)
+Returns union of two NFAs
+```python
+new_nfa = nfa1.union(nfa2)
+```
+```python
+new_nfa = nfa1 | nfa2
+```
+
 #### NFA.eliminate_lambda(self)
 
 Removes epsilon transitions from the NFA which recognizes the same language.
@@ -453,6 +462,11 @@ Return a regular expression (string) equivalent to given NFA.
 
 ```python
 regex = nfa1.to_regex()
+```
+
+#### show_diagram(self, path=None)
+```python
+nfa1.show_diagram(path = './abc.png')
 ```
 
 ### class GNFA(FA)
@@ -519,6 +533,12 @@ Validates GNFA
 gnfa.validate()
 ```
 
+#### GNFA.copy()
+Returns a deep copy of GNFA
+```python
+gnfa2 = gnfa1.copy()
+```
+
 #### GNFA.to_regex(self)
 Convert GNFA to regular expression.
 ```python
@@ -532,52 +552,6 @@ gnfa.to_regex() # returns a regular expression (string)
 
 ```python
 gnfa.show_diagram(path='./gnfa.png', show_None=False)
-```
-
-### Regular Expressions
-A set of tools for working with regular languages. These can be found under
-`automata/base/regex.py`
-
-A regular expression with the following operations only are supported in this library:
-
-
-- `*`: Kleene star operation. language repeated zero or more times. Ex: `a*`,`(ab)*`
-- `?`: Language repeated zero or one time. Ex: `a?`
-- Concatenation: Ex: `abcd`
-- `|`: Union. Ex: `a|b`
-- `()`: Grouping
-
-This is similar to the python RE module but this library does not support any other
-special character than given above. All regular languages can be written with these.
-
-Preferably the tools for the same can be imported as
-```python
-import automata.base.regex as re
-```
-
-#### automata.base.regex.validate(regex)
-Raise an error(`InvalidRegExError`) if the regular expression is invalid.
-
-```python
-re.validate('ab(c|d)*ba?')
-```
-
-#### automata.base.regex.isequal(re1, re2)
-Return True if both regular expressions are equivalent
-```python
-re.isequal('aa?', 'a|aa')
-```
-
-#### automata.base.regex.issubset(re1, re2)
-Return True if re1 is a subset of re2
-```python
-re.issubset('aa?', 'a*')
-```
-
-#### autumata.issuperset(re1, re2)
-Return True if re1 is a subset of re2
-```python
-re.issuperset('a*', 'a?')
 ```
 
 ### class PDA(Automaton, metaclass=ABCMeta)
@@ -1175,6 +1149,52 @@ ntm.validate()  # returns True
 
 ```python
 ntm.copy()  # returns deep copy of ntm
+```
+
+### Regular Expressions
+A set of tools for working with regular languages. These can be found under
+`automata/base/regex.py`
+
+A regular expression with the following operations only are supported in this library:
+
+
+- `*`: Kleene star operation. language repeated zero or more times. Ex: `a*`,`(ab)*`
+- `?`: Language repeated zero or one time. Ex: `a?`
+- Concatenation: Ex: `abcd`
+- `|`: Union. Ex: `a|b`
+- `()`: Grouping
+
+This is similar to the python RE module but this library does not support any other
+special character than given above. All regular languages can be written with these.
+
+Preferably the tools for the same can be imported as
+```python
+import automata.base.regex as re
+```
+
+#### automata.base.regex.validate(regex)
+Raise an error(`InvalidRegExError`) if the regular expression is invalid.
+
+```python
+re.validate('ab(c|d)*ba?')
+```
+
+#### automata.base.regex.isequal(re1, re2)
+Return True if both regular expressions are equivalent
+```python
+re.isequal('aa?', 'a|aa')
+```
+
+#### automata.base.regex.issubset(re1, re2)
+Return True if re1 is a subset of re2
+```python
+re.issubset('aa?', 'a*')
+```
+
+#### autumata.issuperset(re1, re2)
+Return True if re1 is a subset of re2
+```python
+re.issuperset('a*', 'a?')
 ```
 
 ### Base exception classes

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ pip install automata-lib
   - [Finite Automaton (FA)](#class-faautomaton-metaclassabcmeta)
     - [Deterministic (DFA)](#class-dfafa)
     - [Non-Deterministic (NFA)](#class-nfafa)
+    - [Generalised Non-Deterministic (GNFA)](#class-gnfafa)
+    - [Regular Expressions](#regular-expressions)
   - [Pushdown Automaton (PDA)](#class-pdaautomaton-metaclassabcmeta)
     - [Deterministic (DPDA)](#class-dpdapda)
     - [Non-Deterministic (NPDA)](#class-npdapda)
@@ -427,6 +429,14 @@ nfa1.concatenate(nfa2)
 nfa1.kleene_star()
 ```
 
+#### NFA.eliminate_lambda(self)
+
+Removes epsilon transitions from the NFA which recognizes the same language.
+
+```python
+nfa1.eliminate_lambda()
+```
+
 #### NFA.from_dfa(cls, dfa)
 
 Creates an NFA that is equivalent to the given DFA.
@@ -435,6 +445,14 @@ Creates an NFA that is equivalent to the given DFA.
 from automata.fa.nfa import NFA
 from automata.fa.dfa import DFA
 nfa = NFA.from_dfa(dfa)  # returns an equivalent NFA
+```
+
+#### NFA.to_regex(self)
+
+Return a regular expression (string) equivalent to given NFA.
+
+```python
+regex = nfa1.to_regex()
 ```
 
 ### class GNFA(FA)
@@ -460,8 +478,7 @@ regular expressions and `None` also in addition to normal symbols.
 for each state except `final_state`. Each key is a state name and each value is `dict`
 which maps a state (the key) to the transition expression (the value).
     - value: a regular expression (string) consisting of `input_symbols` and the following symbols only:
-    `|` - Either or ; `*` - star: zero or more occurrences of previous symbol. `()` - 
-   parenthesis: Capture and group. Rest any of the characters and sequences as in the python module RegEx are not supported here.
+    `*`, `|`, `?`, `()`. Check [Regular Expressions](#regular-expressions) 
 
 ```python
 from automata.fa.gnfa import GNFA
@@ -487,6 +504,7 @@ from automata.fa.gnfa import GNFA
 from automata.fa.dfa import DFA
 gnfa = GNFA.from_dfa(dfa) # returns an equivalent GNFA
 ```
+
 #### GNFA.from_nfa(self, nfa)
 Initialize this GNFA as one equivalent to the given NFA.
 ```python
@@ -495,10 +513,16 @@ from automata.fa.nfa import NFA
 gnfa = GNFA.from_nfa(nfa) # returns an equivalent GNFA
 ```
 
+#### GNFA.validate(self)
+Validates GNFA
+```python
+gnfa.validate()
+```
+
 #### GNFA.to_regex(self)
 Convert GNFA to regular expression.
 ```python
-gnfa.to_regex() # returns a regular expression
+gnfa.to_regex() # returns a regular expression (string)
 ```
 
 #### GNFA.show_diagram(self, path=None, show_None = True):
@@ -510,6 +534,51 @@ gnfa.to_regex() # returns a regular expression
 gnfa.show_diagram(path='./gnfa.png', show_None=False)
 ```
 
+### Regular Expressions
+A set of tools for working with regular languages. These can be found under
+`automata/base/regex.py`
+
+A regular expression with the following operations only are supported in this library:
+
+
+- `*`: Kleene star operation. language repeated zero or more times. Ex: `a*`,`(ab)*`
+- `?`: Language repeated zero or one time. Ex: `a?`
+- Concatenation: Ex: `abcd`
+- `|`: Union. Ex: `a|b`
+- `()`: Grouping
+
+This is similar to the python RE module but this library does not support any other
+special character than given above. All regular languages can be written with these.
+
+Preferably the tools for the same can be imported as
+```python
+import automata.base.regex as re
+```
+
+#### automata.base.regex.validate(regex)
+Raise an error(`InvalidRegExError`) if the regular expression is invalid.
+
+```python
+re.validate('ab(c|d)*ba?')
+```
+
+#### automata.base.regex.isequal(re1, re2)
+Return True if both regular expressions are equivalent
+```python
+re.isequal('aa?', 'a|aa')
+```
+
+#### automata.base.regex.issubset(re1, re2)
+Return True if re1 is a subset of re2
+```python
+re.issubset('aa?', 'a*')
+```
+
+#### autumata.issuperset(re1, re2)
+Return True if re1 is a subset of re2
+```python
+re.issuperset('a*', 'a?')
+```
 
 ### class PDA(Automaton, metaclass=ABCMeta)
 
@@ -1164,6 +1233,13 @@ prohibited for Turing machines).
 
 Raised if the automaton did not accept the input string after validating (e.g.
 the automaton stopped on a non-final state after validating input).
+
+#### class RegExException
+
+A base class for all regular expression related errors.
+
+#### class InvalidRegExError
+Raised if the input regular expression is invalid.
 
 ### Turing machine exception classes
 

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -51,7 +51,7 @@ class Automaton(metaclass=abc.ABCMeta):
 
     def _validate_initial_state_transitions(self):
         """Raise an error if the initial state has no transitions defined."""
-        if self.initial_state not in self.transitions:
+        if self.initial_state not in self.transitions and len(self.states) > 1:
             raise exceptions.MissingStateError(
                 'initial state {} has no transitions defined'.format(
                     self.initial_state))

--- a/automata/base/exceptions.py
+++ b/automata/base/exceptions.py
@@ -50,13 +50,13 @@ class RejectionException(AutomatonException):
     pass
 
 
-class RegExException(Exception):
+class RegexException(Exception):
     """The base class for all regular expression related errors"""
 
     pass
 
 
-class InvalidRegExError(RegExException):
+class InvalidRegexError(RegexException):
     """Regular expression is invalid"""
 
     pass

--- a/automata/base/exceptions.py
+++ b/automata/base/exceptions.py
@@ -48,3 +48,15 @@ class RejectionException(AutomatonException):
     """The input was rejected by the automaton."""
 
     pass
+
+
+class RegExException(Exception):
+    """The base class for all regular expression related errors"""
+
+    pass
+
+
+class InvalidRegExError(RegExException):
+    """Regular expression is invalid"""
+
+    pass

--- a/automata/base/regex.py
+++ b/automata/base/regex.py
@@ -52,6 +52,7 @@ def validate(regex):
         raise exceptions.InvalidRegexError(
             '{} is an invalid regular expression'.format(
                 regex))
+    return True
 
 
 def isequal(re1, re2):

--- a/automata/base/regex.py
+++ b/automata/base/regex.py
@@ -2,7 +2,6 @@
 """Methods for working with regular expressions"""
 
 import automata.base.exceptions as exceptions
-
 from automata.fa.dfa import DFA
 from automata.fa.nfa import NFA
 

--- a/automata/base/regex.py
+++ b/automata/base/regex.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Methods for working with regular expressions"""
+
+import automata.base.exceptions as exceptions
+
+from automata.fa.dfa import DFA
+from automata.fa.nfa import NFA
+
+
+def _validate(regex):
+    """Return True if the regular expression is valid"""
+
+    stack1 = 0
+    for i in range(len(regex)):
+        if regex[i] == '(':
+            stack1 += 1
+        elif regex[i] == ')':
+            stack1 = stack1 - 1
+
+        if stack1 < 0:
+            return False
+
+        if regex[i] == '*':
+            if i > 0 and regex[i - 1] in {'(', '|', '*', '?'}:
+                return False
+            elif i == 0:
+                return False
+
+        if regex[i] == '|':
+            if i > 1 and regex[i - 1] in {'(', '|'}:
+                return False
+            elif i < len(regex) - 1 and regex[i + 1] in {')', '|', '*', '?'}:
+                return False
+            elif i == 0 or i == len(regex) - 1:
+                return False
+
+        if regex[i] == '(':
+            if i < len(regex) - 1 and regex[i + 1] == ')':
+                return False
+    if stack1 != 0:
+        return False
+    else:
+        return True
+
+
+def validate(regex):
+    """Raise an error if the regular expression is invalid"""
+
+    if not _validate(regex):
+        raise exceptions.InvalidRegExError(
+            '{} is an invalid regular expression'.format(
+                regex))
+
+
+def isequal(re1, re2):
+    """Return True if both regular expressions are equivalent"""
+
+    nfa1 = NFA.from_regex(re1)
+    nfa2 = NFA.from_regex(re2)
+    nfa1.eliminate_lambda()
+    nfa2.eliminate_lambda()
+    dfa1 = DFA.from_nfa(nfa1)
+    dfa2 = DFA.from_nfa(nfa2)
+    dfa1 = dfa1.minify()
+    dfa2 = dfa2.minify()
+    diff = dfa1.symmetric_difference(dfa2)
+
+    return diff.isempty()
+
+
+def issubset(re1, re2):
+    """Return True if re1 is a subset of re2"""
+
+    nfa1 = NFA.from_regex(re1)
+    nfa2 = NFA.from_regex(re2)
+    dfa1 = DFA.from_nfa(nfa1)
+    dfa2 = DFA.from_nfa(nfa2)
+
+    return dfa1.intersection(dfa2) == dfa1
+
+
+def issuperset(re1, re2):
+    """Return True if re1 is a subset of re2"""
+
+    nfa1 = NFA.from_regex(re1)
+    nfa2 = NFA.from_regex(re2)
+    dfa1 = DFA.from_nfa(nfa1)
+    dfa2 = DFA.from_nfa(nfa2)
+
+    return dfa2.issubset(dfa1)

--- a/automata/base/regex.py
+++ b/automata/base/regex.py
@@ -37,6 +37,8 @@ def _validate(regex):
         if regex[i] == '(':
             if i < len(regex) - 1 and regex[i + 1] == ')':
                 return False
+        if i == 0 and regex[i] == '?':
+            return False
     if stack1 != 0:
         return False
     else:
@@ -63,9 +65,8 @@ def isequal(re1, re2):
     dfa2 = DFA.from_nfa(nfa2)
     dfa1 = dfa1.minify()
     dfa2 = dfa2.minify()
-    diff = dfa1.symmetric_difference(dfa2)
 
-    return diff.isempty()
+    return dfa1 == dfa2
 
 
 def issubset(re1, re2):
@@ -76,7 +77,7 @@ def issubset(re1, re2):
     dfa1 = DFA.from_nfa(nfa1)
     dfa2 = DFA.from_nfa(nfa2)
 
-    return dfa1.intersection(dfa2) == dfa1
+    return dfa1.issubset(dfa2)
 
 
 def issuperset(re1, re2):

--- a/automata/base/regex.py
+++ b/automata/base/regex.py
@@ -49,7 +49,7 @@ def validate(regex):
     """Raise an error if the regular expression is invalid"""
 
     if not _validate(regex):
-        raise exceptions.InvalidRegExError(
+        raise exceptions.InvalidRegexError(
             '{} is an invalid regular expression'.format(
                 regex))
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -506,12 +506,12 @@ class DFA(fa.FA):
     @staticmethod
     def _stringify_states_unsorted(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join(states))
+        return '{{{}}}'.format(','.join(str(states)))
 
     @staticmethod
     def _stringify_states(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join(sorted(states)))
+        return '{{{}}}'.format(','.join(str(sorted(states))))
 
     @classmethod
     def _add_nfa_states_from_queue(cls, nfa, current_states,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -506,12 +506,12 @@ class DFA(fa.FA):
     @staticmethod
     def _stringify_states_unsorted(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join({str(state) for state in states}))
+        return '{{{}}}'.format(','.join(states))
 
     @staticmethod
     def _stringify_states(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join(sorted({str(state) for state in states})))
+        return '{{{}}}'.format(','.join(sorted([str(state) for state in states])))
 
     @classmethod
     def _add_nfa_states_from_queue(cls, nfa, current_states,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -110,6 +110,8 @@ class DFA(fa.FA):
 
     def _validate_transition_start_states(self):
         """Raise an error if transition start states are missing."""
+        if self.allow_partial:
+            return
         for state in self.states:
             if state not in self.transitions:
                 raise exceptions.MissingStateError(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -506,12 +506,12 @@ class DFA(fa.FA):
     @staticmethod
     def _stringify_states_unsorted(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join(str(states)))
+        return '{{{}}}'.format(','.join({str(state) for state in states}))
 
     @staticmethod
     def _stringify_states(states):
         """Stringify the given set of states as a single state name."""
-        return '{{{}}}'.format(','.join(str(sorted(states))))
+        return '{{{}}}'.format(','.join(sorted({str(state) for state in states})))
 
     @classmethod
     def _add_nfa_states_from_queue(cls, nfa, current_states,

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -71,16 +71,19 @@ class GNFA(fa.FA):
         gnfa.eliminate_lambda()
         for state in gnfa.states:
             gnfa_transitions = dict()
-            for input_symbol, to_states in gnfa.transitions[state].items():
-                for to_state in to_states:
-                    if to_state in gnfa_transitions.keys():
-                        if gnfa_transitions[to_state] == '' or input_symbol == '':
-                            gnfa_transitions[to_state] = ''
+            if state in gnfa.transitions:
+                for input_symbol, to_states in gnfa.transitions[state].items():
+                    for to_state in to_states:
+                        if to_state in gnfa_transitions.keys():
+                            if gnfa_transitions[to_state] == '' or input_symbol == '':
+                                gnfa_transitions[to_state] = ''
+                            else:
+                                gnfa_transitions[to_state] = "{}|{}".format(gnfa_transitions[to_state], input_symbol)
                         else:
-                            gnfa_transitions[to_state] = "{}|{}".format(gnfa_transitions[to_state], input_symbol)
-                    else:
-                        gnfa_transitions[to_state] = input_symbol
-            gnfa.transitions[state] = gnfa_transitions
+                            gnfa_transitions[to_state] = input_symbol
+                gnfa.transitions[state] = gnfa_transitions
+            else:
+                gnfa.transitions[state] = dict()
 
         new_initial_state = 0
         while new_initial_state in gnfa.states:

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -6,9 +6,8 @@ import copy
 from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
-import automata.fa.nfa as nfa
-
 import automata.base.regex as re
+import automata.fa.nfa as nfa
 
 
 class GNFA(nfa.NFA):

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -134,6 +134,8 @@ class GNFA(nfa.NFA):
                 raise exceptions.InvalidStateError(
                     'No transitions should be defined for '
                     'final state {}'.format(start_state))
+            else:  # pragma: no branch
+                pass
         elif start_state == self.initial_state and self.states - paths.keys() - {self.initial_state} != set():
             raise exceptions.MissingStateError(
                 'state {} does not have transitions defined for states {}'.format(
@@ -142,11 +144,14 @@ class GNFA(nfa.NFA):
             raise exceptions.MissingStateError(
                 'state {} does not have transitions defined for states {}'.format(
                     start_state, str(self.states - paths.keys() - {self.initial_state})))
-        for end_state in paths.keys():  # pragma: no branch
-            if end_state not in self.states:
-                raise exceptions.InvalidStateError(
-                    'end state {} for transition on {} is '
-                    'not valid'.format(end_state, start_state))
+        if paths.keys():
+            for end_state in paths.keys():  # pragma: no branch
+                if end_state not in self.states:
+                    raise exceptions.InvalidStateError(
+                        'end state {} for transition on {} is '
+                        'not valid'.format(end_state, start_state))
+        else:  # pragma: no cover
+            pass
 
     def _validate_final_state(self):
         """Raise an error if the initial state is invalid."""
@@ -220,10 +225,10 @@ class GNFA(nfa.NFA):
                             r2 = ''
                         elif len(r2) == 2 and r2[1] == '*':
                             pass
-                        elif len(r2) > 1:
-                            r2 = '({})*'.format(r2)
                         elif len(r2) == 1:
                             r2 = '{}*'.format(r2)
+                        else:
+                            r2 = '({})*'.format(r2)
 
                         if self._isbracket_req(r3):
                             r3 = '({})'.format(r3)

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Classes and methods for working with generalized non-deterministic finite automata."""
+
+import copy
+from abc import ABC
+
+from pydot import Dot, Edge, Node
+
+import automata.base.exceptions as exceptions
+import automata.fa.fa as fa
+from automata.base.regex import RegEx as re
+
+
+class GNFA(fa.FA):
+    """A generalized nondeterministic finite automaton."""
+
+    def __init__(self, *, states, input_symbols, transitions,
+                 initial_state, final_state):
+        """Initialize a complete NFA."""
+        self.states = states.copy()
+        self.input_symbols = input_symbols.copy()
+        self.transitions = copy.deepcopy(transitions)
+        self.initial_state = initial_state
+        self.final_state = final_state
+        self.validate()
+
+    @classmethod
+    def from_dfa(cls, dfa):
+        """Initialize this GNFA as one equivalent to the given DFA."""
+        gnfa = dfa.copy()
+
+        for state in gnfa.states:
+            gnfa_transitions = dict()
+            for input_symbol, to_state in gnfa.transitions[state].items():
+                if to_state in gnfa_transitions.keys():
+                    gnfa_transitions[to_state] = "{}|{}".format(gnfa_transitions[to_state], input_symbol)
+                else:
+                    gnfa_transitions[to_state] = input_symbol
+            gnfa.transitions[state] = gnfa_transitions
+
+        gnfa.states.add(0)  # add new start state
+        gnfa.transitions[0] = {gnfa.initial_state: ''}
+        gnfa.initial_state = 0
+        gnfa.states.add(1)  # add new accept state
+
+        for state in gnfa.final_states:
+            gnfa.transitions[state][1] = ''
+        gnfa.final_state = 1
+
+        for state in gnfa.states - {1}:
+            if gnfa.states - gnfa.transitions[state].keys():
+                for leftover_state in gnfa.states - gnfa.transitions[state].keys():
+                    if leftover_state is not gnfa.initial_state:
+                        gnfa.transitions[state][leftover_state] = None
+
+        return cls(
+            states=gnfa.states, input_symbols=gnfa.input_symbols,
+            transitions=gnfa.transitions, initial_state=gnfa.initial_state,
+            final_state=gnfa.final_state)
+
+    @classmethod
+    def from_nfa(cls, nfa):
+        """Initialize this GNFA as one equivalent to the given NFA."""
+        gnfa = nfa.copy()
+
+        for state in gnfa.states:
+            gnfa_transitions = dict()
+            for input_symbol, to_states in gnfa.transitions[state].items():
+                for to_state in to_states:
+                    if to_state in gnfa_transitions.keys():
+                        if gnfa_transitions[to_state] == '' or input_symbol == '':
+                            gnfa_transitions[to_state] = ''
+                        else:
+                            gnfa_transitions[to_state] = "{}|{}".format(gnfa_transitions[to_state], input_symbol)
+                    else:
+                        gnfa_transitions[to_state] = input_symbol
+            gnfa.transitions[state] = gnfa_transitions
+
+        gnfa.states.add(0)  # add new start state
+        gnfa.transitions[0] = {gnfa.initial_state: ''}
+        gnfa.initial_state = 0
+        gnfa.states.add(1)  # add new accept state
+
+        for state in gnfa.final_states:
+            gnfa.transitions[state][1] = ''
+        gnfa.final_state = 1
+
+        for state in gnfa.states - {1}:
+            if gnfa.states - gnfa.transitions[state].keys():
+                for leftover_state in gnfa.states - gnfa.transitions[state].keys():
+                    if leftover_state is not gnfa.initial_state:
+                        gnfa.transitions[state][leftover_state] = None
+
+        return cls(
+            states=gnfa.states, input_symbols=gnfa.input_symbols,
+            transitions=gnfa.transitions, initial_state=gnfa.initial_state,
+            final_state=gnfa.final_state)
+
+    @staticmethod
+    def _validate_regex(regex):
+        """Return True if the regular expression is valid"""
+
+        stack1 = 0
+        for i in range(len(regex)):
+            if regex[i] == '(':
+                stack1 += 1
+            elif regex[i] == ')':
+                stack1 = stack1 - 1
+
+            if stack1 < 0:
+                return False
+
+            if regex[i] == '*':
+                if i > 0 and regex[i-1] in {'(', '|', '*'}:
+                    return False
+                elif i == 0:
+                    return False
+
+            if regex[i] == '|':
+                if i > 1 and regex[i-1] in {'(', '|'}:
+                    return False
+                elif i < len(regex)-1 and regex[i+1] in {')', '|', '*'}:
+                    return False
+                elif i == 0 or i == len(regex)-1:
+                    return False
+
+            if regex[i] == '(':
+                if i < len(regex)-1 and regex[i+1] == ')':
+                    return False
+        if stack1 != 0:
+            return False
+        else:
+            return True
+
+    def _validate_transition_invalid_symbols(self, start_state, paths):
+        """Raise an error if transition symbols are invalid."""
+        for regex in paths.values():
+            check = self.input_symbols.copy()
+            check = check.union({'*', '|', '(', ')'})
+            if regex is not None and (set(regex) - check and regex != '' or not self._validate_regex(regex)):
+                raise exceptions.InvalidSymbolError(
+                    'state {} has invalid transition expression {}'.format(
+                        start_state, regex))
+
+    def _validate_transition_end_states(self, start_state, paths):
+        """Raise an error if transition end states are invalid."""
+        for end_state in paths.keys():
+                if end_state not in self.states:
+                    raise exceptions.InvalidStateError(
+                        'end state {} for transition on {} is '
+                        'not valid'.format(end_state, start_state))
+
+    def _validate_final_state(self):
+        """Raise an error if the initial state is invalid."""
+        if self.final_state not in self.states:
+            raise exceptions.InvalidStateError(
+                '{} is not a valid final state'.format(self.final_state))
+
+    def validate(self):
+        """Return True if this NFA is internally consistent."""
+        for start_state, paths in self.transitions.items():
+            self._validate_transition_invalid_symbols(start_state, paths)
+            self._validate_transition_end_states(start_state, paths)
+        self._validate_initial_state()
+        self._validate_initial_state_transitions()
+        self._validate_final_state()
+        return True
+
+    def _isbracket_req(self, regex):
+        bracket_open = 0
+        for i in range(len(regex)):
+            if regex[i] == '(':
+                bracket_open += 1
+            elif regex[i] == ')':
+                bracket_open = bracket_open - 1
+            if bracket_open == 0 and regex[i] == '|':
+                return True
+            else:
+                return False
+
+    @staticmethod
+    def _find_min_connected_node(gnfa):
+        state_set = gnfa.states-{gnfa.initial_state, gnfa.final_state}
+        state_degree = dict.fromkeys(state_set, 0)
+        for state in gnfa.states - {gnfa.final_state}:
+            for to_state, label in gnfa.transitions[state].items():
+                if label is not None:
+                    if state != gnfa.initial_state:
+                        state_degree[state] = state_degree[state] + 1
+                    if to_state != gnfa.final_state:
+                        state_degree[to_state] = state_degree[to_state] + 1
+
+        return min(state_degree, key=state_degree.get)
+
+    def _to_regex(self, gnfa):
+        """
+        Convert GNFA to regular expression.
+        Helper function for 'to_regex' function.
+        """
+        k = len(gnfa.states)
+        if k == 2:
+            return gnfa.transitions[gnfa.initial_state][gnfa.final_state]
+        else:
+            q_rip = self._find_min_connected_node(gnfa)
+            new_states = gnfa.states - {q_rip}
+            for q_i in new_states - {gnfa.final_state}:
+                for q_j in new_states - {gnfa.initial_state}:
+                    r1 = gnfa.transitions[q_i][q_rip]
+                    r2 = gnfa.transitions[q_rip][q_rip]
+                    r3 = gnfa.transitions[q_rip][q_j]
+                    r4 = gnfa.transitions[q_i][q_j]
+
+                    if r1 is None or r3 is None:
+                        gnfa.transitions[q_i][q_j] = r4
+                    else:
+                        # check if putting brackets around r1 is necessary
+                        if self._isbracket_req(r1):
+                            r1 = '({})'.format(r1)
+
+                        if r2 is None:
+                            r2 = ''
+                        elif len(r2) == 2 and r2[1] == '*':
+                            pass
+                        elif len(r2) > 1:
+                            r2 = '({})*'.format(r2)
+                        elif len(r2) == 1:
+                            r2 = '{}*'.format(r2)
+
+                        if self._isbracket_req(r3):
+                            r3 = '({})'.format(r3)
+
+                        if r4 is None:
+                            r4 = ''
+                        elif self._isbracket_req(r4):
+                            r4 = '|({})'.format(r2)
+                        else:
+                            r4 = '|{}'.format(r4)
+
+                        gnfa.transitions[q_i][q_j] = r1 + r2 + r3 + r4
+            gnfa.states = new_states
+            del gnfa.transitions[q_rip]
+            for state in gnfa.states-{gnfa.final_state}:
+                del gnfa.transitions[state][q_rip]
+
+            return self._to_regex(gnfa)
+
+    def to_regex(self):
+        gnfa = self.copy()
+        return self._to_regex(gnfa)
+
+    def show_diagram(self, path=None, show_None = True):
+        """
+            Creates the graph associated with this DFA
+        """
+        # Nodes are set of states
+
+        graph = Dot(graph_type='digraph', rankdir='LR')
+        nodes = {}
+        for state in self.states:
+            if state == self.initial_state:
+                # color start state with green
+                initial_state_node = Node(
+                    state, style='filled', fillcolor='#66cc33')
+                nodes[state] = initial_state_node
+                graph.add_node(initial_state_node)
+            else:
+                if state == self.final_state:
+                    state_node = Node(state, peripheries=2)
+                else:
+                    state_node = Node(state)
+                nodes[state] = state_node
+                graph.add_node(state_node)
+        # adding edges
+        for from_state, lookup in self.transitions.items():
+            for to_state, to_label in lookup.items():
+                if to_label is None and show_None:
+                    to_label = "ø"
+                    graph.add_edge(Edge(
+                        nodes[from_state],
+                        nodes[to_state],
+                        label=to_label
+                    ))
+                elif to_label is not None:
+                    graph.add_edge(Edge(
+                        nodes[from_state],
+                        nodes[to_state],
+                        label=to_label
+                    ))
+        if path:
+            graph.write_png(path)
+        return graph
+
+    def read_input_stepwise(self, input_str):
+        """This method is not implemented yet in GNFA, wait for future versions"""
+
+        pass
+
+
+

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -56,7 +56,7 @@ class GNFA(nfa.NFA):
             gnfa.transitions[state][new_final_state] = ''
         gnfa.final_state = new_final_state
 
-        for state in gnfa.states - {new_final_state}:
+        for state in gnfa.states - {new_final_state}:  # pragma: no branch
             if gnfa.states - gnfa.transitions[state].keys():
                 for leftover_state in gnfa.states - gnfa.transitions[state].keys():
                     if leftover_state is not gnfa.initial_state:
@@ -107,7 +107,7 @@ class GNFA(nfa.NFA):
             gnfa.transitions[state][new_final_state] = ''
         gnfa.final_state = new_final_state
 
-        for state in gnfa.states - {new_final_state}:
+        for state in gnfa.states - {new_final_state}:  # pragma: no branch
             if gnfa.states - gnfa.transitions[state].keys():
                 for leftover_state in gnfa.states - gnfa.transitions[state].keys():
                     if leftover_state is not gnfa.initial_state:

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -6,12 +6,12 @@ import copy
 from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
-import automata.fa.fa as fa
+import automata.fa.nfa as nfa
 
 import automata.base.regex as re
 
 
-class GNFA(fa.FA):
+class GNFA(nfa.NFA):
     """A generalized nondeterministic finite automaton."""
 
     def __init__(self, *, states, input_symbols, transitions,
@@ -134,7 +134,7 @@ class GNFA(fa.FA):
         elif start_state != self.initial_state and self.states - paths.keys() - {self.initial_state} != set():
             raise exceptions.MissingStateError(
                 'state {} does not have transitions defined for states {}'.format(
-                    start_state, str(self.states - paths.keys()- {self.initial_state})))
+                    start_state, str(self.states - paths.keys() - {self.initial_state})))
         for end_state in paths.keys():
             if end_state not in self.states:
                 raise exceptions.InvalidStateError(
@@ -291,10 +291,6 @@ class GNFA(fa.FA):
             graph.write_png(path)
         return graph
 
-    def read_input_stepwise(self, input_str):
-        """This method is not implemented yet in GNFA, wait for future versions"""
-
-        pass
 
 
 

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -2,13 +2,11 @@
 """Classes and methods for working with generalized non-deterministic finite automata."""
 
 import copy
-from abc import ABC
 
 from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
-from automata.base.regex import RegEx as re
 
 
 class GNFA(fa.FA):
@@ -245,6 +243,9 @@ class GNFA(fa.FA):
             return self._to_regex(gnfa)
 
     def to_regex(self):
+        """
+        Convert GNFA to regular expression.
+        """
         gnfa = self.copy()
         return self._to_regex(gnfa)
 

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -57,7 +57,7 @@ class GNFA(nfa.NFA):
         gnfa.final_state = new_final_state
 
         for state in gnfa.states - {new_final_state}:  # pragma: no branch
-            if gnfa.states - gnfa.transitions[state].keys():
+            if gnfa.states - gnfa.transitions[state].keys():  # pragma: no branch
                 for leftover_state in gnfa.states - gnfa.transitions[state].keys():
                     if leftover_state is not gnfa.initial_state:
                         gnfa.transitions[state][leftover_state] = None
@@ -108,7 +108,7 @@ class GNFA(nfa.NFA):
         gnfa.final_state = new_final_state
 
         for state in gnfa.states - {new_final_state}:  # pragma: no branch
-            if gnfa.states - gnfa.transitions[state].keys():
+            if gnfa.states - gnfa.transitions[state].keys():  # pragma: no branch
                 for leftover_state in gnfa.states - gnfa.transitions[state].keys():
                     if leftover_state is not gnfa.initial_state:
                         gnfa.transitions[state][leftover_state] = None

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -124,7 +124,7 @@ class GNFA(nfa.NFA):
             check = self.input_symbols.copy()
             check = check.union({'*', '|', '(', ')', '?'})
             if regex is not None and (set(regex) - check and regex != '' or not re._validate(regex)):
-                raise exceptions.InvalidRegExError(
+                raise exceptions.InvalidRegexError(
                     'state {} has invalid transition expression {}'.format(
                         start_state, regex))
 

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -53,10 +53,7 @@ class GNFA(nfa.NFA):
         gnfa.states.add(new_final_state)  # add new accept state
 
         for state in gnfa.final_states:
-            if state not in gnfa.transitions:
-                gnfa.transitions[state] = {new_final_state: ''}
-            else:
-                gnfa.transitions[state][new_final_state] = ''
+            gnfa.transitions[state][new_final_state] = ''
         gnfa.final_state = new_final_state
 
         for state in gnfa.states - {new_final_state}:
@@ -107,10 +104,7 @@ class GNFA(nfa.NFA):
         gnfa.states.add(new_final_state)  # add new accept state
 
         for state in gnfa.final_states:
-            if state not in gnfa.transitions:
-                gnfa.transitions[state] = {new_final_state: ''}
-            else:
-                gnfa.transitions[state][new_final_state] = ''
+            gnfa.transitions[state][new_final_state] = ''
         gnfa.final_state = new_final_state
 
         for state in gnfa.states - {new_final_state}:
@@ -149,7 +143,7 @@ class GNFA(nfa.NFA):
             raise exceptions.MissingStateError(
                 'state {} does not have transitions defined for states {}'.format(
                     start_state, str(self.states - paths.keys() - {self.initial_state})))
-        for end_state in paths.keys():
+        for end_state in paths.keys():  # pragma: no branch
             if end_state not in self.states:
                 raise exceptions.InvalidStateError(
                     'end state {} for transition on {} is '
@@ -287,7 +281,7 @@ class GNFA(nfa.NFA):
                 graph.add_node(state_node)
         # adding edges
         for from_state, lookup in self.transitions.items():
-            for to_state, to_label in lookup.items():
+            for to_state, to_label in lookup.items():  # pragma: no branch
                 if to_label is None and show_None:
                     to_label = "ø"
                     graph.add_edge(Edge(

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -135,7 +135,7 @@ class NFA(fa.FA):
 
         bracket_level = 0
         highest_bracket = None
-        for i in range(len(master)):
+        for i in range(len(master)):  # pragma: no branch
             if not isinstance(master[i], NFA):
                 if master[i] == '|':
                     if highest_bracket is None or highest_bracket < bracket_level:
@@ -189,6 +189,15 @@ class NFA(fa.FA):
     @classmethod
     def from_regex(cls, regex):
         """Initialize this NFA as one equivalent to the given regular expression"""
+
+        if regex == '':
+            return NFA(
+                states={0},
+                initial_state=0,
+                final_states={0},
+                transitions={},
+                input_symbols=set()
+            )
 
         cls._validate_regex(regex)
         symbols = set(regex) - {'*', '|', '(', ')', '?'}

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -142,7 +142,7 @@ class NFA(fa.FA):
                         highest_bracket = bracket_level
                 elif master[i] == '(':
                     bracket_level += 1
-                elif master[i] == ')':
+                elif master[i] == ')':  # pragma: no branch
                     bracket_level = bracket_level - 1
 
         if highest_bracket is None:

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -143,7 +143,7 @@ class NFA(fa.FA):
                 elif master[i] == '(':
                     bracket_level += 1
                 elif master[i] == ')':  # pragma: no branch
-                    bracket_level = bracket_level - 1
+                    bracket_level -= 1
 
         if highest_bracket is None:
             return

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -32,7 +32,7 @@ class NFA(fa.FA):
             raise NotImplementedError
 
     def __or__(self, other):
-        """Return the union of this DFA and another DFA."""
+        """Return the union of this NFA and another NFA."""
         if isinstance(other, NFA):
             return self.union(other)
         else:
@@ -435,6 +435,9 @@ class NFA(fa.FA):
         L1 and L2 respectively, returns an NFA which accepts
         the union of L1 and L2.
         """
+        if not isinstance(other, NFA):
+            raise NotImplementedError
+
         # first check superset or subset relation
         if DFA.from_nfa(self).issubset(DFA.from_nfa(other)):
             return other.copy()

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -25,7 +25,7 @@ class NFA(fa.FA):
         self.validate()
 
     def __add__(self, other):
-        """Return the concatenation of this DFA and another DFA."""
+        """Return the concatenation of this NFA and another NFA."""
         if isinstance(other, NFA):
             return self.concatenate(other)
         else:

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -4,11 +4,11 @@
 import copy
 from collections import deque
 
+from pydot import Dot, Edge, Node
+
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
 from automata.fa.dfa import DFA
-
-from pydot import Dot, Edge, Node
 
 
 class NFA(fa.FA):

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -214,8 +214,10 @@ class NFA(fa.FA):
                 cls._remove_excess_parenthesis(master)
                 if len(master) < initial_length:
                     initial_length = len(master)
-                else:
+                elif len(master) == initial_length:
                     break
+                else:
+                    pass
 
         def star_option_concatenate():
             initial_length = len(master)
@@ -225,8 +227,10 @@ class NFA(fa.FA):
                 cls._remove_excess_parenthesis(master)
                 if len(master) < initial_length:
                     initial_length = len(master)
-                else:
+                elif len(master) == initial_length:
                     break
+                else:
+                    pass
 
         def star_option_concatenate_union():
             initial_length = len(master)

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -288,7 +288,7 @@ class NFA(fa.FA):
             result = False
 
         if not result:
-            raise exceptions.InvalidRegExError(
+            raise exceptions.InvalidRegexError(
                 '{} is an invalid regular expression'.format(
                     regex))
 

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -2,9 +2,15 @@
 """Classes and methods for working with nondeterministic finite automata."""
 
 import copy
+from collections import deque
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
+from automata.fa.dfa import DFA
+
+from pydot import Dot, Edge, Node
+
+import automata.base.regex as re
 
 
 class NFA(fa.FA):
@@ -54,6 +60,172 @@ class NFA(fa.FA):
                     'state {} has invalid transition symbol {}'.format(
                         start_state, input_symbol))
 
+    @classmethod
+    def _from_symbol(cls, symbol, input_symbols=None):
+        """Generate NFA from single symbol, `input symbols` may be passed to initialize input_symbols for NFA"""
+        states = {0, 1}
+        initial_state = 0
+        if input_symbols is None:
+            input_symbols = {symbol}
+        transitions = {0: {symbol: {1}}}
+        final_states = {1}
+
+        return NFA(
+            states=states,
+            input_symbols=input_symbols,
+            initial_state=initial_state,
+            transitions=transitions,
+            final_states=final_states
+        )
+
+    @staticmethod
+    def _kleene_star(master_list):
+        """Helper function for from_regex. applies kleene star operation wherever possible."""
+        i = 0
+        while True:
+            if i == len(master_list) - 1:
+                break
+            elif not isinstance(master_list[i], NFA):
+                i += 1
+            elif i != len(master_list) - 1 and not isinstance(master_list[i + 1], NFA) and master_list[i + 1] == '*':
+                master_list[i] = master_list[i].kleene_star()
+                master_list.pop(i + 1)
+            else:
+                i += 1
+
+    @staticmethod
+    def _option(master):
+        """applies ? operator wherever possible in master list"""
+        i = 0
+        while True:
+            if i == len(master) - 1:
+                break
+            elif not isinstance(master[i], NFA):
+                i += 1
+            elif i != len(master) - 1 and not isinstance(master[i + 1], NFA) and master[i + 1] == '?':
+                master[i] = master[i].option()
+                master.pop(i + 1)
+            else:
+                i += 1
+
+    @staticmethod
+    def _concatenate(master_list):
+        """applies concatenation operator wherever possible"""
+        i = 0
+        while True:
+            if i == len(master_list) - 1:
+                break
+            elif not isinstance(master_list[i], NFA):
+                i += 1
+            elif i != len(master_list) - 1 and isinstance(master_list[i + 1], NFA):
+                master_list[i] = master_list[i].concatenate(master_list[i + 1])
+                master_list.pop(i + 1)
+            else:
+                i += 1
+
+    @staticmethod
+    def _union(master):
+        """applies union operation wherever possible in master list"""
+        # apply union in the highest level of parenthesis only
+
+        bracket_level = 0
+        highest_bracket = None
+        for i in range(len(master)):
+            if not isinstance(master[i], NFA):
+                if master[i] == '|':
+                    if highest_bracket is None or highest_bracket < bracket_level:
+                        highest_bracket = bracket_level
+                elif master[i] == '(':
+                    bracket_level += 1
+                elif master[i] == ')':
+                    bracket_level = bracket_level - 1
+
+        if highest_bracket is None:
+            return
+
+        stack = 0
+        i = 0
+        while True:
+            if i == len(master) - 1:
+                break
+            elif not isinstance(master[i], NFA) and master[i] == '(':
+                stack += 1
+                i += 1
+            elif not isinstance(master[i], NFA) and master[i] == ')':
+                stack = stack - 1
+                i += 1
+            elif stack == highest_bracket and not isinstance(master[i], NFA) and master[i] == '|' \
+                    and isinstance(master[i + 1], NFA) \
+                    and isinstance(master[i - 1], NFA):
+                master[i - 1] = master[i - 1].union(master[i + 1])
+                master.pop(i)
+                master.pop(i)
+                i = i - 1
+            else:
+                i += 1
+
+    @staticmethod
+    def _remove_excess_parenthesis(master):
+        """removes excess parenthesis from the master list"""
+        i = 0
+        while True:
+            if i == len(master) - 1:
+                break
+            elif i != 0 and i != len(master) - 1 \
+                    and isinstance(master[i], NFA) \
+                    and not isinstance(master[i - 1], NFA) and master[i - 1] == '(' \
+                    and not isinstance(master[i + 1], NFA) and master[i + 1] == ')':
+                master.pop(i - 1)
+                master.pop(i)
+                i = i - 1
+            else:
+                i += 1
+
+    @classmethod
+    def from_regex(cls, regex):
+        """Initialize this NFA as one equivalent to the given regular expression"""
+
+        re.validate(regex)
+        symbols = set(regex) - {'*', '|', '(', ')', '?'}
+        master = list(regex)
+        for i in range(len(master)):
+            if master[i] in symbols:
+                master[i] = cls._from_symbol(master[i], symbols)
+
+        def star_and_option():
+            initial_length = len(master)
+            while True:
+                cls._kleene_star(master)
+                cls._option(master)
+                cls._remove_excess_parenthesis(master)
+                if len(master) < initial_length:
+                    initial_length = len(master)
+                else:
+                    break
+
+        def star_option_concatenate():
+            initial_length = len(master)
+            while True:
+                star_and_option()
+                cls._concatenate(master)
+                cls._remove_excess_parenthesis(master)
+                if len(master) < initial_length:
+                    initial_length = len(master)
+                else:
+                    break
+
+        def star_option_concatenate_union():
+            initial_length = len(master)
+            while True:
+                star_option_concatenate()
+                cls._union(master)
+                cls._remove_excess_parenthesis(master)
+                if len(master) == 1:
+                    break
+
+        star_option_concatenate_union()
+        return master[0]
+
     def _validate_transition_end_states(self, start_state, paths):
         """Raise an error if transition end states are invalid."""
         for end_states in paths.values():
@@ -89,7 +261,7 @@ class NFA(fa.FA):
             state = stack.pop()
             if state not in encountered_states:
                 encountered_states.add(state)
-                if '' in self.transitions[state]:
+                if state in self.transitions and '' in self.transitions[state]:
                     stack.extend(self.transitions[state][''])
 
         return encountered_states
@@ -99,14 +271,71 @@ class NFA(fa.FA):
         next_current_states = set()
 
         for current_state in current_states:
+            if current_state in self.transitions:
+                symbol_end_states = self.transitions[current_state].get(
+                    input_symbol)
+                if symbol_end_states:
+                    for end_state in symbol_end_states:
+                        next_current_states.update(
+                            self._get_lambda_closure(end_state))
+
+        return next_current_states
+
+    def _get_next_current_states2(self, current_states, input_symbol):
+        """Return the next set of current states given the current set."""
+        next_current_states = set()
+
+        for current_state in current_states:
             symbol_end_states = self.transitions[current_state].get(
                 input_symbol)
             if symbol_end_states:
-                for end_state in symbol_end_states:
-                    next_current_states.update(
-                        self._get_lambda_closure(end_state))
+                next_current_states.update(symbol_end_states)
 
         return next_current_states
+
+    def _remove_unreachable_states(self):
+        """Remove states which are not reachable from the initial state."""
+        reachable_states = self._compute_reachable_states()
+        unreachable_states = self.states - reachable_states
+        for state in unreachable_states:
+            self.states.remove(state)
+            del self.transitions[state]
+            if state in self.final_states:
+                self.final_states.remove(state)
+
+    def _compute_reachable_states(self):
+        """Compute the states which are reachable from the initial state."""
+        reachable_states = set()
+        states_to_check = deque()
+        states_to_check.append(self.initial_state)
+        reachable_states.add(self.initial_state)
+        while states_to_check:
+            state = states_to_check.popleft()
+            for symbol, dst_states in self.transitions[state].items():
+                for dst_state in dst_states:
+                    if dst_state not in reachable_states:
+                        reachable_states.add(dst_state)
+                        states_to_check.append(dst_state)
+        return reachable_states
+
+    def eliminate_lambda(self):
+        """Removes epsilon transitions from the NFA which recognizes the same language."""
+        for state in self.states:
+            lambda_enclosure = self._get_lambda_closure(state) - {state}
+            for input_symbol in self.input_symbols:
+                next_current_states = self._get_next_current_states2(lambda_enclosure, input_symbol)
+                if state not in self.transitions:
+                    self.transitions[state] = dict()
+                if input_symbol in self.transitions[state]:
+                    self.transitions[state][input_symbol].update(next_current_states)
+                else:
+                    self.transitions[state][input_symbol] = next_current_states
+
+            if state not in self.final_states and self.final_states & lambda_enclosure:
+                self.final_states.add(state)
+            self.transitions[state].pop('', None)
+
+        self._remove_unreachable_states()
 
     def _check_for_input_rejection(self, current_states):
         """Raise an error if the given config indicates rejected input."""
@@ -130,6 +359,59 @@ class NFA(fa.FA):
             yield current_states
 
         self._check_for_input_rejection(current_states)
+
+    def union(self, other):
+        """
+        Given two NFAs, M1 and M2, which accept the languages
+        L1 and L2 respectively, returns an NFA which accepts
+        the union of L1 and L2.
+        """
+        # first check superset or subset relation
+        if DFA.from_nfa(self).issubset(DFA.from_nfa(other)):
+            return other.copy()
+        elif DFA.from_nfa(self).issuperset(DFA.from_nfa(other)):
+            return self.copy()
+
+        state_map_a = dict()
+        for state in self.states:
+            state_map_a[state] = len(state_map_a) + 1
+
+        state_map_b = dict()
+        for state in other.states:
+            state_map_b[state] = len(state_map_a) + len(state_map_b) + 1
+
+        new_states = set(state_map_a.values()) | set(state_map_b.values()) | {0}
+        new_transitions = dict()
+        for state in new_states:
+            new_transitions[state] = dict()
+
+        # Connect new initial state to both branch
+        new_transitions[0] = {'': {state_map_a[self.initial_state], state_map_b[other.initial_state]}}
+        # Transitions of self
+        for state_a, transitions in self.transitions.items():
+            for symbol, states in transitions.items():
+                new_transitions[state_map_a[state_a]][symbol] = {
+                    state_map_a[state_b] for state_b in states
+                }
+
+        # Transitions of other
+        for state_a, transitions in other.transitions.items():
+            for symbol, states in transitions.items():
+                new_transitions[state_map_b[state_a]][symbol] = {
+                    state_map_b[state_b] for state_b in states
+                }
+
+        # Final states
+        new_final_states = {state_map_a[state] for state in self.final_states} | {state_map_b[state] for state in
+                                                                                  other.final_states}
+
+        return NFA(
+            states=new_states,
+            input_symbols=self.input_symbols | other.input_symbols,
+            transitions=new_transitions,
+            initial_state=0,
+            final_states=new_final_states
+        )
 
     def concatenate(self, other):
         """
@@ -191,36 +473,57 @@ class NFA(fa.FA):
         new_initial_state = 0
         while new_initial_state in self.states:
             new_initial_state += 1
-        new_final_state = new_initial_state + 1
-        while new_final_state in self.states:
-            new_final_state += 1
         new_states.add(new_initial_state)
-        new_states.add(new_final_state)
 
         # Transitions are the same with a few additions.
         new_transitions = copy.deepcopy(self.transitions)
         # We add epsilon transition from new initial state
-        # to old initial state and new final state.
+        # to old initial state
         new_transitions[new_initial_state] = {
-            '': {self.initial_state, new_final_state}
+            '': {self.initial_state}
         }
-        # We have no transitions from new final state
-        new_transitions[new_final_state] = dict()
         # For each final state in original NFA we add epsilon
-        # transition to the old initial state and to the new
-        # final state.
+        # transition to the old initial state
         for state in self.final_states:
+            if state not in new_transitions:
+                new_transitions[state] = dict()
             if '' not in new_transitions[state]:
                 new_transitions[state][''] = set()
             new_transitions[state][''].add(self.initial_state)
-            new_transitions[state][''].add(new_final_state)
 
         return NFA(
             states=new_states,
             input_symbols=self.input_symbols,
             transitions=new_transitions,
             initial_state=new_initial_state,
-            final_states={new_final_state}
+            final_states=self.final_states | {new_initial_state}
+        )
+
+    def option(self):
+        """
+        Given an NFA which accepts the language L returns
+        an NFA which accepts L repeated 0 or 1 times. (option - ?)
+        """
+        new_states = set(self.states)
+        new_initial_state = 0
+        while new_initial_state in self.states:
+            new_initial_state += 1
+        new_states.add(new_initial_state)
+
+        # Transitions are the same with a few additions.
+        new_transitions = copy.deepcopy(self.transitions)
+        # We add epsilon transition from new initial state
+        # to old initial state
+        new_transitions[new_initial_state] = {
+            '': {self.initial_state}
+        }
+
+        return NFA(
+            states=new_states,
+            input_symbols=self.input_symbols,
+            transitions=new_transitions,
+            initial_state=new_initial_state,
+            final_states=self.final_states | {new_initial_state}
         )
 
     def reverse(self):
@@ -259,3 +562,45 @@ class NFA(fa.FA):
             initial_state=new_initial_state,
             final_states=new_final_states
         )
+
+    def show_diagram(self, path=None):
+        """
+            Creates the graph associated with this DFA
+        """
+        # Nodes are set of states
+
+        graph = Dot(graph_type='digraph', rankdir='LR')
+        nodes = {}
+        for state in self.states:
+            if state == self.initial_state:
+                # color start state with green
+                if state in self.final_states:
+                    initial_state_node = Node(
+                        state,
+                        style='filled',
+                        peripheries=2,
+                        fillcolor='#66cc33')
+                else:
+                    initial_state_node = Node(
+                        state, style='filled', fillcolor='#66cc33')
+                nodes[state] = initial_state_node
+                graph.add_node(initial_state_node)
+            else:
+                if state in self.final_states:
+                    state_node = Node(state, peripheries=2)
+                else:
+                    state_node = Node(state)
+                nodes[state] = state_node
+                graph.add_node(state_node)
+        # adding edges
+        for from_state, lookup in self.transitions.items():
+            for to_label, to_states in lookup.items():
+                for to_state in to_states:
+                    graph.add_edge(Edge(
+                        nodes[from_state],
+                        nodes[to_state],
+                        label=to_label
+                    ))
+        if path:
+            graph.write_png(path)
+        return graph

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -5,9 +5,8 @@ import os
 import os.path
 import tempfile
 import types
-from unittest.mock import patch
-
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -2,9 +2,8 @@
 """Classes and functions for testing the behavior of DTMs."""
 
 import types
-from unittest.mock import patch
-
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import automata.tm.exceptions as tm_exceptions

--- a/tests/test_fa.py
+++ b/tests/test_fa.py
@@ -5,6 +5,7 @@ import unittest
 
 from automata.fa.dfa import DFA
 from automata.fa.nfa import NFA
+from automata.fa.gnfa import GNFA
 
 
 class TestFA(unittest.TestCase):
@@ -37,6 +38,20 @@ class TestFA(unittest.TestCase):
             initial_state='q0',
             final_states={'q1'}
         )
+        # GNFA which matches strings beginning with 'a', ending with 'a', and containing
+        # no consecutive 'b's
+        self.gnfa = GNFA(
+            states={'q_in', 'q_f', 'q0', 'q1', 'q2'},
+            input_symbols={'a', 'b'},
+            transitions={
+                'q0': {'q1': 'a', 'q_f': None, 'q2': None, 'q0': None},
+                'q1': {'q1': 'a', 'q2': '', 'q_f': '', 'q0': None},
+                'q2': {'q0': 'b', 'q_f': None, 'q2': None, 'q1': None},
+                'q_in': {'q0': '', 'q_f': None, 'q2': None, 'q1': None}
+            },
+            initial_state='q_in',
+            final_state='q_f'
+        )
 
     def assert_is_copy(self, first, second):
         """Assert that the first FA is a deep copy of the second."""
@@ -49,3 +64,14 @@ class TestFA(unittest.TestCase):
         self.assertEqual(first.initial_state, second.initial_state)
         self.assertIsNot(first.final_states, second.final_states)
         self.assertEqual(first.final_states, second.final_states)
+
+    def assert_is_copy_for_gnfa(self, first, second):
+        """Assert that the first GNFA is a deep copy of the second."""
+        self.assertIsNot(first.states, second.states)
+        self.assertEqual(first.states, second.states)
+        self.assertIsNot(first.input_symbols, second.input_symbols)
+        self.assertEqual(first.input_symbols, second.input_symbols)
+        self.assertIsNot(first.transitions, second.transitions)
+        self.assertEqual(first.transitions, second.transitions)
+        self.assertEqual(first.initial_state, second.initial_state)
+        self.assertEqual(first.final_state, second.final_state)

--- a/tests/test_fa.py
+++ b/tests/test_fa.py
@@ -4,8 +4,8 @@
 import unittest
 
 from automata.fa.dfa import DFA
-from automata.fa.nfa import NFA
 from automata.fa.gnfa import GNFA
+from automata.fa.nfa import NFA
 
 
 class TestFA(unittest.TestCase):

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of GNFAs."""
 import os
-import types
 import tempfile
-from unittest.mock import patch
-
+import types
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa
-from automata.fa.nfa import NFA
 from automata.fa.dfa import DFA
 from automata.fa.gnfa import GNFA
+from automata.fa.nfa import NFA
 
 
 class TestGNFA(test_fa.TestFA):

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -250,7 +250,7 @@ class TestGNFA(test_fa.TestFA):
         and check for equivalence of NFA and previous DFA
         """
 
-        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|aaa*bb(dcc*|(d|c)|abb(dcc*|(d|c)))')
+        nfa = NFA.from_regex('a(aaa*bbcd|abbcd)d*|aa*bb(dcc*|(d|c)b|a?bb(dcc*|(d|c)))ab(c|d)*(ccd)?')
         gnfa = GNFA.from_nfa(nfa)
         regex = gnfa.to_regex()
         nfa = NFA.from_regex(regex)

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -251,7 +251,7 @@ class TestGNFA(test_fa.TestFA):
         and check for equivalence of NFA and previous DFA
         """
 
-        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))*|abb(dcc*|(d|c)))')
+        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|aaa*bb(dcc*|(d|c)|abb(dcc*|(d|c)))')
         gnfa = GNFA.from_nfa(nfa)
         regex = gnfa.to_regex()
         nfa = NFA.from_regex(regex)

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of GNFAs."""
+
+import types
+from unittest.mock import patch
+
+import unittest
+
+import automata.base.exceptions as exceptions
+import tests.test_fa as test_fa
+from automata.fa.nfa import NFA
+from automata.fa.dfa import DFA
+from automata.fa.gnfa import GNFA
+
+
+class TestGNFA(test_fa.TestFA):
+    """A test class for testing generalised nondeterministic finite automata."""
+
+    def test_init_gnfa(self):
+        """Should copy GNFA if passed into NFA constructor."""
+        new_gnfa = GNFA.copy(self.gnfa)
+        self.assert_is_copy_for_gnfa(new_gnfa, self.gnfa)
+
+    def test_init_nfa_missing_formal_params(self):
+        """Should raise an error if formal NFA parameters are missing."""
+        with self.assertRaises(TypeError):
+            GNFA(
+                states={'q0', 'q1'},
+                input_symbols={'0', '1'},
+                initial_state='q0',
+                final_state='q1'
+            )
+
+    def test_copy_gnfa(self):
+        """Should create exact copy of NFA if copy() method is called."""
+        new_gnfa = self.gnfa.copy()
+        self.assert_is_copy_for_gnfa(new_gnfa, self.gnfa)
+
+    def test_init_dfa(self):
+        """Should convert DFA to GNFA if passed into GNFA constructor."""
+        gnfa = GNFA.from_dfa(self.dfa)
+        self.assertEqual(gnfa.states, {0, 1, 'q2', 'q0', 'q1'})
+        self.assertEqual(gnfa.input_symbols, {'0', '1'})
+        self.assertEqual(gnfa.transitions, {
+            'q0': {'q0': '0', 'q1': '1', 1: None, 'q2': None},
+            'q1': {'q0': '0', 'q2': '1', 1: '', 'q1': None},
+            'q2': {'q2': '0', 'q1': '1', 1: None, 'q0': None},
+            0: {'q0': '', 1: None, 'q1': None, 'q2': None}
+        })
+        self.assertEqual(gnfa.initial_state, 0)
+
+    def test_init_nfa(self):
+        """Should convert NFA to GNFA if passed into GNFA constructor."""
+        gnfa = GNFA.from_nfa(self.nfa)
+        self.assertEqual(gnfa.states, {0, 1, 'q0', 'q1'})
+        self.assertEqual(gnfa.input_symbols, {'b', 'a'})
+        self.assertEqual(gnfa.transitions, {
+            'q0': {'q1': 'a', 1: None, 'q0': None},
+            'q1': {'q1': 'a', 'q0': 'b', 1: ''},
+            0: {'q0': '', 1: None, 'q1': None}
+        })
+        self.assertEqual(gnfa.initial_state, 0)
+
+    @patch('automata.fa.gnfa.GNFA.validate')
+    def test_init_validation(self, validate):
+        """Should validate NFA when initialized."""
+        GNFA.copy(self.gnfa)
+        validate.assert_called_once_with()
+
+    def test_gnfa_equal(self):
+        """Should correctly determine if two NFAs are equal."""
+        new_gnfa = self.gnfa.copy()
+        self.assertTrue(self.gnfa == new_gnfa, 'NFAs are not equal')
+
+    def test_nfa_not_equal(self):
+        """Should correctly determine if two NFAs are not equal."""
+        new_gnfa = self.gnfa.copy()
+        new_gnfa.states.add('q2')
+        self.assertTrue(self.nfa != new_gnfa, 'NFAs are equal')
+
+    def test_validate_invalid_symbol(self):
+        """Should raise error if a transition references an invalid symbol."""
+        with self.assertRaises(exceptions.InvalidRegExError):
+            self.gnfa.transitions['q1']['q2'] = {'c'}
+            self.gnfa.validate()
+
+    def test_validate_invalid_state(self):
+        """Should raise error if a transition references an invalid state."""
+        with self.assertRaises(exceptions.InvalidSymbolError):
+            self.nfa.transitions['q1']['q3'] = {'a'}
+            self.nfa.validate()
+
+    def test_validate_invalid_initial_state(self):
+        """Should raise error if the initial state is invalid."""
+        with self.assertRaises(exceptions.InvalidStateError):
+            self.gnfa.initial_state = 'q3'
+            self.gnfa.validate()
+
+    def test_validate_initial_state_transitions(self):
+        """Should raise error if the initial state has no transitions."""
+        with self.assertRaises(exceptions.MissingStateError):
+            del self.gnfa.transitions[self.gnfa.initial_state]
+            self.gnfa.validate()
+
+    def test_validate_invalid_final_state(self):
+        """Should raise error if the final state is invalid."""
+        with self.assertRaises(exceptions.InvalidStateError):
+            self.gnfa.final_state = 'q3'
+            self.gnfa.validate()
+
+    def test_validate_missing_state(self):
+        """Should raise an error if some transitions are missing."""
+        with self.assertRaises(exceptions.MissingStateError):
+            self.gnfa.states.add('q3')
+            self.gnfa.validate()
+
+    def test_to_regex(self):
+        """
+        We generate GNFA from DFA then convert it to regex
+        then generate NFA from regex (already tested method)
+        and check for equivalence of NFA and previous DFA
+        """
+
+        gnfa = GNFA.from_dfa(self.dfa)
+        regex = gnfa.to_regex()
+        nfa = NFA.from_regex(regex)
+        dfa2 = DFA.from_nfa(nfa)
+
+        self.assertEqual(self.dfa, dfa2)

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of GNFAs."""
-
+import os
 import types
+import tempfile
 from unittest.mock import patch
 
 import unittest
@@ -15,6 +16,8 @@ from automata.fa.gnfa import GNFA
 
 class TestGNFA(test_fa.TestFA):
     """A test class for testing generalised nondeterministic finite automata."""
+
+    temp_dir_path = tempfile.gettempdir()
 
     def test_init_gnfa(self):
         """Should copy GNFA if passed into NFA constructor."""
@@ -52,13 +55,13 @@ class TestGNFA(test_fa.TestFA):
     def test_init_nfa(self):
         """Should convert NFA to GNFA if passed into GNFA constructor."""
         gnfa = GNFA.from_nfa(self.nfa)
-        self.assertEqual(gnfa.states, {0, 1, 'q0', 'q1'})
+        self.assertEqual(gnfa.states, {0, 1, 'q0', 'q1', 'q2'})
         self.assertEqual(gnfa.input_symbols, {'b', 'a'})
         self.assertEqual(gnfa.transitions, {
-            'q0': {'q1': 'a', 1: None, 'q0': None},
-            'q1': {'q1': 'a', 'q0': 'b', 1: ''},
-            0: {'q0': '', 1: None, 'q1': None}
-        })
+            0: {1: None, 'q0': '', 'q1': None, 'q2': None},
+            'q0': {1: None, 'q0': None, 'q1': 'a', 'q2': None},
+            'q1': {1: '', 'q0': None, 'q1': 'a', 'q2': ''},
+            'q2': {1: None, 'q0': 'b', 'q1': None, 'q2': None}})
         self.assertEqual(gnfa.initial_state, 0)
 
     @patch('automata.fa.gnfa.GNFA.validate')
@@ -108,11 +111,104 @@ class TestGNFA(test_fa.TestFA):
             self.gnfa.final_state = 'q3'
             self.gnfa.validate()
 
+    def test_validate_final_state_transition(self):
+        """Should raise error if there are transitions from final state"""
+        with self.assertRaises(exceptions.InvalidStateError):
+            self.gnfa.transitions[self.gnfa.final_state] = self.gnfa.transitions[self.gnfa.initial_state]
+            self.gnfa.validate()
+
     def test_validate_missing_state(self):
         """Should raise an error if some transitions are missing."""
         with self.assertRaises(exceptions.MissingStateError):
             self.gnfa.states.add('q3')
             self.gnfa.validate()
+
+    def test_validate_incomplete_transitions(self):
+        """
+        Should raise error if transitions from (except final state)
+        and to (except initial state) every state is missing.
+        """
+        gnfa2 = self.gnfa.copy()
+        gnfa3 = self.gnfa.copy()
+        with self.assertRaises(exceptions.MissingStateError):
+            del self.gnfa.transitions['q1']['q0']
+            self.gnfa.validate()
+
+        with self.assertRaises(exceptions.MissingStateError):
+            del gnfa2.transitions['q_in']['q_f']
+            gnfa2.validate()
+
+        with self.assertRaises(exceptions.InvalidStateError):
+            gnfa3.transitions['q_in']['q5'] = {}
+            gnfa3.validate()
+
+    def test_from_dfa(self):
+        """
+        Check if GNFA is generated properly from DFA
+        """
+
+        dfa = DFA(
+            states={0, 1, 2, 4},
+            input_symbols={'a', 'b'},
+            initial_state=0,
+            final_states={4},
+            transitions={
+                0: {'a': 1, 'b': 2},
+                1: {'a': 2, 'b': 2},
+                2: {'b': 4}
+            },
+            allow_partial=True
+        )
+
+        gnfa = GNFA.from_dfa(dfa)
+
+        gnfa2 = GNFA(
+            states = {0, 1, 2, 3, 4, 5},
+            input_symbols={'a', 'b'},
+            initial_state=3,
+            final_state=5,
+            transitions={
+                0: {1: 'a', 2: 'b', 0: None, 4: None, 5: None},
+                1: {2: 'a|b', 0: None, 1: None, 4: None, 5: None},
+                2: {4: 'b', 0: None, 1: None, 2: None, 5: None},
+                3: {0: '', 1: None, 2: None, 4: None, 5: None},
+                4: {5: '', 0: None, 1: None, 2: None, 4: None}}
+        )
+
+        self.assertEqual(gnfa, gnfa2)
+
+    def test_from_nfa(self):
+        """Should convert NFA to GNFA properly"""
+
+        nfa = NFA(
+            states={0, 1, 2, 4},
+            input_symbols={'a', 'b'},
+            transitions={
+                0: {'a': {1}, 'b': {1}, '': {1}},
+                1: {'a': {1, 2}, '': {2, 4}},
+                2: {'': {0}, 'b': {0, 4}}
+            },
+            initial_state=0,
+            final_states={4}
+        )
+
+        gnfa = GNFA.from_nfa(nfa)
+
+        gnfa2 = GNFA(
+            states = {0, 1, 2, 3, 4, 5},
+            initial_state=3,
+            final_state=5,
+            input_symbols={'a', 'b'},
+            transitions={
+                0: {1: '(a|b)?', 0: None, 2: None, 4: None, 5: None},
+                1: {1: 'a', 2: 'a?', 4: '', 0: None, 5: None},
+                2: {0: 'b?', 4: 'b', 1: None, 2: None, 5: None},
+                4: {5: '', 0: None, 1: None, 2: None, 4: None},
+                3: {0: '', 1: None, 2: None, 4: None, 5: None}
+            }
+        )
+
+        self.assertEqual(gnfa, gnfa2)
 
     def test_to_regex(self):
         """
@@ -121,9 +217,90 @@ class TestGNFA(test_fa.TestFA):
         and check for equivalence of NFA and previous DFA
         """
 
-        gnfa = GNFA.from_dfa(self.dfa)
+        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))|abb(dcc*|(d|c)))')
+        gnfa = GNFA.from_nfa(nfa)
         regex = gnfa.to_regex()
         nfa = NFA.from_regex(regex)
         dfa2 = DFA.from_nfa(nfa)
 
-        self.assertEqual(self.dfa, dfa2)
+        dfa = DFA.from_nfa(nfa)
+
+        self.assertEqual(dfa, dfa2)
+
+    def test_show_diagram_showNone(self):
+        """
+        Should construct the diagram for a GNFA when show_None = False
+        """
+
+        gnfa = self.gnfa
+
+        graph = gnfa.show_diagram(show_None=False)
+        self.assertEqual(
+            {node.get_name() for node in graph.get_nodes()},
+            gnfa.states)
+        self.assertEqual(graph.get_node(gnfa.initial_state)[0].get_style(), 'filled')
+        self.assertEqual(graph.get_node(gnfa.final_state)[0].get_peripheries(), 2)
+        self.assertEqual(graph.get_node('q2')[0].get_peripheries(), None)
+        self.assertEqual(
+            {(edge.get_source(), edge.get_label(), edge.get_destination())
+             for edge in graph.get_edges()},
+            {
+                ('q0', 'a', 'q1'),
+                ('q1', 'a', 'q1'),
+                ('q1', '', 'q2'),
+                ('q1', '', 'q_f'),
+                ('q2', 'b', 'q0'),
+                ('q_in', '', 'q0')
+            })
+
+    def test_show_diagram_showNone(self):
+        """
+        Should construct the diagram for a GNFA when show_None = False
+        """
+
+        gnfa = self.gnfa
+
+        graph = gnfa.show_diagram()
+        self.assertEqual(
+            {node.get_name() for node in graph.get_nodes()},
+            gnfa.states)
+        self.assertEqual(graph.get_node(gnfa.initial_state)[0].get_style(), 'filled')
+        self.assertEqual(graph.get_node(gnfa.final_state)[0].get_peripheries(), 2)
+        self.assertEqual(graph.get_node('q2')[0].get_peripheries(), None)
+        self.assertEqual(
+            {(edge.get_source(), edge.get_label(), edge.get_destination())
+             for edge in graph.get_edges()},
+            {
+                ('q_in', '', 'q0'),
+                ('q0', 'ø', 'q2'),
+                ('q1', '', 'q2'),
+                ('q0', 'ø', 'q_f'),
+                ('q1', '', 'q_f'),
+                ('q_in', 'ø', 'q2'),
+                ('q_in', 'ø', 'q1'),
+                ('q1', 'a', 'q1'),
+                ('q2', 'b', 'q0'),
+                ('q2', 'ø', 'q2'),
+                ('q_in', 'ø', 'q_f'),
+                ('q2', 'ø', 'q1'),
+                ('q0', 'ø', 'q0'),
+                ('q2', 'ø', 'q_f'),
+                ('q0', 'a', 'q1'),
+                ('q1', 'ø', 'q0')
+            })
+
+    def test_show_diagram_write_file(self):
+        """
+        Should construct the diagram for a NFA
+        and write it to the specified file.
+        """
+        diagram_path = os.path.join(self.temp_dir_path, 'test_gnfa.png')
+        try:
+            os.remove(diagram_path)
+        except OSError:
+            pass
+        self.assertFalse(os.path.exists(diagram_path))
+        self.gnfa.show_diagram(path=diagram_path)
+        self.assertTrue(os.path.exists(diagram_path))
+        os.remove(diagram_path)
+

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -83,7 +83,7 @@ class TestGNFA(test_fa.TestFA):
 
     def test_validate_invalid_symbol(self):
         """Should raise error if a transition references an invalid symbol."""
-        with self.assertRaises(exceptions.InvalidRegExError):
+        with self.assertRaises(exceptions.InvalidRegexError):
             self.gnfa.transitions['q1']['q2'] = {'c'}
             self.gnfa.validate()
 

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -161,7 +161,6 @@ class TestGNFA(test_fa.TestFA):
         )
 
         gnfa = GNFA.from_dfa(dfa)
-
         gnfa2 = GNFA(
             states = {0, 1, 2, 3, 4, 5},
             input_symbols={'a', 'b'},
@@ -173,6 +172,41 @@ class TestGNFA(test_fa.TestFA):
                 2: {4: 'b', 0: None, 1: None, 2: None, 5: None},
                 3: {0: '', 1: None, 2: None, 4: None, 5: None},
                 4: {5: '', 0: None, 1: None, 2: None, 4: None}}
+        )
+
+        self.assertEqual(gnfa, gnfa2)
+
+    def test_from_dfa_single_state(self):
+        nfa = NFA.from_regex('')
+        dfa = DFA.from_nfa(nfa)
+        gnfa = GNFA.from_nfa(dfa)
+
+        gnfa2 = GNFA(
+            states={0, 1, '{0}'},
+            input_symbols=set(),
+            initial_state=0,
+            final_state=1,
+            transitions={
+                '{0}': {1: '', '{0}': None},
+                0: {'{0}': '', 1: None}
+            }
+        )
+
+        self.assertEqual(gnfa, gnfa2)
+
+    def test_from_nfa_single_state(self):
+        nfa = NFA.from_regex('')
+        gnfa = GNFA.from_nfa(nfa)
+
+        gnfa2 = GNFA(
+            states={0, 1, 2},
+            input_symbols=set(),
+            initial_state=1,
+            final_state=2,
+            transitions={
+                0: {2: '', 0: None},
+                1: {0: '', 2: None}
+            }
         )
 
         self.assertEqual(gnfa, gnfa2)
@@ -217,7 +251,7 @@ class TestGNFA(test_fa.TestFA):
         and check for equivalence of NFA and previous DFA
         """
 
-        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))|abb(dcc*|(d|c)))')
+        nfa = NFA.from_regex('(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))*|abb(dcc*|(d|c)))')
         gnfa = GNFA.from_nfa(nfa)
         regex = gnfa.to_regex()
         nfa = NFA.from_regex(regex)
@@ -253,9 +287,9 @@ class TestGNFA(test_fa.TestFA):
                 ('q_in', '', 'q0')
             })
 
-    def test_show_diagram_showNone(self):
+    def test_show_diagram(self):
         """
-        Should construct the diagram for a GNFA when show_None = False
+        Should construct the diagram for a GNFA when show_None = True
         """
 
         gnfa = self.gnfa

--- a/tests/test_mntm.py
+++ b/tests/test_mntm.py
@@ -4,9 +4,8 @@
 import math
 import random
 import types
-from unittest.mock import patch
-
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import automata.tm.exceptions as tm_exceptions

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -304,6 +304,9 @@ class TestNFA(test_fa.TestFA):
 
         self.assertEqual(dfa1, dfa2)
 
+    def test_from_regex_empty_string(self):
+        nfa = NFA.from_regex('')
+
     def test_eliminate_lambda(self):
         nfa1 = NFA(
             states={0, 1, 2, 3, 4, 5, 6},
@@ -462,6 +465,6 @@ class TestNFA(test_fa.TestFA):
         except OSError:
             pass
         self.assertFalse(os.path.exists(diagram_path))
-        self.dfa.show_diagram(path=diagram_path)
+        self.nfa.show_diagram(path=diagram_path)
         self.assertTrue(os.path.exists(diagram_path))
         os.remove(diagram_path)

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -315,7 +315,6 @@ class TestNFA(test_fa.TestFA):
             final_states={3, 6}
         )
         nfa1.eliminate_lambda()
-        print(nfa1.transitions)
         nfa2 = NFA(
             states={0, 1, 2, 3, 5},
             initial_state=0,

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of NFAs."""
-
+import os
+import tempfile
 import types
 from unittest.mock import patch
 
@@ -14,6 +15,8 @@ from automata.fa.dfa import DFA
 
 class TestNFA(test_fa.TestFA):
     """A test class for testing nondeterministic finite automata."""
+
+    temp_dir_path = tempfile.gettempdir()
 
     def test_init_nfa(self):
         """Should copy NFA if passed into NFA constructor."""
@@ -369,6 +372,24 @@ class TestNFA(test_fa.TestFA):
         dfa2 = DFA.from_nfa(nfa4)
 
         self.assertEqual(dfa1, dfa2)
+        # second check
+        nfa5 = nfa1 | nfa2
+        dfa3 = DFA.from_nfa(nfa5)
+
+        self.assertEqual(dfa3, dfa2)
+
+        # third check: union of NFA which is subset of other
+        nfa6 = NFA.from_regex('aa*')
+        nfa7 = NFA.from_regex('a*')
+        nfa8 = nfa6.union(nfa7)
+        nfa9 = nfa7.union(nfa6)
+        self.assertEqual(nfa8, nfa7)
+        self.assertEqual(nfa9, nfa7)
+
+        # raise error if other is not NFA
+        self.assertRaises(NotImplementedError, self.nfa.union, self.dfa)
+        with self.assertRaises(NotImplementedError):
+            check = self.nfa | self.dfa
 
     def test_validate_regex(self):
         """Should raise an error if invalid regex is passed into NFA.to_regex()"""
@@ -377,3 +398,70 @@ class TestNFA(test_fa.TestFA):
         self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '?')
         self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a|b|*')
         self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a||b')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '((abc*)))((abd)')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '*')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'abcd()')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'ab(bc)*((bbcd)')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a(*)')
+        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'ab(|)')
+
+    def test_from_symbol(self):
+        """Should generate NFA from single transition symbol"""
+
+        nfa1 = NFA._from_symbol('a')
+
+        nfa2 = NFA(
+            states={0, 1},
+            input_symbols={'a'},
+            initial_state=0,
+            transitions={0: {'a': {1}}},
+            final_states={1}
+        )
+
+        self.assertEqual(nfa1.states, nfa2.states)
+        self.assertEqual(nfa1.initial_state, nfa2.initial_state)
+        self.assertEqual(nfa1.transitions, nfa2.transitions)
+        self.assertEqual(nfa1.final_states, nfa2.final_states)
+        self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
+
+    def test_show_diagram_initial_final_same(self):
+        """
+        Should construct the diagram for a NFA whose initial state
+        is also a final state.
+        """
+
+        nfa = self.nfa
+
+        nfa.final_states.add('q0')
+        graph = nfa.show_diagram()
+        self.assertEqual(
+            {node.get_name() for node in graph.get_nodes()},
+            {'q0', 'q1', 'q2'})
+        self.assertEqual(graph.get_node('q0')[0].get_style(), 'filled')
+        self.assertEqual(graph.get_node('q0')[0].get_peripheries(), 2)
+        self.assertEqual(graph.get_node('q1')[0].get_peripheries(), 2)
+        self.assertEqual(graph.get_node('q2')[0].get_peripheries(), None)
+        self.assertEqual(
+            {(edge.get_source(), edge.get_label(), edge.get_destination())
+             for edge in graph.get_edges()},
+            {
+                ('q0', 'a', 'q1'),
+                ('q1', 'a', 'q1'),
+                ('q1', '', 'q2'),
+                ('q2', 'b', 'q0')
+            })
+
+    def test_show_diagram_write_file(self):
+        """
+        Should construct the diagram for a NFA
+        and write it to the specified file.
+        """
+        diagram_path = os.path.join(self.temp_dir_path, 'test_dfa.png')
+        try:
+            os.remove(diagram_path)
+        except OSError:
+            pass
+        self.assertFalse(os.path.exists(diagram_path))
+        self.dfa.show_diagram(path=diagram_path)
+        self.assertTrue(os.path.exists(diagram_path))
+        os.remove(diagram_path)

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -3,14 +3,13 @@
 import os
 import tempfile
 import types
-from unittest.mock import patch
-
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa
-from automata.fa.nfa import NFA
 from automata.fa.dfa import DFA
+from automata.fa.nfa import NFA
 
 
 class TestNFA(test_fa.TestFA):

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -397,16 +397,16 @@ class TestNFA(test_fa.TestFA):
     def test_validate_regex(self):
         """Should raise an error if invalid regex is passed into NFA.to_regex()"""
 
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'ab|')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '?')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a|b|*')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a||b')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '((abc*)))((abd)')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, '*')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'abcd()')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'ab(bc)*((bbcd)')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'a(*)')
-        self.assertRaises(exceptions.InvalidRegExError, NFA.from_regex, 'ab(|)')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'ab|')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, '?')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'a|b|*')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'a||b')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, '((abc*)))((abd)')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, '*')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'abcd()')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'ab(bc)*((bbcd)')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'a(*)')
+        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'ab(|)')
 
     def test_from_symbol(self):
         """Should generate NFA from single transition symbol"""

--- a/tests/test_ntm.py
+++ b/tests/test_ntm.py
@@ -2,9 +2,8 @@
 """Classes and functions for testing the behavior of NTMs."""
 
 import types
-from unittest.mock import patch
-
 import unittest
+from unittest.mock import patch
 
 import automata.base.exceptions as exceptions
 import automata.tm.exceptions as tm_exceptions

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -10,7 +10,11 @@ import automata.base.exceptions as exceptions
 class TestRegex(unittest.TestCase):
     """A test class for testing regular expression tools"""
 
-    def test_validate(self):
+    def test_validate_valid(self):
+        """Should pass validation for valid regular expression"""
+        self.assertEqual(re.validate('a*'), True)
+
+    def test_validate_invalid(self):
         """Should raise error for invalid regular expressions"""
         self.assertRaises(exceptions.InvalidRegexError, re.validate, 'ab|')
         self.assertRaises(exceptions.InvalidRegexError, re.validate, '?')

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classes and functions for testing the behavior of RegEx tools"""
+"""Classes and functions for testing the behavior of Regex tools"""
 
 import unittest
 
@@ -7,21 +7,21 @@ import automata.base.regex as re
 import automata.base.exceptions as exceptions
 
 
-class TestRegEx(unittest.TestCase):
+class TestRegex(unittest.TestCase):
     """A test class for testing regular expression tools"""
 
     def test_validate(self):
         """Should raise error for invalid regular expressions"""
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'ab|')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, '?')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a|b|*')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a||b')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, '((abc*)))((abd)')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, '*')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'abcd()')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'ab(bc)*((bbcd)')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a(*)')
-        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a(|)')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'ab|')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, '?')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'a|b|*')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'a||b')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, '((abc*)))((abd)')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, '*')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'abcd()')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'ab(bc)*((bbcd)')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'a(*)')
+        self.assertRaises(exceptions.InvalidRegexError, re.validate, 'a(|)')
 
     def test_isequal(self):
         """Should correctly check equivalence of two regular expressions"""

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -3,8 +3,8 @@
 
 import unittest
 
-import automata.base.regex as re
 import automata.base.exceptions as exceptions
+import automata.base.regex as re
 
 
 class TestRegex(unittest.TestCase):

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Classes and functions for testing the behavior of RegEx tools"""
+
+import unittest
+
+import automata.base.regex as re
+import automata.base.exceptions as exceptions
+
+
+class TestRegEx(unittest.TestCase):
+    """A test class for testing regular expression tools"""
+
+    def test_validate(self):
+        """Should raise error for invalid regular expressions"""
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'ab|')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, '?')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a|b|*')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a||b')
+
+    def test_isequal(self):
+        """Should correctly check equivalence of two regular expressions"""
+
+        self.assertTrue(re.isequal('aa?', 'a|aa'))
+        self.assertTrue(re.isequal('a(a*b|b)', 'aaa*b|ab'))
+        self.assertTrue(re.isequal('a(a*b|b)b(cd*|dc*)', '(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))|abb(dcc*|(d|c)))'))
+        self.assertTrue(re.isequal('(aaa*bbcd|abbcd)d*|(aaa*bb(dcc*|(d|c))|abb(dcc*|(d|c)))',
+                                   '((aaaa*bbcd|aabbcd)d|abbcdd)d*|((aaaa*bb|aabb)dccc*|'
+                                   '((aaaa*bbcd|aabbcd)|((aaaa*bb|aabb)(dc|(c|d))|(abbdccc*|(abb(dc|(c|d))|abbcd)))))'))
+
+        self.assertFalse(re.isequal('baaa*b(b|a)|(bab(b|a)|(bb|ba))',
+                                    'baaaa*b(a|b)|(baab(a|b)|bab(bb|(a|(b|ba))))'))
+
+    def test_issubset(self):
+        """Should correctly verify if re1 is subset of re2"""
+
+        self.assertTrue(re.issubset('aa?', 'a*'))
+        self.assertFalse(re.issubset('a*', 'a?'))
+        self.assertTrue(re.issubset('aaa*b|bc', 'a*b|b*c*'))
+
+    def test_issuperset(self):
+        """Should correctly verify if re1 is superset of re2"""
+
+        self.assertFalse(re.issuperset('aa?', 'a*'))
+        self.assertTrue(re.issuperset('a*', 'a?'))
+        self.assertTrue(re.issuperset('a*b|b*c*', 'aaa*b|bc'))
+
+
+

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -16,6 +16,12 @@ class TestRegEx(unittest.TestCase):
         self.assertRaises(exceptions.InvalidRegExError, re.validate, '?')
         self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a|b|*')
         self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a||b')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, '((abc*)))((abd)')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, '*')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'abcd()')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'ab(bc)*((bbcd)')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a(*)')
+        self.assertRaises(exceptions.InvalidRegExError, re.validate, 'a(|)')
 
     def test_isequal(self):
         """Should correctly check equivalence of two regular expressions"""

--- a/tests/test_tm.py
+++ b/tests/test_tm.py
@@ -5,8 +5,8 @@ import unittest
 
 import automata.base.exceptions as exceptions
 from automata.tm.dtm import DTM
-from automata.tm.ntm import NTM
 from automata.tm.mntm import MNTM
+from automata.tm.ntm import NTM
 
 
 class TestTM(unittest.TestCase):

--- a/tests/test_tmtools.py
+++ b/tests/test_tmtools.py
@@ -3,9 +3,8 @@
 
 import contextlib
 import io
-from unittest.mock import call, patch
-
 import unittest
+from unittest.mock import call, patch
 
 import automata.tm.tools as tmtools
 import tests.test_tm as test_tm


### PR DESCRIPTION
Thanks for this nice library. 

So basically, I have worked on converting an NFA/DFA to regular expression and also backward, regular expression to NFA conversion. All other changes were done to help this task, test it, and remove existing errors.

1. New class added: GNFA - Generalised Nondetermistic Finite automaton. (as `automata/fa/gnfa.py`). I have added a description of GNFA in `README.me` explaining its characteristics.
- `GNFA.from_nfa(cls, nfa)`
- `GNFA.from_dfa(cls, dfa)`
- `GNFA.to_regex(self)` #13 
- `GNFA.show_diagram(self, path=None, show_None = True`
All other functions were defined as helper functions or for initializing the class. Check `README.me` for all additions.

2. Additions /Changes to NFA (`automata/fa/nfa.py`)
- `NFA.from_regex(cls, regex)` #13 
- `NFA.eliminate_lambda(self)` #31 
- `NFA.kleene_star(self)` Debugged and changed it according to #45 
- `NFA.union(self, other)`
- `NFA.show_diagram(self, path=None)`
- `NFA.option(self)` for `?` but can't read `''` because of the way this empty symbol is defined here. Nevertheless, this can help in building other NFAs (as helped in regex to NFA conversion)

3. Regular expressions (`automata/base/regex.py`): Just a set of methods for dealing with regular expressions. I have explained the syntax for a regular expression in `README.me`
- `automata.base.regex.validate(regex)`
- `automata.base.regex,issequal(re1, re2)`
- `automata.base.regex.issubset(re1, re2)`
- `automata.base.regex.issuperset(re1, re2)`