### PR TITLE
Resolve retain names issue

### DIFF
--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -23,6 +23,26 @@ def freeze_value(value):
         return tuple(freeze_value(element) for element in value)
     return value
 
+def get_renaming_function(counter):
+    """
+    A helper function that returns a renaming function to be used in the creation of
+    other automata. The parameter counter should be an itertools count.
+    This helper function will return the same distinct output taken from counter
+    for each distinct input.
+    """
+
+    new_state_name_dict = {}
+
+    def renaming_function(item):
+        nonlocal new_state_name_dict
+        if item in new_state_name_dict:
+            return new_state_name_dict[item]
+
+        return new_state_name_dict.setdefault(item, next(counter))
+
+    return renaming_function
+
+
 
 class PartitionRefinement:
     """Maintain and refine a partition of a set of items into subsets.

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -23,6 +23,7 @@ def freeze_value(value):
         return tuple(freeze_value(element) for element in value)
     return value
 
+
 def get_renaming_function(counter):
     """
     A helper function that returns a renaming function to be used in the creation of
@@ -41,7 +42,6 @@ def get_renaming_function(counter):
         return new_state_name_dict.setdefault(item, next(counter))
 
     return renaming_function
-
 
 
 class PartitionRefinement:

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -35,7 +35,6 @@ def get_renaming_function(counter):
     new_state_name_dict = {}
 
     def renaming_function(item):
-        nonlocal new_state_name_dict
         if item in new_state_name_dict:
             return new_state_name_dict[item]
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -384,8 +384,12 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states or q_b in other.final_states
 
