### PR TITLE
Support for pickling of finite automata

### DIFF
--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -33,11 +33,17 @@ class Automaton(metaclass=abc.ABCMeta):
 
     def __setattr__(self, name, value):
         """Set custom setattr to make class immutable."""
-        raise AttributeError(f'This {type(self).__name__} is immutable')
+        if global_config.allow_mutable_automata:
+            object.__setattr__(self, name, value)
+        else:
+            raise AttributeError(f'This {type(self).__name__} is immutable')
 
     def __delattr__(self, name):
         """Set custom delattr to make class immutable."""
-        raise AttributeError(f'This {type(self).__name__} is immutable')
+        if global_config.allow_mutable_automata:
+            object.__delattr__(self, name)
+        else:
+            raise AttributeError(f'This {type(self).__name__} is immutable')
 
     @abc.abstractmethod
     def read_input_stepwise(self, input_str):

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -33,17 +33,17 @@ class Automaton(metaclass=abc.ABCMeta):
 
     def __setattr__(self, name, value):
         """Set custom setattr to make class immutable."""
-        if global_config.allow_mutable_automata:
-            object.__setattr__(self, name, value)
-        else:
-            raise AttributeError(f'This {type(self).__name__} is immutable')
+        raise AttributeError(f'This {type(self).__name__} is immutable')
 
     def __delattr__(self, name):
         """Set custom delattr to make class immutable."""
-        if global_config.allow_mutable_automata:
-            object.__delattr__(self, name)
-        else:
-            raise AttributeError(f'This {type(self).__name__} is immutable')
+        raise AttributeError(f'This {type(self).__name__} is immutable')
+
+    def __getstate__(self):
+        return self.input_parameters
+
+    def __setstate__(self, d):
+        self.__init__(**d)
 
     @abc.abstractmethod
     def read_input_stepwise(self, input_str):

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -40,9 +40,13 @@ class Automaton(metaclass=abc.ABCMeta):
         raise AttributeError(f'This {type(self).__name__} is immutable')
 
     def __getstate__(self):
+        """Return the object's state, described by its input parameters"""
         return self.input_parameters
 
     def __setstate__(self, d):
+        """Restore the object state from its input parameters"""
+        # Notice that the default __setstate__ method won't work
+        #   because __setattr__ is disabled due to immutability
         self.__init__(**d)
 
     @abc.abstractmethod

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -13,11 +13,13 @@ class TestSerialization(test_fa.TestFA):
     """
 
     def test_serialize_dfa(self):
+        """Should convert a DFA to pickle serialization and reads it back"""
         s = pickle.dumps(self.dfa)
         dfa = pickle.loads(s)
         self.assertEqual(self.dfa, dfa)
 
     def test_serialize_nfa(self):
+        """Should convert a NFA to pickled representation and read it back"""
         s = pickle.dumps(self.nfa)
         nfa = pickle.loads(s)
         self.assertEqual(self.nfa, nfa)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Tests for automata pickle serialization"""
+
+import pickle
+
+import tests.test_fa as test_fa
+
+
+class TestSerialization(test_fa.TestFA):
+    """
+    This tests verifies that the cycle FA -> .pkl -> FA works.
+    The test only applies to DFA and NFAs as other classes do not implement equality
+    """
+
+    def test_serialize_dfa(self):
+        s = pickle.dumps(self.dfa)
+        dfa = pickle.loads(s)
+        self.assertEqual(self.dfa, dfa)
+
+    def test_serialize_nfa(self):
+        s = pickle.dumps(self.nfa)
+        nfa = pickle.loads(s)
+        self.assertEqual(self.nfa, nfa)


### PR DESCRIPTION
The initial use-case that I stumbled upon was to serialize DFAs with pickle. I would get an error because it was calling __setattr__, which is disabled even though I was setting the `allow_mutable_automata` flag.

If we allow for mutable automata, then one should be able to modify its attributes.

```python
global_config.allow_mutable_automata = True
dfa_1 = DFA(
    states={0, 1},
    input_symbols={0, 1},
    transitions={0: {0: 1, 1: 0}, 1: {0: 1, 1: 1}},
    initial_state=0,
    final_states={1},
)

with open('dfa.pkl', 'wb') as f:
    pickle.dump(dfa_1, f)
with open('dfa.pkl', 'rb') as f:
    dfa_1_read = pickle.load(f)
assert dfa_1 == dfa_1_read
```

**Edit:** After some consideration, I decided to disable set/get attributes as this will mess with the `validate` function. Instead serialization is implemented directly with the setattribute/getattribute functions