### PR TITLE
Remove concat token from parser and fix old comment

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -291,19 +291,19 @@ class DFA(fa.FA):
             for symbol, end_state in path.items():
                 transition_back_map[symbol][end_state].append(start_state)
 
+        origin_dicts = tuple(transition_back_map.values())
         processing = {final_states_id}
 
         while processing:
             # Save a copy of the set, since it could get modified while executing
-            active_state = frozenset(eq_classes.get_set_by_id(processing.pop()))
-            for active_letter in self.input_symbols:
-                origin_dict = transition_back_map[active_letter]
-                states_that_move_into_active_state_chain = chain.from_iterable(
+            active_state = tuple(eq_classes.get_set_by_id(processing.pop()))
+            for origin_dict in origin_dicts:
+                states_that_move_into_active_state = chain.from_iterable(
                     origin_dict[end_state] for end_state in active_state
                 )
 
-                # Using a tuple because we don't need to make a deep copy
-                new_eq_class_pairs = eq_classes.refine(states_that_move_into_active_state_chain)
+                # Refine set partition by states moving into current active one
+                new_eq_class_pairs = eq_classes.refine(states_that_move_into_active_state)
 
                 for (YintX_id, YdiffX_id) in new_eq_class_pairs:
                     # Only adding one id to processing, since the other is already there

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -202,7 +202,6 @@ def get_regex_lexer():
     lexer.register_token(RightParen, r'\)')
     lexer.register_token(StringToken, r'[A-Za-z0-9]')
     lexer.register_token(UnionToken, r'\|')
-    lexer.register_token(ConcatToken, r'\.')
     lexer.register_token(KleeneToken, r'\*')
     lexer.register_token(OptionToken, r'\?')
 


### PR DESCRIPTION
@caleb531 Replaces an out-of-date comment and removes the concat token from the regex parser (since the concatenation operator is implicit and not part of the syntax in the documentation).