### PR TITLE
Regex empty string

### DIFF
--- a/automata/regex/postfix.py
+++ b/automata/regex/postfix.py
@@ -103,7 +103,7 @@ def validate_tokens(token_list: List[Token]) -> None:
         # No left parens right before infix or postfix operators, or right
         # before a right paren
         elif isinstance(prev_token, LeftParen):
-            if isinstance(curr_token, (InfixOperator, PostfixOperator, RightParen)):
+            if isinstance(curr_token, (InfixOperator, PostfixOperator)):
                 raise exceptions.InvalidRegexError(
                     f"'{prev_token}' cannot appear immediately before '{curr_token}'."
                 )

--- a/automata/regex/regex.py
+++ b/automata/regex/regex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Methods for working with regular expressions"""
 
+from itertools import count
 from typing import AbstractSet, Literal, Optional
 
 import automata.base.exceptions as exceptions
@@ -23,7 +24,7 @@ def validate(regex: str) -> Literal[True]:
     """Raise an error if the regular expression is invalid"""
     input_symbols = set(regex) - RESERVED_CHARACTERS
 
-    validate_tokens(get_regex_lexer(input_symbols).lex(regex))
+    validate_tokens(get_regex_lexer(input_symbols, count(0)).lex(regex))
 
     return True
 

--- a/docs/regular-expressions.md
+++ b/docs/regular-expressions.md
@@ -16,8 +16,9 @@ A regular expression with the following operations only are supported in this li
 - `&`: Intersection. Ex: `a&b`
 - `.`: Wildcard. Ex: `a.b`
 - `^`: Shuffle. Ex: `a^b`
-- `{}` : Quantifiers expressing finite repetitions. Ex: `a{1,2}`,`a{3,}`
-- `()`: Grouping.
+- `{}`: Quantifiers expressing finite repetitions. Ex: `a{1,2}`,`a{3,}`
+- `()`: The empty string.
+- `(...)`: Grouping.
 
 This is similar to the Python `re` module, but this library does not support any special
 characters other than those given above. All regular languages can be written with these.

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -571,7 +571,6 @@ class TestNFA(test_fa.TestFA):
             exceptions.InvalidRegexError, NFA.from_regex, "((abc*)))((abd)"
         )
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "*")
-        self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "abcd()")
         self.assertRaises(
             exceptions.InvalidRegexError, NFA.from_regex, "ab(bc)*((bbcd)"
         )

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -207,6 +207,7 @@ class TestRegex(unittest.TestCase):
         self.assertTrue(re.isequal("()", ""))
         self.assertTrue(re.isequal("a|()", "a?"))
         self.assertTrue(re.isequal("a()", "a"))
+        self.assertTrue(re.isequal("a()b()()c()", "abc"))
 
     def test_invalid_symbols(self):
         """Should throw exception if reserved character is in input symbols"""

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -26,7 +26,6 @@ class TestRegex(unittest.TestCase):
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "a||b")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "((abc*)))((abd)")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "*")
-        self.assertRaises(exceptions.InvalidRegexError, re.validate, "abcd()")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "ab(bc)*((bbcd)")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "a(*)")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "a(|)")
@@ -202,6 +201,12 @@ class TestRegex(unittest.TestCase):
                 "(aa|bb^ca|cb){1,}", "(aa|bb^ca|cb)+", input_symbols=input_symbols
             )
         )
+
+    def test_blank(self):
+        """Should correctly parse blank"""
+        self.assertTrue(re.isequal("()", ""))
+        self.assertTrue(re.isequal("a|()", "a?"))
+        self.assertTrue(re.isequal("a()", "a"))
 
     def test_invalid_symbols(self):
         """Should throw exception if reserved character is in input symbols"""


### PR DESCRIPTION
Added empty string to regex with `()`. Resolves #128.