### PR TITLE
Refactor *Stack / *Configuration classes to be dataclass-based

### DIFF
--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -21,9 +21,3 @@ class PDAConfiguration:
     state: AutomatonStateT
     remaining_input: str
     stack: PDAStack
-
-    def __repr__(self) -> str:
-        """Return a string representation of the configuration."""
-        return "{}(state='{}', remaining_input='{}', stack={})".format(
-            self.__class__.__name__, self.state, self.remaining_input, self.stack
-        )

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Classes and methods for working with PDA configurations."""
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from automata.base.automaton import AutomatonStateT
 from automata.pda.stack import PDAStack
 
 
-class PDAConfiguration(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class PDAConfiguration:
     """
     A configuration is a triple of current state, remaining input and stack.
 
@@ -21,6 +22,6 @@ class PDAConfiguration(NamedTuple):
 
     def __repr__(self) -> str:
         """Return a string representation of the configuration."""
-        return "{}('{}', '{}', {})".format(
+        return "{}(state='{}', remaining_input='{}', stack={})".format(
             self.__class__.__name__, self.state, self.remaining_input, self.stack
         )

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -7,7 +7,7 @@ from automata.base.automaton import AutomatonStateT
 from automata.pda.stack import PDAStack
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class PDAConfiguration:
     """
     A configuration is a triple of current state, remaining input and stack.
@@ -15,6 +15,8 @@ class PDAConfiguration:
     It represents the complete runtime state of a PDA.
     It is hashable and immutable.
     """
+
+    __slots__ = ("state", "remaining_input", "stack")
 
     state: AutomatonStateT
     remaining_input: str

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -113,7 +113,9 @@ class DPDA(pda.PDA):
         if not self._has_accepted(current_configuration):
             raise exceptions.RejectionException(
                 "the DPDA stopped in a non-accepting configuration "
-                "({state}, {stack})".format(**current_configuration._asdict())
+                "({}, {})".format(
+                    current_configuration.state, current_configuration.stack
+                )
             )
 
     def _get_next_configuration(self, old_config: PDAConfiguration) -> PDAConfiguration:

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -2,19 +2,18 @@
 """Classes and methods for working with PDA stacks."""
 from __future__ import annotations
 
-import collections
+from dataclasses import dataclass
 from typing import Iterator, Sequence, Tuple
 
 
-class PDAStack(collections.namedtuple("PDAStack", ["stack"])):
+@dataclass(frozen=True, slots=True)
+class PDAStack:
     """A PDA stack."""
 
     stack: Tuple[str, ...]
 
-    # TODO can we get rid of this? Kinda weird inheritance here
-    def __new__(cls, elements: Sequence[str]):
-        """Create the new PDA stack."""
-        return super(PDAStack, cls).__new__(cls, tuple(elements))
+    def __init__(self, elements: Sequence[str]):
+        object.__setattr__(self, "stack", tuple(elements))
 
     def top(self) -> str:
         """Return the symbol at the top of the stack."""
@@ -50,4 +49,4 @@ class PDAStack(collections.namedtuple("PDAStack", ["stack"])):
 
     def __repr__(self) -> str:
         """Return a string representation of the stack."""
-        return "{}{}".format(self.__class__.__name__, self.stack)
+        return "{}({})".format(self.__class__.__name__, self.stack)

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -6,9 +6,11 @@ from dataclasses import dataclass
 from typing import Iterator, Sequence, Tuple
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class PDAStack:
     """A PDA stack."""
+
+    __slots__ = ("stack",)
 
     stack: Tuple[str, ...]
 

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -14,8 +14,8 @@ class PDAStack:
 
     stack: Tuple[str, ...]
 
-    def __init__(self, elements: Sequence[str]):
-        object.__setattr__(self, "stack", tuple(elements))
+    def __init__(self, stack: Sequence[str]):
+        object.__setattr__(self, "stack", tuple(stack))
 
     def top(self) -> str:
         """Return the symbol at the top of the stack."""

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -14,7 +14,7 @@ class PDAStack:
 
     stack: Tuple[str, ...]
 
-    def __init__(self, stack: Sequence[str]):
+    def __init__(self, stack: Sequence[str]) -> None:
         object.__setattr__(self, "stack", tuple(stack))
 
     def top(self) -> str:

--- a/automata/tm/configuration.py
+++ b/automata/tm/configuration.py
@@ -8,9 +8,11 @@ from automata.tm.tape import TMTape
 from automata.tm.tm import TMStateT
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class TMConfiguration:
     """A Turing machine configuration."""
+
+    __slots__ = ("state", "tape")
 
     state: TMStateT
     tape: TMTape
@@ -32,9 +34,11 @@ class TMConfiguration:
         )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class MTMConfiguration:
     """A Multitape Turing machine configuration."""
