### PR TITLE
Refactor DFA.minify()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automata
 
-*Copyright 2016-2022 Caleb Evans*  
+*Copyright 2016-2022 Caleb Evans*
 *Released under the MIT license*
 
 [![tests](https://github.com/caleb531/automata/actions/workflows/tests.yml/badge.svg)](https://github.com/caleb531/automata/actions/workflows/tests.yml)
@@ -223,49 +223,55 @@ minimal_dfa = dfa.minify()
 minimal_dfa_with_old_names = dfa.minify(retain_names=True)
 ```
 
-#### DFA.complement(self)
+#### DFA.complement(self, retain_names=False, minify=True)
+
 Creates a DFA which accepts an input if and only if the old one does not.
+Minifies by default. Unreachable states are always removed.
 
 ```python
-complement_dfa = ~dfa
+minimal_complement_dfa = ~dfa
+complement_dfa = dfa.complement(minify=False)
 ```
 
-#### DFA.union(self, other, minify=True)
+#### DFA.union(self, other, retain_names=False, minify=True)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the union of A and B. Minifies by default.
+Unreachable states are always removed.
 
 ```python
 minimal_union_dfa = dfa | other_dfa
 union_dfa = dfa.union(other_dfa, minify=False)
 ```
 
-#### DFA.intersection(self, other, minify=True)
+#### DFA.intersection(self, other, retain_names=False, minify=True)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the intersection of A and B. Minifies by default.
+Unreachable states are always removed.
 
 ```python
 minimal_intersection_dfa = dfa & other_dfa
 intersection_dfa = dfa.intersection(other_dfa, minify=False)
 ```
 
-#### DFA.difference(self, other, minify=True)
+#### DFA.difference(self, other, retain_names=False, minify=True)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the set difference of A and B, often
 denoted A \ B or A - B. Minifies by default.
+Unreachable states are always removed.
 
 ```python
 minimal_difference_dfa = dfa - other_dfa
 difference_dfa = dfa.difference(other_dfa, minify=False)
 ```
 
-#### DFA.symmetric_difference(self, other, minify=True)
+#### DFA.symmetric_difference(self, other, retain_names=False, minify=True)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the symmetric difference of A and B.
-Minifies by default.
+Minifies by default. Unreachable states are always removed.
 
 ```python
 minimal_symmetric_difference_dfa = dfa ^ other_dfa
@@ -317,10 +323,10 @@ Returns `True` if the DFA accepts a finite language, False otherwise.
 dfa.isfinite()
 ```
 
-#### DFA.from_nfa(cls, nfa, retain_names=False)
+#### DFA.from_nfa(cls, nfa, retain_names=False, minify=True)
 
 Creates a DFA that is equivalent to the given NFA. States are renamed by
-default unless `retain_names` is set to `True`.
+default unless `retain_names` is set to `True`. Minifies by default.
 
 ```python
 from automata.fa.dfa import DFA

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -723,8 +723,8 @@ class DFA(fa.FA):
 
             # Enqueue the next set of current states for the generated DFA.
             for input_symbol in target_nfa.input_symbols:
-                next_current_states = frozenset(target_nfa._get_next_current_states(
-                    current_states, input_symbol))
+                next_current_states = target_nfa._get_next_current_states(
+                    current_states, input_symbol)
                 dfa_transitions[current_state_name][input_symbol] = get_name(next_current_states)
                 state_queue.append(next_current_states)
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -2,7 +2,7 @@
 """Classes and methods for working with deterministic finite automata."""
 
 from collections import deque
-from itertools import chain, count, product
+from itertools import chain, count
 
 import networkx as nx
 from pydot import Dot, Edge, Node
@@ -273,7 +273,8 @@ class DFA(fa.FA):
             retain_names=retain_names)
 
     @classmethod
-    def _minify(cls, *, reachable_states, input_symbols, transitions, initial_state, reachable_final_states, retain_names):
+    def _minify(cls, *, reachable_states, input_symbols, transitions, initial_state,
+                reachable_final_states, retain_names):
         """Minify helper function. DFA data passed in must have no unreachable states."""
 
         # First, assemble backmap and equivalence class data structure
@@ -404,7 +405,6 @@ class DFA(fa.FA):
             initial_state=new_initial_state,
             final_states=set(filter(union_fn, new_states))
         )
