### PR TITLE
Speed up Automata Creation

### DIFF
--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -15,7 +15,8 @@ class Automaton(metaclass=abc.ABCMeta):
 
     def __init__(self, **kwargs):
         for attr_name, attr_value in kwargs.items():
-            value = freezeValue(attr_value) if global_config.ensure_frozen_values else attr_value
+            value = freezeValue(attr_value) \
+                if not global_config.allow_mutable_automata else attr_value
             object.__setattr__(self, attr_name, value)
         self.__post_init__()
 

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -14,10 +14,12 @@ class Automaton(metaclass=abc.ABCMeta):
     """An abstract base class for all automata, including Turing machines."""
 
     def __init__(self, **kwargs):
-        for attr_name, attr_value in kwargs.items():
-            value = freezeValue(attr_value) \
-                if not global_config.allow_mutable_automata else attr_value
-            object.__setattr__(self, attr_name, value)
+        if not global_config.allow_mutable_automata:
+            for attr_name, attr_value in kwargs.items():
+                object.__setattr__(self, attr_name, freezeValue(attr_value))
+        else:
+            for attr_name, attr_value in kwargs.items():
+                object.__setattr__(self, attr_name, attr_value)
         self.__post_init__()
 
     def __post_init__(self):

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -15,7 +15,8 @@ class Automaton(metaclass=abc.ABCMeta):
 
     def __init__(self, **kwargs):
         for attr_name, attr_value in kwargs.items():
-            object.__setattr__(self, attr_name, freezeValue(attr_value))
+            value = freezeValue(attr_value) if global_config.ensure_frozen_values else attr_value
+            object.__setattr__(self, attr_name, value)
         self.__post_init__()
 
     def __post_init__(self):

--- a/automata/base/config.py
+++ b/automata/base/config.py
@@ -2,3 +2,6 @@
 
 
 should_validate_automata = True
+# When set to False, it disables the freezeValue step to speed up the automata creation
+#   -> You must guarantee that your code does not modify the automata
+ensure_frozen_values = True

--- a/automata/base/config.py
+++ b/automata/base/config.py
@@ -2,6 +2,6 @@
 
 
 should_validate_automata = True
-# When set to False, it disables the freezeValue step to speed up the automata creation
+# When set to True, it disables the freezeValue step
 #   -> You must guarantee that your code does not modify the automata
-ensure_frozen_values = True
+allow_mutable_automata = False

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -10,17 +10,18 @@ def freezeValue(value):
     immutable one by recursively processing said structure and any of its
     members, freezing them as well
     """
-    if isinstance(value, list):
-        return tuple(freezeValue(element) for element in value)
+    if isinstance(value, (str, int)):
+        return value
     if isinstance(value, set):
         return frozenset(freezeValue(element) for element in value)
-    elif isinstance(value, dict):
+    if isinstance(value, dict):
         return frozendict({
             dict_key: freezeValue(dict_value)
             for dict_key, dict_value in value.items()
         })
-    else:
-        return value
+    if isinstance(value, list):
+        return tuple(freezeValue(element) for element in value)
+    return value
 
 
 class PartitionRefinement:

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -12,13 +12,13 @@ def freezeValue(value):
     """
     if isinstance(value, (str, int)):
         return value
-    if isinstance(value, set):
-        return frozenset(freezeValue(element) for element in value)
     if isinstance(value, dict):
         return frozendict({
             dict_key: freezeValue(dict_value)
             for dict_key, dict_value in value.items()
         })
+    if isinstance(value, set):
+        return frozenset(freezeValue(element) for element in value)
     if isinstance(value, list):
         return tuple(freezeValue(element) for element in value)
     return value

--- a/docs/class-automaton.md
+++ b/docs/class-automaton.md
@@ -50,6 +50,18 @@ params['final_states'] = {'q2'}
 dfa2 = DFA(**params)
 ```
 
+#### Enabling mutable automata
+
+It's possible to enable mutable automata, but in this case the user must ensure that 
+the automatas are never modified, otherwise correct behavior cannot be ensured.
+
+```python
+import automata.base.config as global_config
+
+global_config.ensure_frozen_values = False
+# The rest of your code...
+```
+
 ### Automaton instances are validated by default
 
 By default, all Automaton instances are checked for common inconsistencies when

--- a/docs/class-automaton.md
+++ b/docs/class-automaton.md
@@ -52,13 +52,18 @@ dfa2 = DFA(**params)
 
 #### Enabling mutable automata
 
-It's possible to enable mutable automata, but in this case the user must ensure that 
-the automatas are never modified, otherwise correct behavior cannot be ensured.
+Automaton immutability is enforced via a "freeze" step during object initialization that 
+turns mutable parameters (such as sets or dicts) into their immutable counterparts (frozensets/frozendicts).
+This extra step becomes a bottleneck when creating multiple copies of the same automaton.
+
+It is possible to disable this checking via the `enable_mutable_automata` global configuration feature. 
+In this case, the user must ensure that the automaton instances are never modified, 
+otherwise correct behavior cannot be ensured.
 
 ```python
 import automata.base.config as global_config
 
-global_config.allow_mutable_automata = False
+global_config.allow_mutable_automata = True
 # The rest of your code...
 ```
 

--- a/docs/class-automaton.md
+++ b/docs/class-automaton.md
@@ -58,7 +58,7 @@ the automatas are never modified, otherwise correct behavior cannot be ensured.
 ```python
 import automata.base.config as global_config
 
-global_config.ensure_frozen_values = False
+global_config.allow_mutable_automata = False
 # The rest of your code...
 ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,8 +28,8 @@ class TestConfig(unittest.TestCase):
         validate.assert_not_called()
 
     @patch('automata.base.utils.freezeValue')