+
+    __slots__ = ("state", "tapes")
 
     state: TMStateT
     tapes: List[TMTape]

--- a/automata/tm/configuration.py
+++ b/automata/tm/configuration.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Classes and methods for working with Turing machine configurations."""
 
-from typing import List, NamedTuple
+from dataclasses import dataclass
+from typing import List
 
 from automata.tm.tape import TMTape
 from automata.tm.tm import TMStateT
 
 
-class TMConfiguration(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class TMConfiguration:
     """A Turing machine configuration."""
 
     state: TMStateT
@@ -30,7 +32,8 @@ class TMConfiguration(NamedTuple):
         )
 
 
-class MTMConfiguration(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class MTMConfiguration:
     """A Multitape Turing machine configuration."""
 
     state: TMStateT

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Classes and methods for working with Turing machine tapes."""
 
-import collections
+from dataclasses import dataclass
 from typing import Iterator, Sequence, Tuple
 
 from typing_extensions import Self
@@ -9,25 +9,27 @@ from typing_extensions import Self
 from automata.tm.tm import TMDirectionT
 
 
-class TMTape(
-    collections.namedtuple("TMTape", ["tape", "blank_symbol", "current_position"])
-):
+@dataclass(frozen=True)
+class TMTape:
     """A Turing machine tape."""
+
+    __slots__ = ("tape", "blank_symbol", "current_position")
 
     tape: Tuple[str]
     blank_symbol: str
     current_position: int
 
-    def __new__(
-        cls, tape: Sequence[str], *, blank_symbol: str, current_position: int = 0
+    def __init__(
+        self, tape: Sequence[str], *, blank_symbol: str, current_position: int = 0
     ):
         """Initialize a new Turing machine tape."""
         tape = list(tape)
         # Make sure that there's something under the cursor.
         while len(tape) <= current_position:
             tape.append(blank_symbol)
-        tape = tuple(tape)
-        return super(TMTape, cls).__new__(cls, tape, blank_symbol, current_position)
+        object.__setattr__(self, "tape", tuple(tape))
+        object.__setattr__(self, "blank_symbol", blank_symbol)
+        object.__setattr__(self, "current_position", current_position)
 
     def read_symbol(self) -> str:
         """Read the symbol at the current position in the tape."""

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -21,7 +21,7 @@ class TMTape:
 
     def __init__(
         self, tape: Sequence[str], *, blank_symbol: str, current_position: int = 0
-    ):
+    ) -> None:
         """Initialize a new Turing machine tape."""
         tape = list(tape)
         # Make sure that there's something under the cursor.

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -265,24 +265,24 @@ class TestDTM(test_tm.TestTM):
     def test_read_input_accepted(self):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.dtm1.read_input("00001111")
-        self.assertEqual(final_config[0], "q4")
-        self.assertEqual(str(final_config[1]), "TMTape('xxxxyyyy..', 9)")
+        self.assertEqual(final_config.state, "q4")
+        self.assertEqual(str(final_config.tape), "TMTape('xxxxyyyy..', 9)")
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
         validation_generator = self.dtm1.read_input_stepwise("00001111")
         self.assertIsInstance(validation_generator, types.GeneratorType)
         configs = list(validation_generator)
-        self.assertEqual(configs[0][0], "q0")
-        self.assertEqual(str(configs[0][1]), "TMTape('00001111', 0)")
-        self.assertEqual(configs[-1][0], "q4")
-        self.assertEqual(str(configs[-1][1]), "TMTape('xxxxyyyy..', 9)")
+        self.assertEqual(configs[0].state, "q0")
+        self.assertEqual(str(configs[0].tape), "TMTape('00001111', 0)")
+        self.assertEqual(configs[-1].state, "q4")
+        self.assertEqual(str(configs[-1].tape), "TMTape('xxxxyyyy..', 9)")
 
     def test_read_input_offset(self):
         """Should valdiate input when tape is offset."""
         final_config = self.dtm2.read_input("01010101")