-
 
     def intersection(self, other, *, retain_names=False, minify=True):
         """

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -349,15 +349,14 @@ class DFA(fa.FA):
         if self.input_symbols != other.input_symbols:
             raise exceptions.SymbolMismatchError('The input symbols between the two given DFAs do not match')
 
-        new_states = set(product(self.states, other.states))
+        new_states = self._get_reachable_states_product_graph(other)
 
         new_transitions = {
             (state_a, state_b): {
-                symbol: (transitions_a[symbol], transitions_b[symbol])
+                symbol: (self.transitions[state_a][symbol], other.transitions[state_b][symbol])
                 for symbol in self.input_symbols
             }
-            for (state_a, transitions_a), (state_b, transitions_b) in
-            product(self.transitions.items(), other.transitions.items())
+            for (state_a, state_b) in new_states
         }
 
         new_initial_state = (self.initial_state, other.initial_state)
@@ -367,7 +366,7 @@ class DFA(fa.FA):
             input_symbols=self.input_symbols,
             transitions=new_transitions,
             initial_state=new_initial_state,
-            final_states=final_states
+            final_states=final_states & new_states
         )
 
     def union(self, other, *, retain_names=False, minify=True):

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -341,7 +341,7 @@ class DFA(fa.FA):
             final_states=new_final_states,
         )
 
-    def _cross_product(self, other, final_state_fn):
+    def _cross_product(self, other):
         """
         Creates a new DFA which is the cross product of DFAs self and other
         with an empty set of final states.
@@ -361,13 +361,7 @@ class DFA(fa.FA):
 
         new_initial_state = (self.initial_state, other.initial_state)
 
-        return self.__class__(
-            states=new_states,
-            input_symbols=self.input_symbols,
-            transitions=new_transitions,
-            initial_state=new_initial_state,
-            final_states=set(filter(final_state_fn, new_states))
-        )
+        return new_states, new_transitions, new_initial_state
 
     def union(self, other, *, retain_names=False, minify=True):
         """
@@ -380,7 +374,15 @@ class DFA(fa.FA):
             state_a, state_b = state
             return state_a in self.final_states or state_b in other.final_states
 
-        new_dfa = self._cross_product(other, union_fn)
+        new_states, new_transitions, new_initial_state = self._cross_product(other)
+
+        return self.__class__(
+            states=new_states,
+            input_symbols=self.input_symbols,
+            transitions=new_transitions,
+            initial_state=new_initial_state,
+            final_states=set(filter(union_fn, new_states))
+        )
 
         if minify:
             return new_dfa.minify(retain_names=retain_names)
@@ -397,7 +399,15 @@ class DFA(fa.FA):
             state_a, state_b = state
             return state_a in self.final_states and state_b in other.final_states
 
-        new_dfa = self._cross_product(other, intersection_fn)
+        new_states, new_transitions, new_initial_state = self._cross_product(other)
+
+        return self.__class__(
+            states=new_states,
+            input_symbols=self.input_symbols,
+            transitions=new_transitions,
+            initial_state=new_initial_state,
+            final_states=set(filter(intersection_fn, new_states))
+        )
 
         if minify:
             return new_dfa.minify(retain_names=retain_names)
@@ -413,7 +423,15 @@ class DFA(fa.FA):
             state_a, state_b = state
             return state_a in self.final_states and state_b not in other.final_states
 
-        new_dfa = self._cross_product(other, difference_fn)
+        new_states, new_transitions, new_initial_state = self._cross_product(other)
+
+        return self.__class__(
+            states=new_states,
+            input_symbols=self.input_symbols,
+            transitions=new_transitions,
+            initial_state=new_initial_state,
+            final_states=set(filter(difference_fn, new_states))
+        )
 
         if minify:
             return new_dfa.minify(retain_names=retain_names)
@@ -429,7 +447,15 @@ class DFA(fa.FA):
             state_a, state_b = state
             return (state_a in self.final_states) ^ (state_b in other.final_states)
 
-        new_dfa = self._cross_product(other, symmetric_difference_fn)
+        new_states, new_transitions, new_initial_state = self._cross_product(other)
+
+        return self.__class__(
+            states=new_states,
+            input_symbols=self.input_symbols,
+            transitions=new_transitions,
+            initial_state=new_initial_state,
+            final_states=set(filter(symmetric_difference_fn, new_states))
+        )
 
         if minify:
             return new_dfa.minify(retain_names=retain_names)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -5,11 +5,11 @@ from collections import deque
 from itertools import chain, count
 
 import networkx as nx
-from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
 from automata.base.utils import PartitionRefinement
+from pydot import Dot, Edge, Node
 
 
 class DFA(fa.FA):

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -388,6 +388,15 @@ class DFA(fa.FA):
 
         new_states, new_transitions, new_initial_state = self._cross_product(other)
 
+        if minify:
+            return self._minify(
+                reachable_states=new_states,
+                input_symbols=self.input_symbols,
+                transitions=new_transitions,
+                initial_state=new_initial_state,
+                reachable_final_states=set(filter(union_fn, new_states)),
+                retain_names=retain_names)
+
         return self.__class__(
             states=new_states,
             input_symbols=self.input_symbols,
@@ -396,10 +405,6 @@ class DFA(fa.FA):
             final_states=set(filter(union_fn, new_states))
         )
 
-        if minify:
-            return new_dfa.minify(retain_names=retain_names)
-
-        return new_dfa
 
     def intersection(self, other, *, retain_names=False, minify=True):
         """
