### PR TITLE
Add shuffle product operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,13 +673,16 @@ from automata.fa.dfa import DFA
 nfa = NFA.from_dfa(dfa)  # returns an equivalent NFA
 ```
 
-#### NFA.from_regex(cls, regex)
+#### NFA.from_regex(cls, regex, input_symbols=None)
 
-Returns a new NFA instance from the given regular expression.
+Returns a new NFA instance from the given regular expression. The
+parameter `input_symbols` should be a set of the input symbols to use,
+defaults to all non-reserved symbols in the given `regex`.
 
 ```python
 from automata.fa.nfa import NFA
-NFA.from_regex('ab(c|d)*ba?')
+nfa1 = NFA.from_regex('ab(c|d)*ba?')
+nfa2 = NFA.from_regex('aaa*', input_symbols={'a', 'b'})
 ```
 
 #### Converting NFA to regular expression
@@ -705,7 +708,7 @@ The `GNFA` class is a subclass of `NFA` and represents a generalized
 nondeterministic finite automaton. It can be found under `automata/fa/gnfa.py`.
 Its main usage is for conversion of DFAs and NFAs to regular expressions.
 
-Every `GNFA` has the following properties: `states`, `input_sympols`,
+Every `GNFA` has the following properties: `states`, `input_symbols`,
 `transitions`, `initial_state`, and `final_state`. This is very similar to the
 `NFA` signature, except that a `GNFA` has several differences with respect to
 `NFA`

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ contains_substring_dcba = DFA.contains_subsequence({'a', 'b', 'c', 'd'}, 'dcba')
 avoids_substring_dcba = DFA.contains_subsequence({'a', 'b', 'c', 'd'}, 'dcba', contains=False)
 ```
 
-#### DFA.of_length(cls, input_symbols, min_length=0, max_length=None)
+#### DFA.of_length(cls, input_symbols, min_length=0, max_length=None, symbols_to_count=None)
 
 Directly computes the minimal DFA which accepts all words whose length is between `min_length` and `max_length`, inclusive.
 To allow infinitely long words the value `None` can be passed in for `max_length`.

