### PR TITLE
Optimize reachable states algorithms

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -471,18 +471,24 @@ class DFA(fa.FA):
         if self.input_symbols != other.input_symbols:
             raise exceptions.SymbolMismatchError('The input symbols between the two given DFAs do not match')
 
-        # Generate product graph corresponding to component DFAs
-        product_graph = nx.DiGraph([
-            ((start_state_a, start_state_b), (transitions_a[symbol], transitions_b[symbol]))
-            for (start_state_a, transitions_a), (start_state_b, transitions_b), symbol in
-            product(self.transitions.items(), other.transitions.items(), self.input_symbols)
-        ])
+        visited_set = set()
+        queue = deque()
 
         product_initial_state = (self.initial_state, other.initial_state)
-        reachable_states = nx.descendants(product_graph, product_initial_state)
-        reachable_states.add(product_initial_state)
+        queue.append(product_initial_state)
+        visited_set.add(product_initial_state)
 
-        return reachable_states
+        while queue:
+            q_a, q_b = queue.popleft()
+
+            for chr in self.input_symbols:
+                product_state = (self.transitions[q_a][chr], other.transitions[q_b][chr])
+
+                if product_state not in visited_set:
+                    visited_set.add(product_state)
+                    queue.append(product_state)
+
+        return visited_set
 
     def issubset(self, other):
         """Return True if this DFA is a subset of another DFA."""

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -258,7 +258,7 @@ class DFA(fa.FA):
         while queue:
             state = queue.popleft()
 
-            for next_state in self.transitions[state]:
+            for next_state in self.transitions[state].values():
                 if next_state not in visited_set:
                     visited_set.add(next_state)
                     queue.append(next_state)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -258,9 +258,7 @@ class DFA(fa.FA):
         while queue:
             state = queue.popleft()
 
-            for chr in self.input_symbols:
-                next_state = self.transitions[state][chr]
-
+            for next_state in self.transitions[state]:
                 if next_state not in visited_set:
                     visited_set.add(next_state)
                     queue.append(next_state)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -249,8 +249,23 @@ class DFA(fa.FA):
 
     def _compute_reachable_states(self):
         """Compute the states which are reachable from the initial state."""
-        G = self._get_digraph()
-        return nx.descendants(G, self.initial_state) | {self.initial_state}
+        visited_set = set()
+        queue = deque()
+
+        queue.append(self.initial_state)
+        visited_set.add(self.initial_state)
+
+        while queue:
+            state = queue.popleft()
+
+            for chr in self.input_symbols:
+                next_state = self.transitions[state][chr]
+
+                if next_state not in visited_set:
+                    visited_set.add(next_state)
+                    queue.append(next_state)
+
+        return visited_set
 
     def minify(self, retain_names=False):
         """

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -6,12 +6,12 @@ from enum import IntEnum
 from itertools import chain, count, product
 
 import networkx as nx
-from frozendict import frozendict
-from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
 from automata.base.utils import PartitionRefinement
+from frozendict import frozendict
+from pydot import Dot, Edge, Node
 
 
 class OriginEnum(IntEnum):

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -3,13 +3,12 @@
 
 from itertools import product
 
-from frozendict import frozendict
-from pydot import Dot, Edge, Node
-
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
 import automata.fa.nfa as nfa
 import automata.regex.regex as re
+from frozendict import frozendict
+from pydot import Dot, Edge, Node
 
 
 class GNFA(nfa.NFA):

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -2,6 +2,7 @@
 """Classes and methods for working with nondeterministic finite automata."""
 
 from collections import deque
+from itertools import chain
 
 import networkx as nx
 
@@ -202,26 +203,15 @@ class NFA(fa.FA):
 
         while queue:
             state = queue.popleft()
+            state_dict = transitions.get(state)
 
-            for chr in input_symbols:
-                for next_state in transitions[state][chr]:
-
+            if state_dict:
+                for next_state in chain.from_iterable(dest for dest in state_dict.values()):
                     if next_state not in visited_set:
                         visited_set.add(next_state)
                         queue.append(next_state)
 
         return visited_set
-
-
-        graph = nx.DiGraph([
-            (start_state, end_state)
-            for start_state, transition in transitions.items()
-            for end_states in transition.values()
-            for end_state in end_states
-        ])
-        graph.add_nodes_from(states)
-
-        return nx.descendants(graph, initial_state) | {initial_state}
 
     def eliminate_lambda(self):
         """Removes epsilon transitions from the NFA which recognizes the same language."""

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Classes and methods for working with nondeterministic finite automata."""
 
-import networkx as nx
-from frozendict import frozendict
-from pydot import Dot, Edge, Node
 from collections import deque
+
+import networkx as nx
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
 from automata.regex.parser import parse_regex
+from frozendict import frozendict
+from pydot import Dot, Edge, Node
 
 
 class NFA(fa.FA):


### PR DESCRIPTION
@caleb531 turns out it's faster in some cases to do BFS directly instead of reading all states of a product graph into a data structure (since this effectively makes two passes through the data instead of 1). Networkx implements the same algorithm anyway in pure Python. Saw 10x speedup in some cases.