@@ -413,6 +418,15 @@ class DFA(fa.FA):
 
         new_states, new_transitions, new_initial_state = self._cross_product(other)
 
+        if minify:
+            return self._minify(
+                reachable_states=new_states,
+                input_symbols=self.input_symbols,
+                transitions=new_transitions,
+                initial_state=new_initial_state,
+                reachable_final_states=set(filter(intersection_fn, new_states)),
+                retain_names=retain_names)
+
         return self.__class__(
             states=new_states,
             input_symbols=self.input_symbols,
@@ -420,10 +434,6 @@ class DFA(fa.FA):
             initial_state=new_initial_state,
             final_states=set(filter(intersection_fn, new_states))
         )
-
-        if minify:
-            return new_dfa.minify(retain_names=retain_names)
-        return new_dfa
 
     def difference(self, other, *, retain_names=False, minify=True):
         """
@@ -437,6 +447,15 @@ class DFA(fa.FA):
 
         new_states, new_transitions, new_initial_state = self._cross_product(other)
 
+        if minify:
+            return self._minify(
+                reachable_states=new_states,
+                input_symbols=self.input_symbols,
+                transitions=new_transitions,
+                initial_state=new_initial_state,
+                reachable_final_states=set(filter(difference_fn, new_states)),
+                retain_names=retain_names)
+
         return self.__class__(
             states=new_states,
             input_symbols=self.input_symbols,
@@ -444,10 +463,6 @@ class DFA(fa.FA):
             initial_state=new_initial_state,
             final_states=set(filter(difference_fn, new_states))
         )
-
-        if minify:
-            return new_dfa.minify(retain_names=retain_names)
-        return new_dfa
 
     def symmetric_difference(self, other, *, retain_names=False, minify=True):
         """
@@ -461,6 +476,15 @@ class DFA(fa.FA):
 
         new_states, new_transitions, new_initial_state = self._cross_product(other)
 
+        if minify:
+            return self._minify(
+                reachable_states=new_states,
+                input_symbols=self.input_symbols,
+                transitions=new_transitions,
+                initial_state=new_initial_state,
+                reachable_final_states=set(filter(symmetric_difference_fn, new_states)),
+                retain_names=retain_names)
+
         return self.__class__(
             states=new_states,
             input_symbols=self.input_symbols,
@@ -468,10 +492,6 @@ class DFA(fa.FA):
             initial_state=new_initial_state,
             final_states=set(filter(symmetric_difference_fn, new_states))
         )
-
-        if minify:
-            return new_dfa.minify(retain_names=retain_names)
-        return new_dfa
 
     def complement(self):
         """Return the complement of this DFA."""

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -682,7 +682,7 @@ class DFA(fa.FA):
         )
 
     @classmethod
-    def from_nfa(cls, target_nfa, retain_names=False):
+    def from_nfa(cls, target_nfa, *, retain_names=False, minify=True):
         """Initialize this DFA as one equivalent to the given NFA."""
         dfa_states = set()
         dfa_symbols = target_nfa.input_symbols
@@ -728,9 +728,20 @@ class DFA(fa.FA):
                 dfa_transitions[current_state_name][input_symbol] = get_name(next_current_states)
                 state_queue.append(next_current_states)
 