--- a/README.md
+++ b/README.md
@@ -430,8 +430,11 @@ avoids_substring_dcba = DFA.contains_subsequence({'a', 'b', 'c', 'd'}, 'dcba', c
 
 #### DFA.of_length(cls, input_symbols, min_length=0, max_length=None, symbols_to_count=None)
 
-Directly computes the minimal DFA which accepts all words whose length is between `min_length` and `max_length`, inclusive.
-To allow infinitely long words the value `None` can be passed in for `max_length`.
+Directly computes the minimal DFA which accepts all words whose length is between `min_length`
+and `max_length`, inclusive. To allow infinitely long words, the value `None` can be
+passed in for `max_length`. If `symbols_to_count` is `None` (default behavior), then counts
+all symbols. Otherwise, only counts symbols present in the set `symbols_to_count` and
+ignores other symbols.
 
 ```python
 dfa = DFA.of_length({'0', '1'}, min_length=4)
@@ -443,6 +446,9 @@ dfa = DFA.of_length({'0', '1'}, min_length=4, max_length=8)
 Directly computes a DFA that counts given symbols and accepts all strings where
 the remainder of division by `k` is in the set of `remainders` given.
 The default value of `remainders` is `{0}` and all symbols are counted by default.
+If `symbols_to_count` is `None` (default behavior), then counts all symbols.
+Otherwise, only counts symbols present in the set `symbols_to_count` and
+ignores other symbols.
 
 ```python
 even_length_strings = DFA.count_mod({'0', '1'}, 2)

--- a/README.md
+++ b/README.md
@@ -623,6 +623,16 @@ new_nfa = nfa1.intersection(nfa2)
 new_nfa = nfa1 & nfa2
 ```
 
+#### NFA.shuffle_product(self, other)
+
+Returns shuffle product of two NFAs. This produces an NFA that accepts all
+interleavings of strings in the input NFAs.
+See [this article](https://link.springer.com/chapter/10.1007/978-3-031-19685-0_3) for more details.
+
+```python
+new_nfa = nfa1.shuffle_product(nfa2)
+```
+
 #### NFA.eliminate_lambda(self)
 
 Removes epsilon transitions from the NFA which recognizes the same language.

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -841,17 +841,23 @@ class DFA(fa.FA):
         )
 
     @classmethod
-    def of_length(cls, input_symbols, *, min_length=0, max_length=None):
+    def of_length(cls, input_symbols, *, min_length=0, max_length=None, symbols_to_count=None):
         """
         Directly computes the minimal DFA recognizing strings whose length
         is between `min_length` and `max_length`, inclusive.
         To allow infinitely long words the value `None` can be passed in for `max_length`.
         """
+        if symbols_to_count is None:
+            symbols_to_count = input_symbols
+
         transitions = {}
         length_range = range(min_length) if max_length is None else range(max_length+1)
         for prev_state in length_range:
             next_state = prev_state + 1
-            transitions[prev_state] = {symbol: next_state for symbol in input_symbols}
+            transitions[prev_state] = {
+                symbol: next_state if symbol in symbols_to_count else prev_state
+                for symbol in input_symbols
+            }
         last_state = len(transitions)
         transitions[last_state] = {symbol: last_state for symbol in input_symbols}
         final_states = {last_state} if max_length is None else set(range(min_length, max_length+1))

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -138,7 +138,7 @@ class NFA(fa.FA):
         nfa_builder = parse_regex(regex)
 
         return cls(
-            states=set(nfa_builder._transitions.keys()),
+            states=frozenset(nfa_builder._transitions.keys()),
             input_symbols=input_symbols,
             transitions=nfa_builder._transitions,
             initial_state=nfa_builder._initial_state,
@@ -527,8 +527,7 @@ class NFA(fa.FA):
 
         new_input_symbols = self.input_symbols | other.input_symbols
         new_initial_state = (self.initial_state, other.initial_state)
-        new_final_states = set(product(self.final_states, other.final_states))
-        new_states = set(product(self.states, other.states))
+        new_states = frozenset(product(self.states, other.states))
 
         new_transitions = dict()
 
@@ -549,7 +548,7 @@ class NFA(fa.FA):
             input_symbols=new_input_symbols,
             transitions=new_transitions,
             initial_state=new_initial_state,
-            final_states=new_final_states
+            final_states=frozenset(product(self.final_states, other.final_states))
         )
 
     def show_diagram(self, path=None):

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -525,14 +525,10 @@ class NFA(fa.FA):
         the shuffle of L1 and L2.
         """
 
-        # First, eliminate lambdas because they cause problems with this construction
-        self_without_lambdas = self.eliminate_lambda()
-        other_without_lambdas = other.eliminate_lambda()
-
-        new_input_symbols = self_without_lambdas.input_symbols | other_without_lambdas.input_symbols
-        new_initial_state = (self_without_lambdas.initial_state, other_without_lambdas.initial_state)
-        new_final_states = set(product(self_without_lambdas.final_states, other_without_lambdas.final_states))
-        new_states = set(product(self_without_lambdas.states, other_without_lambdas.states))
+        new_input_symbols = self.input_symbols | other.input_symbols
+        new_initial_state = (self.initial_state, other.initial_state)
+        new_final_states = set(product(self.final_states, other.final_states))
+        new_states = set(product(self.states, other.states))
 
         new_transitions = dict()
 
@@ -540,11 +536,11 @@ class NFA(fa.FA):
             state_dict = new_transitions.setdefault(curr_state, dict())
             q_a, q_b = curr_state
 
-            transitions_a = self_without_lambdas.transitions.get(q_a, dict())
+            transitions_a = self.transitions.get(q_a, dict())
             for symbol, end_states in transitions_a.items():
                 state_dict.setdefault(symbol, set()).update(product(end_states, [q_b]))
 
-            transitions_b = other_without_lambdas.transitions.get(q_b, dict())
+            transitions_b = other.transitions.get(q_b, dict())
             for symbol, end_states in transitions_b.items():
                 state_dict.setdefault(symbol, set()).update(product([q_a], end_states))
 

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -524,6 +524,8 @@ class NFA(fa.FA):
         L1 and L2 respectively, returns an NFA which accepts
         the shuffle of L1 and L2.
         """
+        if not isinstance(other, NFA):
+            raise TypeError(f"other must be an NFA, not {other.__class__.__name__}")
 
         new_input_symbols = self.input_symbols | other.input_symbols
         new_initial_state = (self.initial_state, other.initial_state)

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -124,9 +124,17 @@ class NFA(fa.FA):
         )
 
     @classmethod
-    def from_regex(cls, regex):
+    def from_regex(cls, regex, *, input_symbols=None):
         """Initialize this NFA as one equivalent to the given regular expression"""
-        input_symbols = set(regex) - {'*', '|', '(', ')', '?', ' ', '\t', '&', '+'}
+        reserved_characters = {'*', '|', '(', ')', '?', ' ', '\t', '&', '+'}
+
+        if input_symbols is None:
+            input_symbols = set(regex) - reserved_characters
+        else:
+            conflicting_symbols = reserved_characters & input_symbols
+            if conflicting_symbols:
+                raise ValueError(f'Invalid input symbols: {conflicting_symbols}')
+
         nfa_builder = parse_regex(regex)
 
         return cls(

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -133,7 +133,7 @@ class NFA(fa.FA):
         else:
             conflicting_symbols = reserved_characters & input_symbols
             if conflicting_symbols:
-                raise ValueError(f'Invalid input symbols: {conflicting_symbols}')
+                raise exceptions.InvalidSymbolError(f'Invalid input symbols: {conflicting_symbols}')
 
         nfa_builder = parse_regex(regex)
 

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1743,6 +1743,26 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dfa4.minimum_word_length(), 4)
         self.assertEqual(dfa4.maximum_word_length(), 8)
 
+        dfa5 = DFA.of_length(binary, min_length=2, max_length=2, symbols_to_count={'1'})
+        dfa6 = DFA(
+            states={0, 1, 2, 3},
+            input_symbols=binary,
+            transitions={
+                0: {'1': 1, '0': 0},
+                1: {'1': 2, '0': 1},
+                2: {'1': 3, '0': 2},
+                3: {'1': 3, '0': 3},
+            },
+            initial_state=0,
+            final_states={2}
+        )
+        self.assertEqual(dfa5, dfa6)
+
+        dfa7 = DFA.of_length(binary, symbols_to_count={'1'})
+        dfa8 = DFA.of_length(binary, symbols_to_count={'0'})
+
+        self.assertEqual(dfa7.union(dfa8), DFA.universal_language(binary))
+
     def test_count_mod(self):
         binary = {'0', '1'}
         with self.assertRaises(ValueError):

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -962,6 +962,10 @@ class TestNFA(test_fa.TestFA):
 
         self.assertEqual(nfa5.shuffle_product(nfa7), nfa8)
 
+        # raise error if other is not NFA
+        with self.assertRaises(TypeError):
+            self.nfa & self.dfa
+
     def test_nfa_shuffle_product_set_laws(self):
         """Test set laws for shuffle product"""
         alphabet = {'a', 'b'}

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -939,9 +939,38 @@ class TestNFA(test_fa.TestFA):
         """
         alphabet = {'a', 'b'}
 
+        # Basic finite language test case
         nfa1 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'aba'}))
         nfa2 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'bab'}))
 
-        nfa3 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'abbaab', 'baabab', 'ababab', 'babaab', 'abbaba', 'baabba', 'ababba', 'bababa'}))
+        nfa3 = NFA.from_dfa(DFA.from_finite_language(alphabet, {
+            'abbaab', 'baabab', 'ababab', 'babaab', 'abbaba', 'baabba', 'ababba', 'bababa'
+        }))
 
         self.assertEqual(nfa1.shuffle_product(nfa2), nfa3)
+
+        # Regular language test case
+        nfa4 = NFA.from_regex('aa', input_symbols=alphabet)
+        nfa5 = NFA.from_regex('b*', input_symbols=alphabet)
+
+        nfa6 = NFA(
+            states={0, 1, 2, 3},
+            input_symbols=alphabet,
+            transitions={
+                0: {'a': {1}, 'b': {0}},
+                1: {'a': {2}, 'b': {1}},
+                2: {'a': {3}, 'b': {2}},
+                3: {'b': {3}},
+            },
+            initial_state=0,
+            final_states={2}
+        )
+
+        self.assertEqual(nfa4.shuffle_product(nfa5), nfa6)
+
+        # Language properties test case
+        nfa7 = NFA.from_regex('a(a*b|b)', input_symbols=alphabet)
+        nfa8 = NFA.from_regex('(aa+b)&(abbb)|(bba+)', input_symbols=alphabet)
+        nfa8 = NFA.from_regex('a(a*b|b)b(ab*|ba*)', input_symbols=alphabet)
+
+        self.assertEqual(nfa7.shuffle_product(nfa8), nfa8.shuffle_product(nfa7))

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -529,10 +529,10 @@ class TestNFA(test_fa.TestFA):
         # third check: union of NFA which is subset of other
         nfa6 = NFA.from_regex('aa*')
         nfa7 = NFA.from_regex('a*')
-        nfa8 = nfa6.union(nfa7)
-        nfa9 = nfa7.union(nfa6)
-        self.assertEqual(nfa8, nfa7)
-        self.assertEqual(nfa9, nfa7)
+        nfa1 = nfa6.union(nfa7)
+        nfa2 = nfa7.union(nfa6)
+        self.assertEqual(nfa1, nfa7)
+        self.assertEqual(nfa2, nfa7)
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
@@ -554,10 +554,10 @@ class TestNFA(test_fa.TestFA):
         # third check: intersection of NFA which is subset of other
         nfa6 = NFA.from_regex('aa*')
         nfa7 = NFA.from_regex('a*')
-        nfa8 = nfa6.intersection(nfa7)
-        nfa9 = nfa7.intersection(nfa6)
-        self.assertEqual(nfa8, nfa6)
-        self.assertEqual(nfa9, nfa6)
+        nfa1 = nfa6.intersection(nfa7)
+        nfa2 = nfa7.intersection(nfa6)
+        self.assertEqual(nfa1, nfa6)
+        self.assertEqual(nfa2, nfa6)
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
@@ -953,35 +953,34 @@ class TestNFA(test_fa.TestFA):
         nfa4 = NFA.from_regex('aa', input_symbols=alphabet)
         nfa5 = NFA.from_regex('b*', input_symbols=alphabet)
 
-        nfa6 = NFA(
-            states={0, 1, 2, 3},
-            input_symbols=alphabet,
-            transitions={
-                0: {'a': {1}, 'b': {0}},
-                1: {'a': {2}, 'b': {1}},
-                2: {'a': {3}, 'b': {2}},
-                3: {'b': {3}},
-            },
-            initial_state=0,
-            final_states={2}
-        )
+        nfa6 = NFA.from_dfa(DFA.of_length(alphabet, min_length=2, max_length=2, symbols_to_count={'a'}))
 
         self.assertEqual(nfa4.shuffle_product(nfa5), nfa6)
 
+        nfa7 = NFA.from_regex('a?a?a?')
+        nfa8 = NFA.from_dfa(DFA.of_length(alphabet, max_length=3, symbols_to_count={'a'}))
+
+        self.assertEqual(nfa5.shuffle_product(nfa7), nfa8)
+
+
+    def test_nfa_shuffle_product_set_laws(self):
+        """Test set laws for shuffle product"""
+        alphabet = {'a', 'b'}
+
         # Language properties test case
-        nfa7 = NFA.from_regex('a(a*b|b)', input_symbols=alphabet)
-        nfa8 = NFA.from_regex('(aa+b)&(abbb)|(bba+)', input_symbols=alphabet)
-        nfa9 = NFA.from_regex('a(a*b|b)b(ab*|ba*)', input_symbols=alphabet)
+        nfa1 = NFA.from_regex('a(a*b|b)', input_symbols=alphabet)
+        nfa2 = NFA.from_regex('(aa+b)&(abbb)|(bba+)', input_symbols=alphabet)
+        nfa3 = NFA.from_regex('a(a*b|b)b(ab*|ba*)', input_symbols=alphabet)
 
         # Commutativity
-        self.assertEqual(nfa7.shuffle_product(nfa8), nfa8.shuffle_product(nfa7))
+        self.assertEqual(nfa1.shuffle_product(nfa2), nfa2.shuffle_product(nfa1))
         # Associativity
         self.assertEqual(
-            nfa7.shuffle_product(nfa8.shuffle_product(nfa9)),
-            nfa7.shuffle_product(nfa8).shuffle_product(nfa9)
+            nfa1.shuffle_product(nfa2.shuffle_product(nfa3)),
+            nfa1.shuffle_product(nfa2).shuffle_product(nfa3)
         )
         # Distributes over union
         self.assertEqual(
-            nfa7.shuffle_product(nfa8.union(nfa9)),
-            nfa7.shuffle_product(nfa8).union(nfa7.shuffle_product(nfa9))
+            nfa1.shuffle_product(nfa2.union(nfa3)),
+            nfa1.shuffle_product(nfa2).union(nfa1.shuffle_product(nfa3))
         )

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -529,10 +529,10 @@ class TestNFA(test_fa.TestFA):
         # third check: union of NFA which is subset of other
         nfa6 = NFA.from_regex('aa*')
         nfa7 = NFA.from_regex('a*')
-        nfa1 = nfa6.union(nfa7)
-        nfa2 = nfa7.union(nfa6)
-        self.assertEqual(nfa1, nfa7)
-        self.assertEqual(nfa2, nfa7)
+        nfa8 = nfa6.union(nfa7)
+        nfa9 = nfa7.union(nfa6)
+        self.assertEqual(nfa8, nfa7)
+        self.assertEqual(nfa9, nfa7)
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
@@ -554,10 +554,10 @@ class TestNFA(test_fa.TestFA):
         # third check: intersection of NFA which is subset of other
         nfa6 = NFA.from_regex('aa*')
         nfa7 = NFA.from_regex('a*')
-        nfa1 = nfa6.intersection(nfa7)
-        nfa2 = nfa7.intersection(nfa6)
-        self.assertEqual(nfa1, nfa6)
-        self.assertEqual(nfa2, nfa6)
+        nfa8 = nfa6.intersection(nfa7)
+        nfa9 = nfa7.intersection(nfa6)
+        self.assertEqual(nfa8, nfa6)
+        self.assertEqual(nfa9, nfa6)
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -971,6 +971,17 @@ class TestNFA(test_fa.TestFA):
         # Language properties test case
         nfa7 = NFA.from_regex('a(a*b|b)', input_symbols=alphabet)
         nfa8 = NFA.from_regex('(aa+b)&(abbb)|(bba+)', input_symbols=alphabet)
-        nfa8 = NFA.from_regex('a(a*b|b)b(ab*|ba*)', input_symbols=alphabet)
+        nfa9 = NFA.from_regex('a(a*b|b)b(ab*|ba*)', input_symbols=alphabet)
 
+        # Commutativity
         self.assertEqual(nfa7.shuffle_product(nfa8), nfa8.shuffle_product(nfa7))
+        # Associativity
+        self.assertEqual(
+            nfa7.shuffle_product(nfa8.shuffle_product(nfa9)),
+            nfa7.shuffle_product(nfa8).shuffle_product(nfa9)
+        )
+        # Distributes over union
+        self.assertEqual(
+            nfa7.shuffle_product(nfa8.union(nfa9)),
+            nfa7.shuffle_product(nfa8).union(nfa7.shuffle_product(nfa9))
+        )

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -962,7 +962,6 @@ class TestNFA(test_fa.TestFA):
 
         self.assertEqual(nfa5.shuffle_product(nfa7), nfa8)
 
-
     def test_nfa_shuffle_product_set_laws(self):
         """Test set laws for shuffle product"""
         alphabet = {'a', 'b'}

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -930,3 +930,18 @@ class TestNFA(test_fa.TestFA):
         for close_string in close_strings_deletion:
             self.assertTrue(nice_nfa_deletion.accepts_input(close_string))
             self.assertFalse(nice_nfa_insertion.accepts_input(close_string))
+
+    def test_nfa_shuffle_product(self):
+        """
+        Test shuffle product of two NFAs.
+
+        Test cases based on https://planetmath.org/shuffleoflanguages
+        """
+        alphabet = {'a', 'b'}
+
+        nfa1 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'aba'}))
+        nfa2 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'bab'}))
+
+        nfa3 = NFA.from_dfa(DFA.from_finite_language(alphabet, {'abbaab', 'baabab', 'ababab', 'babaab', 'abbaba', 'baabba', 'ababba', 'bababa'}))
+
+        self.assertEqual(nfa1.shuffle_product(nfa2), nfa3)

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -964,7 +964,7 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa & self.dfa
+            self.nfa.shuffle_product(self.dfa)
 
     def test_nfa_shuffle_product_set_laws(self):
         """Test set laws for shuffle product"""

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -104,5 +104,5 @@ class TestRegex(unittest.TestCase):
 
     def test_invalid_symbols(self):
         """Should throw exception if reserved character is in input symbols"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(exceptions.InvalidSymbolError):
             NFA.from_regex('a+', input_symbols={'a', '+'})

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -101,3 +101,8 @@ class TestRegex(unittest.TestCase):
         self.assertTrue(re.isequal('(abc)(abc)*', '(abc)+'))
         self.assertTrue(re.isequal('a&a+', 'a'))
         self.assertFalse(re.isequal('a*', 'a+'))
+
+    def test_invalid_symbols(self):
+        """Should throw exception if reserved character is in input symbols"""
+        with self.assertRaises(ValueError):
+            NFA.from_regex('a+', input_symbols={'a', '+'})


### PR DESCRIPTION
Adds shuffle product operation for NFAs. Creates an NFA that accepts interleavings of component languages. Seen this construction in some articles / other automata packages, so thought it was worth including for completeness.