-        new_states, new_transitions, new_initial_state, new_final_states = \
-            self._cross_product(other, union_function, should_construct_dfa=True, retain_names=retain_names)
+        new_states, new_transitions, new_initial_state, new_final_states = self._cross_product(
+            other,
+            union_function,
+            should_construct_dfa=True,
+            retain_names=retain_names
+        )
 
         if minify:
             return self._minify(
@@ -415,8 +419,12 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b in other.final_states
 
-        new_states, new_transitions, new_initial_state, new_final_states = \
-            self._cross_product(other, intersection_function, should_construct_dfa=True, retain_names=retain_names)
+        new_states, new_transitions, new_initial_state, new_final_states = self._cross_product(
+            other,
+            intersection_function,
+            should_construct_dfa=True,
+            retain_names=retain_names
+        )
 
         if minify:
             return self._minify(
@@ -446,8 +454,12 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b not in other.final_states
 
-        new_states, new_transitions, new_initial_state, new_final_states = \
-            self._cross_product(other, difference_function, should_construct_dfa=True, retain_names=retain_names)
+        new_states, new_transitions, new_initial_state, new_final_states = self._cross_product(
+            other,
+            difference_function,
+            should_construct_dfa=True,
+            retain_names=retain_names
+        )
 
         if minify:
             return self._minify(
@@ -477,9 +489,12 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return (q_a in self.final_states) ^ (q_b in other.final_states)
 
-
-        new_states, new_transitions, new_initial_state, new_final_states = \
-            self._cross_product(other, symmetric_difference_function, should_construct_dfa=True, retain_names=retain_names)
+        new_states, new_transitions, new_initial_state, new_final_states = self._cross_product(
+            other,
+            symmetric_difference_function,
+            should_construct_dfa=True,
+            retain_names=retain_names
+        )
 
         if minify:
             return self._minify(
@@ -565,7 +580,7 @@ class DFA(fa.FA):
             # Get next state in BFS queue
             curr_state = queue.popleft()
 
-            # Add state to the transition dict
+            # Add state to the transition dict if constructing DFA
             if should_construct_dfa:
                 curr_state_name = get_name(curr_state)
                 state_transitions = product_transitions.setdefault(curr_state_name, {})
@@ -573,6 +588,7 @@ class DFA(fa.FA):
                 if state_target_fn(curr_state):
                     final_states.add(curr_state_name)
 
+            # Otherwise, just check the target function
             elif state_target_fn(curr_state):
                 return True
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -10,7 +10,7 @@ from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
-from automata.base.utils import PartitionRefinement
+from automata.base.utils import get_renaming_function, PartitionRefinement
 
 
 class DFA(fa.FA):
@@ -552,17 +552,10 @@ class DFA(fa.FA):
         if self.input_symbols != other.input_symbols:
             raise exceptions.SymbolMismatchError('The input symbols between the two given DFAs do not match')
 
-        new_state_name_dict = {}
-        state_name_counter = count(0)
-
-        def get_name_renamed(state):
-            nonlocal state_name_counter, new_state_name_dict
-            return new_state_name_dict.setdefault(state, next(state_name_counter))
-
         def get_name_original(state):
             return state
 
-        get_name = get_name_original if retain_names else get_name_renamed
+        get_name = get_name_original if retain_names else get_renaming_function(count(0))
 
         product_transitions = {} if should_construct_dfa else None
         final_states = set() if should_construct_dfa else None
@@ -1231,17 +1224,11 @@ class DFA(fa.FA):
     def from_nfa(cls, target_nfa, *, retain_names=False, minify=True):
         """Initialize this DFA as one equivalent to the given NFA."""
         # Data structures for state renaming
-        new_state_name_dict = {}
-        state_name_counter = count(0)
 
-        def get_name_renamed(states):
-            nonlocal state_name_counter, new_state_name_dict
-            return new_state_name_dict.setdefault(states, next(state_name_counter))
+        def get_name_original(state):
+            return state
 
-        def get_name_original(states):
-            return states
-
-        get_name = get_name_original if retain_names else get_name_renamed
+        get_name = get_name_original if retain_names else get_renaming_function(count(0))
 
         # equivalent DFA states states
         nfa_initial_states = frozenset(target_nfa._lambda_closures[target_nfa.initial_state])

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1225,8 +1225,8 @@ class DFA(fa.FA):
         """Initialize this DFA as one equivalent to the given NFA."""
         # Data structures for state renaming
 
-        def get_name_original(state):
-            return state
+        def get_name_original(states):
+            return states
 
         get_name = get_name_original if retain_names else get_renaming_function(count(0))
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -10,7 +10,7 @@ from pydot import Dot, Edge, Node
 
 import automata.base.exceptions as exceptions
 import automata.fa.fa as fa
-from automata.base.utils import get_renaming_function, PartitionRefinement
+from automata.base.utils import PartitionRefinement, get_renaming_function
 
 
 class DFA(fa.FA):

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -666,7 +666,7 @@ class NFA(fa.FA):
             # Add lambda transition from final state, flipping third entry to true
             if q_b in other_reachable_final_states:
                 state_dict = new_transitions.setdefault(curr_state, {})
-                state_dict.setdefault('', set()).update({(q_a, q_b, True)})
+                state_dict.setdefault('', set()).add((q_a, q_b, True))
 
         # Populate transitions for after reading the prefix
         for state_a, state_b in product(self_reachable_states, other_reachable_final_states):

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -4,12 +4,12 @@
 from collections import deque
 from itertools import chain, count, product, zip_longest
 
+from automata.base.utils import get_renaming_function
 from automata.regex.lexer import Lexer
 from automata.regex.postfix import (InfixOperator, LeftParen, Literal,
                                     PostfixOperator, RightParen,
                                     parse_postfix_tokens, tokens_to_postfix,
                                     validate_tokens)
-from automata.base.utils import get_renaming_function
 
 RESERVED_CHARACTERS = frozenset({'*', '|', '(', ')', '?', ' ', '\t', '&', '+', '.', '^'})
 

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -9,6 +9,7 @@ from automata.regex.postfix import (InfixOperator, LeftParen, Literal,
                                     PostfixOperator, RightParen,
                                     parse_postfix_tokens, tokens_to_postfix,
                                     validate_tokens)
+from automata.base.utils import get_renaming_function
 
 RESERVED_CHARACTERS = frozenset({'*', '|', '(', ')', '?', ' ', '\t', '&', '+', '.', '^'})
 
@@ -93,10 +94,8 @@ class NFARegexBuilder:
         Apply the intersection operation to the NFA represented by this builder and other.
         Use BFS to only traverse reachable part (keeps number of states down).
         """
-        new_state_name_dict = {}
 
-        def get_state_name(state_name):
-            return new_state_name_dict.setdefault(state_name, self.__get_next_state_name())
+        get_state_name = get_renaming_function(self._state_name_counter)
 
         new_final_states = set()
         new_transitions = {}
@@ -220,10 +219,8 @@ class NFARegexBuilder:
         Apply the shuffle operation to the NFA represented by this builder and other.
         No need for BFS since all states are accessible.
         """
-        new_state_name_dict = {}
 
-        def get_state_name(state_name):
-            return new_state_name_dict.setdefault(state_name, self.__get_next_state_name())
+        get_state_name = get_renaming_function(self._state_name_counter)
 
         self._initial_state = get_state_name((self._initial_state, other._initial_state))
 

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -399,6 +399,9 @@ class TestDFA(test_fa.TestFA):
             ('q4', 'p0'), ('q4', 'p1'), ('q4', 'p2')
         })
 
+        # Test retain names logic without minify
+        self.assertEqual(dfa1.union(dfa2, retain_names=False, minify=False), new_dfa)
+
     def test_intersection(self):
         """Should compute the intersection between two DFAs"""
         # This DFA accepts all words which contain at least four
@@ -457,6 +460,9 @@ class TestDFA(test_fa.TestFA):
             ('q4', 'p0'), ('q4', 'p1'),
         })
 
+        # Test retain names logic without minify
+        self.assertEqual(dfa1.intersection(dfa2, retain_names=False, minify=False), new_dfa)
+
     def test_difference(self):
         """Should compute the difference between two DFAs"""
         # This DFA accepts all words which contain at least four
@@ -514,6 +520,9 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(new_dfa.final_states, {
              ('q4', 'p2')
         })
+
+        # Test retain names logic without minify
+        self.assertEqual(dfa1.difference(dfa2, retain_names=False, minify=False), new_dfa)
 
     def test_symmetric_difference(self):
         """Should compute the symmetric difference between two DFAs"""
@@ -576,6 +585,9 @@ class TestDFA(test_fa.TestFA):
             ('q3', 'p0'), ('q3', 'p1'),
             ('q4', 'p2')
         })
+
+        # Test retain names logic without minify
+        self.assertEqual(dfa1.symmetric_difference(dfa2, retain_names=False, minify=False), new_dfa)
 
     def test_issubset(self):
         """Should test if one DFA is a subset of another"""


### PR DESCRIPTION
Add retain names functionality to cross product. Resolves an inconsistency with expected behavior and should improve efficiency of minify function.

EDIT: Don't merge yet, just found a really dumb subtle bug in here. This also needs to wait until the shuffle product PR is merged, since that issue is present there as well (not a breaking bug).