+        if minify:
+            return cls._minify(
+                reachable_states=dfa_states,
+                input_symbols=dfa_symbols,
+                transitions=dfa_transitions,
+                initial_state=dfa_initial_state,
+                reachable_final_states=dfa_final_states,
+                retain_names=retain_names)
+
         return cls(
-            states=dfa_states, input_symbols=dfa_symbols,
-            transitions=dfa_transitions, initial_state=dfa_initial_state,
+            states=dfa_states,
+            input_symbols=dfa_symbols,
+            transitions=dfa_transitions,
+            initial_state=dfa_initial_state,
             final_states=dfa_final_states)
 
     def show_diagram(self, path=None):

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -518,7 +518,6 @@ class DFA(fa.FA):
                 reachable_final_states=reachable_states - reachable_final_states,
                 retain_names=retain_names)
 
-
         return self.__class__(
             states=self.states,
             input_symbols=self.input_symbols,

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -176,7 +176,7 @@ def add_concat_tokens(token_list):
 
 def get_regex_lexer():
     """Get lexer for parsing regular expressions."""
-    lexer: Lexer = Lexer()
+    lexer = Lexer()
 
     lexer.register_token(LeftParen, r'\(')
     lexer.register_token(RightParen, r'\)')

--- a/automata/regex/regex.py
+++ b/automata/regex/regex.py
@@ -40,8 +40,8 @@ def issubset(re1, re2):
 
     nfa1 = NFA.from_regex(re1)
     nfa2 = NFA.from_regex(re2)
-    dfa1 = DFA.from_nfa(nfa1).minify(retain_names=False)
-    dfa2 = DFA.from_nfa(nfa2).minify(retain_names=False)
+    dfa1 = DFA.from_nfa(nfa1)
+    dfa2 = DFA.from_nfa(nfa2)
 
     return dfa1.issubset(dfa2)
 
@@ -51,7 +51,7 @@ def issuperset(re1, re2):
 
     nfa1 = NFA.from_regex(re1)
     nfa2 = NFA.from_regex(re2)
-    dfa1 = DFA.from_nfa(nfa1).minify(retain_names=False)
-    dfa2 = DFA.from_nfa(nfa2).minify(retain_names=False)
+    dfa1 = DFA.from_nfa(nfa1)
+    dfa2 = DFA.from_nfa(nfa2)
 
     return dfa2.issubset(dfa1)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -369,8 +369,8 @@ class TestDFA(test_fa.TestFA):
         )
         new_dfa = A.union(B, retain_names=True, minify=False)
         self.assertEqual(new_dfa.states, {
-            ('q0', 'p0'), ('q0', 'p1'), ('q0', 'p2'),
-            ('q1', 'p0'), ('q1', 'p1'), ('q1', 'p2'),
+            ('q0', 'p0'),
+            ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'), ('q2', 'p2'),
             ('q3', 'p0'), ('q3', 'p1'), ('q3', 'p2'),
             ('q4', 'p0'), ('q4', 'p1'), ('q4', 'p2')
@@ -378,11 +378,8 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(new_dfa.input_symbols, {'0', '1'})
         self.assertEqual(new_dfa.transitions, {
             ('q0', 'p0'): {'0': ('q0', 'p0'), '1': ('q1', 'p1')},
-            ('q0', 'p1'): {'0': ('q0', 'p0'), '1': ('q1', 'p2')},
-            ('q0', 'p2'): {'0': ('q0', 'p2'), '1': ('q1', 'p2')},
             ('q1', 'p0'): {'0': ('q1', 'p0'), '1': ('q2', 'p1')},
             ('q1', 'p1'): {'0': ('q1', 'p0'), '1': ('q2', 'p2')},
-            ('q1', 'p2'): {'0': ('q1', 'p2'), '1': ('q2', 'p2')},
             ('q2', 'p0'): {'0': ('q2', 'p0'), '1': ('q3', 'p1')},
             ('q2', 'p1'): {'0': ('q2', 'p0'), '1': ('q3', 'p2')},
             ('q2', 'p2'): {'0': ('q2', 'p2'), '1': ('q3', 'p2')},
@@ -395,7 +392,7 @@ class TestDFA(test_fa.TestFA):
         })
         self.assertEqual(new_dfa.initial_state, ('q0', 'p0'))
         self.assertEqual(new_dfa.final_states, {
-            ('q0', 'p0'), ('q0', 'p1'),
+            ('q0', 'p0'),
             ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'),
             ('q3', 'p0'), ('q3', 'p1'),
@@ -434,8 +431,8 @@ class TestDFA(test_fa.TestFA):
         )
         new_dfa = A.intersection(B, retain_names=True, minify=False)
         self.assertEqual(new_dfa.states, {
-            ('q0', 'p0'), ('q0', 'p1'), ('q0', 'p2'),
-            ('q1', 'p0'), ('q1', 'p1'), ('q1', 'p2'),
+            ('q0', 'p0'),
+            ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'), ('q2', 'p2'),
             ('q3', 'p0'), ('q3', 'p1'), ('q3', 'p2'),
             ('q4', 'p0'), ('q4', 'p1'), ('q4', 'p2')
@@ -443,11 +440,8 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(new_dfa.input_symbols, {'0', '1'})
         self.assertEqual(new_dfa.transitions, {
             ('q0', 'p0'): {'0': ('q0', 'p0'), '1': ('q1', 'p1')},
-            ('q0', 'p1'): {'0': ('q0', 'p0'), '1': ('q1', 'p2')},
-            ('q0', 'p2'): {'0': ('q0', 'p2'), '1': ('q1', 'p2')},
             ('q1', 'p0'): {'0': ('q1', 'p0'), '1': ('q2', 'p1')},
             ('q1', 'p1'): {'0': ('q1', 'p0'), '1': ('q2', 'p2')},
-            ('q1', 'p2'): {'0': ('q1', 'p2'), '1': ('q2', 'p2')},
             ('q2', 'p0'): {'0': ('q2', 'p0'), '1': ('q3', 'p1')},
             ('q2', 'p1'): {'0': ('q2', 'p0'), '1': ('q3', 'p2')},
             ('q2', 'p2'): {'0': ('q2', 'p2'), '1': ('q3', 'p2')},
@@ -495,8 +489,8 @@ class TestDFA(test_fa.TestFA):
         )
         new_dfa = A.difference(B, retain_names=True, minify=False)
         self.assertEqual(new_dfa.states, {
-            ('q0', 'p0'), ('q0', 'p1'), ('q0', 'p2'),
-            ('q1', 'p0'), ('q1', 'p1'), ('q1', 'p2'),
+            ('q0', 'p0'),
+            ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'), ('q2', 'p2'),
             ('q3', 'p0'), ('q3', 'p1'), ('q3', 'p2'),
             ('q4', 'p0'), ('q4', 'p1'), ('q4', 'p2')
@@ -504,11 +498,8 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(new_dfa.input_symbols, {'0', '1'})
         self.assertEqual(new_dfa.transitions, {
             ('q0', 'p0'): {'0': ('q0', 'p0'), '1': ('q1', 'p1')},
-            ('q0', 'p1'): {'0': ('q0', 'p0'), '1': ('q1', 'p2')},
-            ('q0', 'p2'): {'0': ('q0', 'p2'), '1': ('q1', 'p2')},
             ('q1', 'p0'): {'0': ('q1', 'p0'), '1': ('q2', 'p1')},
             ('q1', 'p1'): {'0': ('q1', 'p0'), '1': ('q2', 'p2')},
-            ('q1', 'p2'): {'0': ('q1', 'p2'), '1': ('q2', 'p2')},
             ('q2', 'p0'): {'0': ('q2', 'p0'), '1': ('q3', 'p1')},
             ('q2', 'p1'): {'0': ('q2', 'p0'), '1': ('q3', 'p2')},
             ('q2', 'p2'): {'0': ('q2', 'p2'), '1': ('q3', 'p2')},
@@ -556,8 +547,8 @@ class TestDFA(test_fa.TestFA):
         )
         new_dfa = A.symmetric_difference(B, retain_names=True, minify=False)
         self.assertEqual(new_dfa.states, {
-            ('q0', 'p0'), ('q0', 'p1'), ('q0', 'p2'),
-            ('q1', 'p0'), ('q1', 'p1'), ('q1', 'p2'),
+            ('q0', 'p0'),
+            ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'), ('q2', 'p2'),
             ('q3', 'p0'), ('q3', 'p1'), ('q3', 'p2'),
             ('q4', 'p0'), ('q4', 'p1'), ('q4', 'p2')
@@ -565,11 +556,8 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(new_dfa.input_symbols, {'0', '1'})
         self.assertEqual(new_dfa.transitions, {
             ('q0', 'p0'): {'0': ('q0', 'p0'), '1': ('q1', 'p1')},
-            ('q0', 'p1'): {'0': ('q0', 'p0'), '1': ('q1', 'p2')},
-            ('q0', 'p2'): {'0': ('q0', 'p2'), '1': ('q1', 'p2')},
             ('q1', 'p0'): {'0': ('q1', 'p0'), '1': ('q2', 'p1')},
             ('q1', 'p1'): {'0': ('q1', 'p0'), '1': ('q2', 'p2')},
-            ('q1', 'p2'): {'0': ('q1', 'p2'), '1': ('q2', 'p2')},
             ('q2', 'p0'): {'0': ('q2', 'p0'), '1': ('q3', 'p1')},
             ('q2', 'p1'): {'0': ('q2', 'p0'), '1': ('q3', 'p2')},
             ('q2', 'p2'): {'0': ('q2', 'p2'), '1': ('q3', 'p2')},
@@ -582,7 +570,7 @@ class TestDFA(test_fa.TestFA):
         })
         self.assertEqual(new_dfa.initial_state, ('q0', 'p0'))
         self.assertEqual(new_dfa.final_states, {
-            ('q0', 'p0'), ('q0', 'p1'),
+            ('q0', 'p0'),
             ('q1', 'p0'), ('q1', 'p1'),
             ('q2', 'p0'), ('q2', 'p1'),
             ('q3', 'p0'), ('q3', 'p1'),

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -322,7 +322,7 @@ class TestDFA(test_fa.TestFA):
             initial_state='q0',
             final_states={'q0', 'q1'}
         )
-        complement_dfa = ~no_consecutive_11_dfa
+        complement_dfa = no_consecutive_11_dfa.complement(retain_names=True, minify=False)
         self.assertEqual(complement_dfa.states, no_consecutive_11_dfa.states)
         self.assertEqual(
             complement_dfa.input_symbols, no_consecutive_11_dfa.input_symbols

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1229,7 +1229,7 @@ class TestDFA(test_fa.TestFA):
             initial_state='q0',
             final_states={'q2'}
         )
-        dfa = DFA.from_nfa(nfa, retain_names=True)
+        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False)
         self.assertEqual(dfa.states, {frozenset(), frozenset(('q0',)), frozenset(('q0', 'q1')), frozenset(('q2',))})
         self.assertEqual(dfa.input_symbols, {'0', '1'})
         self.assertEqual(dfa.transitions, {
@@ -1254,7 +1254,7 @@ class TestDFA(test_fa.TestFA):
             initial_state='q0',
             final_states={'q2'}
         )
-        dfa = DFA.from_nfa(nfa, retain_names=True)
+        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False)
         self.assertEqual(dfa.states, {
             frozenset(('q0',)), frozenset(('q0', 'q1')), frozenset(('q0', 'q2')), frozenset(('q0', 'q1', 'q2'))
         })
@@ -1270,7 +1270,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_init_nfa_lambda_transition(self):
         """Should convert to a DFA an NFA with a lambda transition."""
-        dfa = DFA.from_nfa(self.nfa, retain_names=True)
+        dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False)
         self.assertEqual(dfa.states, {frozenset(), frozenset(('q0',)), frozenset(('q1', 'q2'))})
         self.assertEqual(dfa.input_symbols, {'a', 'b'})
         self.assertEqual(dfa.transitions, {
@@ -1294,7 +1294,7 @@ class TestDFA(test_fa.TestFA):
             initial_state='q0',
             final_states={'q1'}
         )
-        dfa = DFA.from_nfa(nfa, retain_names=True)  # returns an equivalent DFA
+        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False)  # returns an equivalent DFA
         self.assertEqual(dfa.read_input('a'), frozenset(('q1',)))
 
     def test_partial_dfa(self):

--- a/tests/test_tm.py
+++ b/tests/test_tm.py
@@ -3,7 +3,6 @@
 
 import unittest
 
-import automata.base.exceptions as exceptions
 from automata.tm.dtm import DTM
 from automata.tm.mntm import MNTM
 from automata.tm.ntm import NTM


### PR DESCRIPTION
@caleb531 Refactors the minify and cross product functions to avoid creating intermediate DFAs. Cross product function now returns only reachable part of the product DFA by default.