-        self.assertEqual(final_config[0], "q4")
-        self.assertEqual(str(final_config[1]), "TMTape('yyx1010101', 3)")
+        self.assertEqual(final_config.state, "q4")
+        self.assertEqual(str(final_config.tape), "TMTape('yyx1010101', 3)")
 
     def test_read_input_rejection(self):
         """Should raise error if the machine halts."""

--- a/tests/test_mntm.py
+++ b/tests/test_mntm.py
@@ -385,11 +385,13 @@ class TestMNTM(test_tm.TestTM):
         validation_generator = self.mntm2.read_input_as_ntm("#0000")
         configs = list(validation_generator)
         first_config = configs[0].pop()
-        self.assertEqual(first_config[0], "q-1")
-        self.assertEqual(str(first_config[1]), "TMTape('#^0000_#^_#^_', 0)")
+        self.assertEqual(first_config.state, "q-1")
+        self.assertEqual(str(first_config.tape), "TMTape('#^0000_#^_#^_', 0)")
         last_config = configs[-1].pop()
-        self.assertEqual(last_config[0], "qf")
-        self.assertEqual(str(last_config[1]), "TMTape('#0000#^_#0000#^_#XYYY#^_', 23)")
+        self.assertEqual(last_config.state, "qf")
+        self.assertEqual(
+            str(last_config.tape), "TMTape('#0000#^_#0000#^_#XYYY#^_', 23)"
+        )
 
         with self.assertRaises(exceptions.RejectionException):
             for _ in self.mntm2.read_input_as_ntm("#00"):
@@ -398,9 +400,9 @@ class TestMNTM(test_tm.TestTM):
     def test_read_input_accepted(self):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.mntm1.read_input("0101101011").pop()
-        self.assertEqual(final_config[0], "q1")
-        self.assertEqual(str(final_config[1][0]), "TMTape('0101101011#', 10)")
-        self.assertEqual(str(final_config[1][1]), "TMTape('111111#', 6)")
+        self.assertEqual(final_config.state, "q1")
+        self.assertEqual(str(final_config.tapes[0]), "TMTape('0101101011#', 10)")
+        self.assertEqual(str(final_config.tapes[1]), "TMTape('111111#', 6)")
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
@@ -408,13 +410,13 @@ class TestMNTM(test_tm.TestTM):
         self.assertIsInstance(validation_generator, types.GeneratorType)
         configs = list(validation_generator)
         first_config = configs[0].pop()
-        self.assertEqual(first_config[0], "q0")
-        self.assertEqual(str(first_config[1][0]), "TMTape('0010101111', 0)")
-        self.assertEqual(str(first_config[1][1]), "TMTape('#', 0)")
+        self.assertEqual(first_config.state, "q0")
+        self.assertEqual(str(first_config.tapes[0]), "TMTape('0010101111', 0)")
+        self.assertEqual(str(first_config.tapes[1]), "TMTape('#', 0)")
         last_config = configs[-1].pop()
-        self.assertEqual(last_config[0], "q1")
-        self.assertEqual(str(last_config[1][0]), "TMTape('0010101111#', 10)")
-        self.assertEqual(str(last_config[1][1]), "TMTape('111111#', 6)")
+        self.assertEqual(last_config.state, "q1")
+        self.assertEqual(str(last_config.tapes[0]), "TMTape('0010101111#', 10)")
+        self.assertEqual(str(last_config.tapes[1]), "TMTape('111111#', 6)")
 
     def test_read_input_rejection(self):
         """Should raise error if the machine halts."""

--- a/tests/test_ntm.py
+++ b/tests/test_ntm.py
@@ -250,8 +250,8 @@ class TestNTM(test_tm.TestTM):
     def test_read_input_accepted(self):
         """Should return correct state if acceptable TM input is given."""
         final_config = self.ntm1.read_input("00120001111").pop()
-        self.assertEqual(final_config[0], "q3")
-        self.assertEqual(str(final_config[1]), "TMTape('00120001111.', 11)")
+        self.assertEqual(final_config.state, "q3")
+        self.assertEqual(str(final_config.tape), "TMTape('00120001111.', 11)")
 
     def test_read_input_step(self):
         """Should return validation generator if step flag is supplied."""
