### PR TITLE
Removed NFA._from_symbol method

### DIFF
--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -106,24 +106,6 @@ class NFA(fa.FA):
                         start_state, input_symbol))
 
     @classmethod
-    def _from_symbol(cls, symbol, input_symbols=None):
-        """Generate NFA from single symbol, `input symbols` may be passed to initialize input_symbols for NFA"""
-        states = {0, 1}
-        initial_state = 0
-        if input_symbols is None:
-            input_symbols = {symbol}
-        transitions = {0: {symbol: {1}}}
-        final_states = {1}
-
-        return cls(
-            states=states,
-            input_symbols=input_symbols,
-            initial_state=initial_state,
-            transitions=transitions,
-            final_states=final_states
-        )
-
-    @classmethod
     def from_regex(cls, regex, *, input_symbols=None):
         """Initialize this NFA as one equivalent to the given regular expression"""
 

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -577,44 +577,6 @@ class TestNFA(test_fa.TestFA):
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'a(*)')
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, 'ab(|)')
 
-    def test_from_symbol(self):
-        """Should generate NFA from single transition symbol"""
-
-        nfa1 = NFA._from_symbol('a')
-
-        nfa2 = NFA(
-            states={0, 1},
-            input_symbols={'a'},
-            initial_state=0,
-            transitions={0: {'a': {1}}},
-            final_states={1}
-        )
-
-        self.assertEqual(nfa1.states, nfa2.states)
-        self.assertEqual(nfa1.initial_state, nfa2.initial_state)
-        self.assertEqual(nfa1.transitions, nfa2.transitions)
-        self.assertEqual(nfa1.final_states, nfa2.final_states)
-        self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
-
-    def test_from_symbol_input_symbols(self):
-        """Should generate NFA from single transition symbol"""
-
-        nfa1 = NFA._from_symbol('a', input_symbols={'a', 'b'})
-
-        nfa2 = NFA(
-            states={0, 1},
-            input_symbols={'a', 'b'},
-            initial_state=0,
-            transitions={0: {'a': {1}}},
-            final_states={1}
-        )
-
-        self.assertEqual(nfa1.states, nfa2.states)
-        self.assertEqual(nfa1.initial_state, nfa2.initial_state)
-        self.assertEqual(nfa1.transitions, nfa2.transitions)
-        self.assertEqual(nfa1.final_states, nfa2.final_states)
-        self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
-
     def test_show_diagram_initial_final_same(self):
         """
         Should construct the diagram for a NFA whose initial state


### PR DESCRIPTION
@caleb531 The NFA `_from_symbol` function was only being used as part of the old regex parsing algorithm and the functionality was a less general version of what's currently available with the DFA `from_finite_language` function. This PR removes `_from_symbol`.

As an aside, it _could_ be worth adding some NFA construction algorithms, but if we do then they should be more general than this function was.