-    def test_disable_ensure_values_are_frozen(self, validate):
-        """Should disable the call to freezeValue"""
+    def test_disable_ensure_values_are_frozen(self, freeze_value):
+        """Should enable automaton mutability"""
         global_config.allow_mutable_automata = True
         dfa = DFA(
             states=frozenset(['s1']),
@@ -38,9 +38,9 @@ class TestConfig(unittest.TestCase):
             initial_state='s1',
             final_states=frozenset(['s1']),
         )
-        validate.assert_not_called()
+        freeze_value.assert_not_called()
 
-        # Also this should not call ensure freeze nor throw any error
+        # Also this should not call freezeValue nor throw any error
         dfa = DFA(
             states={'s1'},
             input_symbols={'a'},
@@ -48,17 +48,4 @@ class TestConfig(unittest.TestCase):
             initial_state='s1',
             final_states={'s1'}
         )
-        validate.assert_not_called()
-
-    def test_values_are_frozen(self):
-        """Should freeze the values"""
-        automata.base.utils.freezeValue = MagicMock(wraps=automata.base.utils.freezeValue)
-        global_config.allow_mutable_automata = False
-        dfa = DFA(
-            states={'s1'},
-            input_symbols={'a'},
-            transitions={'s1': {'a': 's1'}},
-            initial_state='s1',
-            final_states={'s1'}
-        )
-        automata.base.utils.freezeValue.assert_called()
+        freeze_value.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,11 @@
 """Functions for testing the global Automata configuration."""
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from frozendict import frozendict
 
 import automata.base.config as global_config
+import automata.base.utils
 from automata.fa.dfa import DFA
 
 
@@ -12,9 +14,11 @@ class TestConfig(unittest.TestCase):
 
     def setUp(self):
         self.orig_should_validate = global_config.should_validate_automata
+        self.orig_ensure_frozen_values = global_config.ensure_frozen_values
 
     def tearDown(self):
         global_config.should_validate_automata = self.orig_should_validate
+        global_config.ensure_frozen_values = self.orig_ensure_frozen_values
 
     @patch('automata.fa.dfa.DFA.validate')
     def test_disable_validation(self, validate):
@@ -22,3 +26,39 @@ class TestConfig(unittest.TestCase):
         global_config.should_validate_automata = False
         DFA.universal_language({0, 1})
         validate.assert_not_called()
+
+    @patch('automata.base.utils.freezeValue')
+    def test_disable_ensure_values_are_frozen(self, validate):
+        """Should disable the call to freezeValue"""
+        global_config.ensure_frozen_values = False
+        dfa = DFA(
+            states=frozenset(['s1']),
+            input_symbols=frozenset('a'),
+            transitions=frozendict({'s1': frozendict({'a': 's1'})}),
+            initial_state='s1',
+            final_states=frozenset(['s1']),
+        )
+        validate.assert_not_called()
+
+        # Also this should not call ensure freeze nor throw any error
+        dfa = DFA(
+            states={'s1'},
+            input_symbols={'a'},
+            transitions={'s1': {'a': 's1'}},
+            initial_state='s1',
+            final_states={'s1'}
+        )
+        validate.assert_not_called()
+
+    def test_values_are_frozen(self):
+        """Should freeze the values"""
+        automata.base.utils.freezeValue = MagicMock(wraps=automata.base.utils.freezeValue)
+        global_config.ensure_frozen_values = True
+        dfa = DFA(
+            states={'s1'},
+            input_symbols={'a'},
+            transitions={'s1': {'a': 's1'}},
+            initial_state='s1',
+            final_states={'s1'}
+        )
+        automata.base.utils.freezeValue.assert_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,11 +14,11 @@ class TestConfig(unittest.TestCase):
 
     def setUp(self):
         self.orig_should_validate = global_config.should_validate_automata
-        self.orig_ensure_frozen_values = global_config.ensure_frozen_values
+        self.orig_allow_mutable_automata = global_config.allow_mutable_automata
 
     def tearDown(self):
         global_config.should_validate_automata = self.orig_should_validate
-        global_config.ensure_frozen_values = self.orig_ensure_frozen_values
+        global_config.allow_mutable_automata = self.orig_allow_mutable_automata
 
     @patch('automata.fa.dfa.DFA.validate')
     def test_disable_validation(self, validate):
@@ -30,7 +30,7 @@ class TestConfig(unittest.TestCase):
     @patch('automata.base.utils.freezeValue')
     def test_disable_ensure_values_are_frozen(self, validate):
         """Should disable the call to freezeValue"""
-        global_config.ensure_frozen_values = False
+        global_config.allow_mutable_automata = True
         dfa = DFA(
             states=frozenset(['s1']),
             input_symbols=frozenset('a'),
@@ -53,7 +53,7 @@ class TestConfig(unittest.TestCase):
     def test_values_are_frozen(self):
         """Should freeze the values"""
         automata.base.utils.freezeValue = MagicMock(wraps=automata.base.utils.freezeValue)
-        global_config.ensure_frozen_values = True
+        global_config.allow_mutable_automata = False
         dfa = DFA(
             states={'s1'},
             input_symbols={'a'},


### PR DESCRIPTION
This commit speeds up the freezeValue method, which is the main bottleneck of automata creation. There are two optimizations:

* Move the most frequent types up the if chain to hit it as early as possible
* Offer the option to disable the freezeValue call completely (the user must guarantee that the values are frozen or accept that the library might break)

When benchmarking the creation of an automata accepting the language a*, we see that disabling the freezeValue call yields a speedup of 3 times if the values are not frozen and 2 times if the values are frozen.

The small overhead introduced by checking the ensure_frozen flag is compensated by the reordering of if statements