@@ -259,11 +259,11 @@ class TestNTM(test_tm.TestTM):
         self.assertIsInstance(validation_generator, types.GeneratorType)
         configs = list(validation_generator)
         first_config = configs[0].pop()
-        self.assertEqual(first_config[0], "q0")
-        self.assertEqual(str(first_config[1]), "TMTape('00120001111', 0)")
+        self.assertEqual(first_config.state, "q0")
+        self.assertEqual(str(first_config.tape), "TMTape('00120001111', 0)")
         last_config = configs[-1].pop()
-        self.assertEqual(last_config[0], "q3")
-        self.assertEqual(str(last_config[1]), "TMTape('00120001111.', 11)")
+        self.assertEqual(last_config.state, "q3")
+        self.assertEqual(str(last_config.tape), "TMTape('00120001111.', 11)")
 
     def test_read_input_rejection(self):
         """Should raise error if the machine halts."""

--- a/tests/test_pdaconfiguration.py
+++ b/tests/test_pdaconfiguration.py
@@ -10,8 +10,9 @@ class TestPDAConfiguration(test_pda.TestPDA):
     """A test class for testing configurations of pushdown automata."""
 
     def test_config_repr(self):
-        """Should create proper string representation of PDA stack."""
+        """Should create proper string representation of PDA configuration."""
         config = PDAConfiguration("q0", "ab", PDAStack(["a", "b"]))
         self.assertEqual(
-            repr(config), "PDAConfiguration('q0', 'ab', PDAStack('a', 'b'))"
+            repr(config),
+            "PDAConfiguration(state='q0', remaining_input='ab', stack=PDAStack(('a', 'b')))",  # noqa
         )

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -15,4 +15,4 @@ class TestPDAStack(test_pda.TestPDA):
     def test_stack_repr(self):
         """Should create proper string representation of PDA stack."""
         stack = PDAStack(["a", "b"])
-        self.assertEqual(repr(stack), "PDAStack('a', 'b')")
+        self.assertEqual(repr(stack), "PDAStack(('a', 'b'))")


### PR DESCRIPTION
@eliotwrobson Alright, here's my attempt to refactor the PDAStack and `*Configuration` classes to use dataclasses instead of namedtuple inheritance. 

## Regarding the PDAStack class

### The return of tuple conversion

I decided to keep the casting to a tuple on instantiation because I felt it was more consistent with the type-casting we are performing currently for the automaton subclasses. Plus, it is just easier to work with because I don't have to remember to explicitly pass a tuple to the constructor

### Inheriting from `Tuple`?

As I was looking at the `PDAStack` class, I was noticing how the `PDAStack` is basically a glorified wrapper for the `stack` tuple underneath. Semantically, they represent the same thing, with no difference in data but only difference in behavior. Therefore, I was thinking: maybe we could just inherit directly from `Tuple[str, ...]`, which would eliminate the redeclaration of `__len__`, give us indexing for free, and just feel less redundant.

For example, if you wanted to create a PDAStack and access its elements, you currently have to write something like:

```python
pda_stack = PDAStack(('a', 'b', 'c'))
print(pda_stack.stack[0])  # the property access here makes the semantics feel a little redundant
```

Versus if we inherit directly from `Tuple`:

```python
stack = PDAStack(('a', 'b', 'c'))
print(stack[0])
```

Now, I suppose we could solve the semantics issue somewhat by renaming the `stack` attribute to something like `elements` (hence, the first example can become something like `stack.elements[0]`. But I would argue this is still redundant, since a `PDAStack` stores no additional data members than an actual `tuple`.

Compare this to a `PDAConfiguration` instance, which stores multiple data members and therefore cannot be simplified any further (i.e. its existence is more justified), at least not without losing the labelling of fields and such. But it just seems like the only benefit to using a `PDAStack` as opposed to a regular tuple is the additional behavior provided via new methods.

## Regarding the *Configuration classes

I've also `PDAConfiguration`, `TMConfiguration`, and `MTMConfiguration` classes to be proper dataclasses instead of named tuples. The side effect of doing this is that we can no longer access the members of the object using integer-based indexing (which apparently I was relying on in my tests). I actually like this, since I think attribute names are less ambiguous anyway, so I updated my tests accordingly (e.g. `config.remaining_input` instead of `config[1]`).

## What about the TMTape class?

Totally forgot about this. Will get to this later or in a separate PR.