### PR TITLE
Add global configuration and allow disabling automaton validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ automaton.accepts_input(word)
 
 Returns a deep copy of the automaton according to its subtype.
 
+### Disabling automatic validation
+
+By default, all Automaton instances are checked for common inconsistencies when
+they are instantiated. If inconsistencies are found, the appropriate exception
+from `automata.base.exceptions` is raised.
+
+Because this validation can be performance-intensive for large automaton
+instances with many states/transitions, you can disable the automatic validation
+using the global configuration feature (introduced in v7):
+
+```python
+import automata.base.config as global_config
+
+global_config.should_validate_automata = False
+
+# The rest of your code...
+```
+
+If, at any point, you wish to opt into validation for a specific Automaton instance, you can call the `validate` method:
+
+```python
+my_automaton.validate()
+```
+
 ### class FA(Automaton, metaclass=ABCMeta)
 
 The `FA` class is an abstract base class from which all finite automata inherit.

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -6,6 +6,7 @@ import abc
 from frozendict import frozendict
 
 import automata.base.exceptions as exceptions
+from automata.base.config import global_config
 from automata.base.utils import freezeValue
 
 
@@ -18,7 +19,8 @@ class Automaton(metaclass=abc.ABCMeta):
         self.__post_init__()
 
     def __post_init__(self):
-        self.validate()
+        if global_config.should_validate_automata:
+            self.validate()
 
     @abc.abstractmethod
     def validate(self):

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -5,8 +5,8 @@ import abc
 
 from frozendict import frozendict
 
+import automata.base.config as global_config
 import automata.base.exceptions as exceptions
-from automata.base.config import global_config
 from automata.base.utils import freezeValue
 
 

--- a/automata/base/config.py
+++ b/automata/base/config.py
@@ -1,0 +1,9 @@
+"""Global configuration for the library and its primitives"""
+
+
+class Config():
+
+    should_validate_automata = True
+
+
+global_config = Config()

--- a/automata/base/config.py
+++ b/automata/base/config.py
@@ -1,9 +1,4 @@
 """Global configuration for the library and its primitives"""
 
 
-class Config():
-
-    should_validate_automata = True
-
-
-global_config = Config()
+should_validate_automata = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Functions for testing the global Automata configuration."""
+
+import unittest
+from unittest.mock import patch
+
+from automata.base.config import global_config
+from automata.fa.dfa import DFA
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.orig_global_config = global_config.__dict__.copy()
+
+    def tearDown(self):
+        global_config.__dict__ = self.orig_global_config
+
+    @patch('automata.fa.dfa.DFA.validate')
+    def test_disable_validation(self, validate):
+        """Should disable automaton validation"""
+        global_config.should_validate_automata = False
+        DFA.universal_language({0, 1})
+        validate.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,17 +4,17 @@
 import unittest
 from unittest.mock import patch
 
-from automata.base.config import global_config
+import automata.base.config as global_config
 from automata.fa.dfa import DFA
 
 
 class TestConfig(unittest.TestCase):
 
     def setUp(self):
-        self.orig_global_config = global_config.__dict__.copy()
+        self.orig_should_validate = global_config.should_validate_automata
 
     def tearDown(self):
-        global_config.__dict__ = self.orig_global_config
+        global_config.should_validate_automata = self.orig_should_validate
 
     @patch('automata.fa.dfa.DFA.validate')
     def test_disable_validation(self, validate):


### PR DESCRIPTION
Adds a new `automata.base.config` module with the following members:

1. A `Config` class that is only used for instantiating the `global_config` instance mentioned below
2. A single `Config` instance called `global_config`, which is referenced in the `automata.base.automaton` module.

README documentation still needs to be added.

@eliotwrobson @Tagl I welcome your feedback on the code I've written so far.