### PR TITLE
Start adding type hints to test cases

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -821,7 +821,7 @@ class DFA(fa.FA):
 
     def successor(
         self,
-        input_str: str,
+        input_str: Optional[str],
         *,
         strict: bool = True,
         key: Optional[Callable[[Any], Any]] = None,
@@ -840,7 +840,7 @@ class DFA(fa.FA):
 
     def successors(
         self,
-        input_str: str,
+        input_str: Optional[str],
         *,
         strict: bool = True,
         key: Optional[Callable[[Any], Any]] = None,

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -2,6 +2,7 @@
 """Classes and methods for working with all finite automata."""
 
 import abc
+from typing import Set
 
 from automata.base.automaton import Automaton, AutomatonStateT
 
@@ -12,3 +13,14 @@ class FA(Automaton, metaclass=abc.ABCMeta):
     """An abstract base class for finite automata."""
 
     __slots__ = tuple()
+
+    @staticmethod
+    def _add_new_state(state_set: Set[FAStateT], start: int = 0) -> int:
+        """Adds new state to the state set and returns it"""
+        new_state = start
+        while new_state in state_set:
+            new_state += 1
+
+        state_set.add(new_state)
+
+        return new_state

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Classes and methods for working with generalized non-deterministic finite
 automata."""
+from __future__ import annotations
 
 from itertools import product
 from typing import AbstractSet, Dict, Mapping, Optional, Set, Type, cast

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -3,6 +3,7 @@
 automata."""
 
 from itertools import product
+from typing import AbstractSet, Mapping, Optional
 
 from frozendict import frozendict
 from pydot import Dot, Edge, Node
@@ -13,6 +14,9 @@ import automata.fa.nfa as nfa
 import automata.regex.regex as re
 
 GNFAStateT = fa.AutomatonStateT
+
+GNFAPathT = Mapping[GNFAStateT, Optional[str]]
+GNFATransitionsT = Mapping[GNFAStateT, GNFAPathT]
 
 
 class GNFA(fa.FA):
@@ -34,7 +38,13 @@ class GNFA(fa.FA):
     final_state: GNFAStateT
 
     def __init__(
-        self, *, states, input_symbols, transitions, initial_state, final_state
+        self,
+        *,
+        states: AbstractSet[GNFAStateT],
+        input_symbols: AbstractSet[str],
+        transitions: GNFATransitionsT,
+        initial_state: GNFAStateT,
+        final_state: GNFAStateT,
     ):
         """Initialize a complete NFA."""
         super(fa.FA, self).__init__(

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -12,8 +12,10 @@ import automata.fa.fa as fa
 import automata.fa.nfa as nfa
 import automata.regex.regex as re
 
+GNFAStateT = fa.AutomatonStateT
 
-class GNFA(nfa.NFA):
+
+class GNFA(fa.FA):
     """A generalized nondeterministic finite automaton."""
 
     # The conventions of using __slots__ state that subclasses automatically
@@ -28,6 +30,8 @@ class GNFA(nfa.NFA):
         "initial_state",
         "final_state",
     )
+
+    final_state: GNFAStateT
 
     def __init__(
         self, *, states, input_symbols, transitions, initial_state, final_state

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -932,7 +932,7 @@ class NFA(fa.FA):
         insertion: bool = True,
         deletion: bool = True,
         substitution: bool = True,
-    ):
+    ) -> Self:
         """
         Constructs the Levenshtein NFA for the given reference_str and given
         Levenshtein distance. This NFA recognizes strings within the given

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -126,10 +126,6 @@ class NFA(fa.FA):
         else:
             return NotImplemented
 
-    def __reversed__(self) -> Self:
-        """Return the reversal of this NFA."""
-        return self.reverse()
-
     @classmethod
     def from_dfa(cls: Type[Self], dfa: dfa.DFA) -> Self:
         """Initialize this NFA as one equivalent to the given DFA."""
@@ -867,17 +863,6 @@ class NFA(fa.FA):
                 new_transition_dict[state_map_dict[state_a]][symbol] = {
                     state_map_dict[state_b] for state_b in states
                 }
-
-    @staticmethod
-    def _add_new_state(state_set: Set[NFAStateT], start: int = 0) -> int:
-        """Adds new state to the state set and returns it"""
-        new_state = start
-        while new_state in state_set:
-            new_state += 1
-
-        state_set.add(new_state)
-
-        return new_state
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/automata/regex/lexer.py
+++ b/automata/regex/lexer.py
@@ -55,7 +55,7 @@ class TokenRegistry(Generic[ResultT]):
 
     _tokens: List[Tuple[TokenFactoryT, re.Pattern]]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._tokens = []
 
     def register(self, token_factory_fn: TokenFactoryT, token_regex: str) -> None:

--- a/automata/regex/lexer.py
+++ b/automata/regex/lexer.py
@@ -16,6 +16,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
     TypeVar,
 )
 
@@ -37,11 +38,8 @@ class Token(Generic[ResultT], metaclass=abc.ABCMeta):
         self.text = text
 
     @classmethod
-    def from_match(cls, match: re.Match) -> Self:
+    def from_match(cls: Type[Self], match: re.Match) -> Self:
         return cls(match.group())
-
-    def get_precedence(self) -> int:
-        raise NotImplementedError
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.text}>"

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -8,6 +8,8 @@ from collections import deque
 from itertools import chain, count, product, repeat, zip_longest
 from typing import AbstractSet, Deque, Dict, Iterable, List, Optional, Set, Tuple, Type
 
+from typing_extensions import Self
+
 import automata.base.exceptions as exceptions
 from automata.base.utils import get_renaming_function
 from automata.regex.lexer import Lexer, Token
@@ -412,7 +414,7 @@ class QuantifierToken(PostfixOperator[NFARegexBuilder]):
         self.upper_bound = upper_bound
 
     @classmethod
-    def from_match(cls, match: re.Match) -> QuantifierToken:
+    def from_match(cls: Type[Self], match: re.Match) -> QuantifierToken:
         lower_bound_str = match.group(1)
         upper_bound_str = match.group(2)
 
@@ -465,7 +467,7 @@ class StringToken(Literal[NFARegexBuilder]):
         self.counter = counter
 
     @classmethod
-    def from_match(cls, match: re.Match) -> StringToken:
+    def from_match(cls: Type[Self], match: re.Match) -> StringToken:
         raise NotImplementedError
 
     def val(self) -> NFARegexBuilder:
@@ -485,7 +487,7 @@ class WildcardToken(Literal[NFARegexBuilder]):
         self.counter = counter
 
     @classmethod
-    def from_match(cls, match: re.Match) -> WildcardToken:
+    def from_match(cls: Type[Self], match: re.Match) -> WildcardToken:
         raise NotImplementedError
 
     def val(self) -> NFARegexBuilder:

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -8,7 +8,7 @@ from collections import deque
 from itertools import chain, count, product, repeat, zip_longest
 from typing import AbstractSet, Deque, Dict, Iterable, List, Optional, Set, Tuple, Type
 
-from typing_extensions import Self
+from typing_extensions import NoReturn, Self
 
 import automata.base.exceptions as exceptions
 from automata.base.utils import get_renaming_function
@@ -467,7 +467,7 @@ class StringToken(Literal[NFARegexBuilder]):
         self.counter = counter
 
     @classmethod
-    def from_match(cls: Type[Self], match: re.Match) -> StringToken:
+    def from_match(cls: Type[Self], match: re.Match) -> NoReturn:
         raise NotImplementedError
 
     def val(self) -> NFARegexBuilder:
@@ -487,7 +487,7 @@ class WildcardToken(Literal[NFARegexBuilder]):
         self.counter = counter
 
     @classmethod
-    def from_match(cls: Type[Self], match: re.Match) -> WildcardToken:
+    def from_match(cls: Type[Self], match: re.Match) -> NoReturn:
         raise NotImplementedError
 
     def val(self) -> NFARegexBuilder:

--- a/docs/fa/class-gnfa.md
+++ b/docs/fa/class-gnfa.md
@@ -1,16 +1,18 @@
-# class GNFA(NFA)
+# class GNFA(FA)
 
 [FA Class](class-fa.md)  
 [Table of Contents](../README.md)
 
-The `GNFA` class is a subclass of `NFA` and represents a generalized
+The `GNFA` class is a subclass of `FA` and represents a generalized
 nondeterministic finite automaton. It can be found under `automata/fa/gnfa.py`.
-Its main usage is for conversion of DFAs and NFAs to regular expressions.
+Its main usage is for conversion of DFAs and NFAs to regular expressions. Note
+that because of this, the `GNFA` doesn't support any binary operators or reading
+input (e.g. `read_input_stepwise`).
 
 Every `GNFA` has the following properties: `states`, `input_symbols`,
 `transitions`, `initial_state`, and `final_state`. This is very similar to the
 `NFA` signature, except that a `GNFA` has several differences with respect to
-`NFA`
+`NFA`:
 - The `initial_state` has transitions going to every other state but no transitions
 coming in from any other state.
 - There is only a single `final_state`, and it has transitions coming in from every
@@ -20,14 +22,15 @@ is not the same has `initial_state`.
 state and also from each state to itself. To accommodate this, transitions can be
 regular expressions and `None` also in addition to normal symbols.
 
+
 `GNFA` is modified with respect to `NFA` in the following parameters:
 
-1. `final_state`: a string (single state).
-2. `transitions`: (its structure is changed from `NFA`) a `dict` consisting of the transitions
+1. `final_state`: a single state.
+2. `transitions`: A `dict` consisting of the transitions
 for each state except `final_state`. Each key is a state name and each value is `dict`
 which maps a state (the key) to the transition expression (the value).
     - value: a regular expression (string) consisting of `input_symbols` and the following symbols only:
-    `*`, `|`, `?`, `()`. Check [Regular Expressions](../regular-expressions.md)
+    `*`, `|`, `?`, `()`. This is a subset of the standard [Regular Expressions](../regular-expressions.md).
 
 ```python
 from automata.fa.gnfa import GNFA

--- a/docs/fa/class-nfa.md
+++ b/docs/fa/class-nfa.md
@@ -87,10 +87,6 @@ nfa1 == nfa2
 nfa.reverse()
 ```
 
-```python
-reversed(nfa)
-```
-
 ## NFA.concatenate(self, other)
 
 ```python

--- a/tests/test_automaton.py
+++ b/tests/test_automaton.py
@@ -7,7 +7,7 @@ from automata.base.automaton import Automaton
 
 
 class TestAutomaton(unittest.TestCase):
-    def test_abstract_methods_not_implemented(self):
+    def test_abstract_methods_not_implemented(self) -> None:
         """Should raise NotImplementedError when calling abstract methods."""
         abstract_methods = {
             "validate": (Automaton,),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 """Functions for testing the global Automata configuration."""
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from frozendict import frozendict
 
@@ -11,23 +11,23 @@ from automata.fa.dfa import DFA
 
 
 class TestConfig(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.orig_should_validate = global_config.should_validate_automata
         self.orig_allow_mutable_automata = global_config.allow_mutable_automata
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         global_config.should_validate_automata = self.orig_should_validate
         global_config.allow_mutable_automata = self.orig_allow_mutable_automata
 
     @patch("automata.fa.dfa.DFA.validate")
-    def test_disable_validation(self, validate):
+    def test_disable_validation(self, validate: MagicMock) -> None:
         """Should disable automaton validation"""
         global_config.should_validate_automata = False
-        DFA.universal_language({0, 1})
+        DFA.universal_language({"0", "1"})
         validate.assert_not_called()
 
     @patch("automata.base.utils.freeze_value")
-    def test_disable_ensure_values_are_frozen(self, freeze_value):
+    def test_disable_ensure_values_are_frozen(self, freeze_value: MagicMock) -> None:
         """Should enable automaton mutability"""
         global_config.allow_mutable_automata = True
         DFA(

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -21,15 +21,15 @@ class TestDFA(test_fa.TestFA):
 
     temp_dir_path = tempfile.gettempdir()
 
-    def test_init_dfa(self):
+    def test_init_dfa(self) -> None:
         """Should copy DFA if passed into DFA constructor."""
         new_dfa = self.dfa.copy()
         self.assertIsNot(new_dfa, self.dfa)
 
-    def test_init_dfa_missing_formal_params(self):
+    def test_init_dfa_missing_formal_params(self) -> None:
         """Should raise an error if formal DFA parameters are missing."""
         with self.assertRaises(TypeError):
-            DFA(
+            DFA(  # type: ignore
                 states={"q0", "q1"},
                 input_symbols={"0", "1"},
                 initial_state="q0",

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -6,7 +6,7 @@ import os.path
 import tempfile
 import types
 from itertools import product
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from frozendict import frozendict
 
@@ -36,37 +36,37 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q1"},
             )
 
-    def test_copy_dfa(self):
+    def test_copy_dfa(self) -> None:
         """Should create exact copy of DFA if copy() method is called."""
         new_dfa = self.dfa.copy()
         self.assertIsNot(new_dfa, self.dfa)
 
-    def test_dfa_immutable_attr_set(self):
+    def test_dfa_immutable_attr_set(self) -> None:
         """Should disallow reassigning DFA attributes"""
         with self.assertRaises(AttributeError):
             self.dfa.states = {}
 
-    def test_dfa_immutable_attr_del(self):
+    def test_dfa_immutable_attr_del(self) -> None:
         """Should disallow deleting DFA attributes"""
         with self.assertRaises(AttributeError):
             del self.dfa.states
 
-    def test_dfa_immutable_dict(self):
+    def test_dfa_immutable_dict(self) -> None:
         """Should create a DFA whose contents are fully immutable/hashable"""
         self.assertIsInstance(hash(frozendict(self.dfa.input_parameters)), int)
 
     @patch("automata.fa.dfa.DFA.validate")
-    def test_init_validation(self, validate):
+    def test_init_validation(self, validate: MagicMock) -> None:
         """Should validate DFA when initialized."""
         self.dfa.copy()
         validate.assert_called_once_with()
 
-    def test_dfa_equal(self):
+    def test_dfa_equal(self) -> None:
         """Should correctly determine if two DFAs are equal."""
         new_dfa = self.dfa.copy()
         self.assertTrue(self.dfa == new_dfa, "DFAs are not equal")
 
-    def test_dfa_not_equal(self):
+    def test_dfa_not_equal(self) -> None:
         """Should correctly determine if two DFAs are not equal."""
         new_dfa = DFA(
             states={"q0"},
@@ -77,7 +77,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertTrue(self.dfa != new_dfa, "DFAs are equal")
 
-    def test_validate_missing_state(self):
+    def test_validate_missing_state(self) -> None:
         """Should raise error if a state has no transitions defined."""
         with self.assertRaises(exceptions.MissingStateError):
             DFA(
@@ -88,7 +88,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_missing_symbol(self):
+    def test_validate_missing_symbol(self) -> None:
         """Should raise error if a symbol transition is missing."""
         with self.assertRaises(exceptions.MissingSymbolError):
             DFA(
@@ -99,7 +99,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_symbol(self):
+    def test_validate_invalid_symbol(self) -> None:
         """Should raise error if a transition references an invalid symbol."""
         with self.assertRaises(exceptions.InvalidSymbolError):
             DFA(
@@ -110,7 +110,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_state(self):
+    def test_validate_invalid_state(self) -> None:
         """Should raise error if a transition references an invalid state."""
         with self.assertRaises(exceptions.InvalidStateError):
             DFA(
@@ -121,7 +121,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_initial_state(self):
+    def test_validate_invalid_initial_state(self) -> None:
         """Should raise error if the initial state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             DFA(
@@ -132,7 +132,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_final_state(self):
+    def test_validate_invalid_final_state(self) -> None:
         """Should raise error if the final state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             DFA(
@@ -143,7 +143,7 @@ class TestDFA(test_fa.TestFA):
                 final_states={"q1"},
             )
 
-    def test_validate_invalid_final_state_non_str(self):
+    def test_validate_invalid_final_state_non_str(self) -> None:
         """Should raise InvalidStateError even for non-string final states."""
         with self.assertRaises(exceptions.InvalidStateError):
             DFA(
@@ -154,35 +154,35 @@ class TestDFA(test_fa.TestFA):
                 final_states={3},
             )
 
-    def test_read_input_accepted(self):
+    def test_read_input_accepted(self) -> None:
         """Should return correct state if acceptable DFA input is given."""
         self.assertEqual(self.dfa.read_input("0111"), "q1")
 
-    def test_read_input_rejection(self):
+    def test_read_input_rejection(self) -> None:
         """Should raise error if the stop state is not a final state."""
         with self.assertRaises(exceptions.RejectionException):
             self.dfa.read_input("011")
 
-    def test_read_input_rejection_invalid_symbol(self):
+    def test_read_input_rejection_invalid_symbol(self) -> None:
         """Should raise error if an invalid symbol is read."""
         with self.assertRaises(exceptions.RejectionException):
             self.dfa.read_input("01112")
 
-    def test_accepts_input_true(self):
+    def test_accepts_input_true(self) -> None:
         """Should return True if DFA input is accepted."""
         self.assertTrue(self.dfa.accepts_input("0111"))
 
-    def test_accepts_input_false(self):
+    def test_accepts_input_false(self) -> None:
         """Should return False if DFA input is rejected."""
         self.assertFalse(self.dfa.accepts_input("011"))
 
-    def test_read_input_step(self):
+    def test_read_input_step(self) -> None:
         """Should return validation generator if step flag is supplied."""
         validation_generator = self.dfa.read_input_stepwise("0111")
         self.assertIsInstance(validation_generator, types.GeneratorType)
         self.assertEqual(list(validation_generator), ["q0", "q0", "q1", "q2", "q1"])
 
-    def test_operations_other_types(self):
+    def test_operations_other_types(self) -> None:
         """Should raise TypeError for all but equals."""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
@@ -200,23 +200,23 @@ class TestDFA(test_fa.TestFA):
         other = 42
         self.assertNotEqual(dfa, other)
         with self.assertRaises(TypeError):
-            dfa | other
+            dfa | other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa & other
+            dfa & other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa - other
+            dfa - other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa ^ other
+            dfa ^ other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa < other
+            dfa < other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa <= other
+            dfa <= other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa > other
+            dfa > other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa >= other
+            dfa >= other  # type: ignore
 
-    def test_equivalence_not_equal(self):
+    def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
@@ -246,7 +246,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertNotEqual(no_consecutive_11_dfa, zero_or_one_1_dfa)
 
-    def test_equivalence_minify(self):
+    def test_equivalence_minify(self) -> None:
         """Should be equivalent after minify."""
         no_consecutive_11_dfa = DFA(
             states={"q0", "q1", "q2", "q3"},
@@ -263,7 +263,7 @@ class TestDFA(test_fa.TestFA):
         minimal_dfa = no_consecutive_11_dfa.minify()
         self.assertEqual(no_consecutive_11_dfa, minimal_dfa)
 
-    def test_equivalence_two_non_minimal(self):
+    def test_equivalence_two_non_minimal(self) -> None:
         """Should be equivalent even though they are non minimal."""
         no_consecutive_11_dfa = DFA(
             states={"q0", "q1", "q2", "q3"},
@@ -291,7 +291,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertEqual(no_consecutive_11_dfa, other_dfa)
 
-    def test_complement(self):
+    def test_complement(self) -> None:
         """Should compute the complement of a DFA"""
         no_consecutive_11_dfa = DFA(
             states={"q0", "q1", "q2"},
@@ -317,7 +317,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertEqual(complement_dfa.final_states, {"q2"})
 
-    def test_union(self):
+    def test_union(self) -> None:
         """Should compute the union between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
@@ -403,7 +403,7 @@ class TestDFA(test_fa.TestFA):
         # Test retain names logic without minify
         self.assertEqual(dfa1.union(dfa2, retain_names=False, minify=False), new_dfa)
 
-    def test_intersection(self):
+    def test_intersection(self) -> None:
         """Should compute the intersection between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
@@ -483,7 +483,7 @@ class TestDFA(test_fa.TestFA):
             dfa1.intersection(dfa2, retain_names=False, minify=False), new_dfa
         )
 
-    def test_difference(self):
+    def test_difference(self) -> None:
         """Should compute the difference between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
@@ -557,7 +557,7 @@ class TestDFA(test_fa.TestFA):
             dfa1.difference(dfa2, retain_names=False, minify=False), new_dfa
         )
 
-    def test_symmetric_difference(self):
+    def test_symmetric_difference(self) -> None:
         """Should compute the symmetric difference between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
@@ -643,7 +643,7 @@ class TestDFA(test_fa.TestFA):
             dfa1.symmetric_difference(dfa2, retain_names=False, minify=False), new_dfa
         )
 
-    def test_issubset(self):
+    def test_issubset(self) -> None:
         """Should test if one DFA is a subset of another"""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
@@ -677,7 +677,7 @@ class TestDFA(test_fa.TestFA):
         self.assertFalse(no_consecutive_11_dfa < zero_or_one_1_dfa)
         self.assertFalse(no_consecutive_11_dfa <= zero_or_one_1_dfa)
 
-    def test_issuperset(self):
+    def test_issuperset(self) -> None:
         """Should test if one DFA is a superset of another"""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
@@ -711,7 +711,7 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(no_consecutive_11_dfa > zero_or_one_1_dfa)
         self.assertTrue(no_consecutive_11_dfa >= zero_or_one_1_dfa)
 
-    def test_symbol_mismatch(self):
+    def test_symbol_mismatch(self) -> None:
         """Should test if symbol mismatch is raised"""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
@@ -745,7 +745,7 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.SymbolMismatchError):
             zero_or_one_b_dfa.difference(no_consecutive_11_dfa)
 
-    def test_isdisjoint(self):
+    def test_isdisjoint(self) -> None:
         """Should test if two DFAs are disjoint"""
         # This DFA accepts all words which contain at least
         # three occurrences of 1
@@ -772,14 +772,14 @@ class TestDFA(test_fa.TestFA):
         self.assertFalse(at_least_three_1.isdisjoint(at_least_one_1))
         self.assertFalse(at_most_one_1.isdisjoint(at_least_one_1))
 
-    def test_isempty_non_empty(self):
+    def test_isempty_non_empty(self) -> None:
         """Should test if a non-empty DFA is empty"""
         # This DFA accepts all words which contain at least
         # three occurrences of 1
         dfa = DFA.from_subsequence({"0", "1"}, "111")
         self.assertFalse(dfa.isempty())
 
-    def test_isempty_empty(self):
+    def test_isempty_empty(self) -> None:
         """Should test if an empty DFA is empty"""
         # This DFA has no reachable final states and
         # therefore accepts the empty language
@@ -797,14 +797,14 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertTrue(dfa1.isempty())
 
-    def test_isfinite_infinite(self):
+    def test_isfinite_infinite(self) -> None:
         """Should test if an infinite DFA is finite (case #1)"""
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
         dfa = DFA.from_substring({"0", "1"}, "11").complement(minify=False)
         self.assertFalse(dfa.isfinite())
 
-    def test_isfinite_infinite_case_2(self):
+    def test_isfinite_infinite_case_2(self) -> None:
         """Should test if an infinite DFA is finite (case #2)"""
         # This DFA accepts all binary strings which have length
         # less than or equal to 5
@@ -825,14 +825,14 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertFalse(dfa1.isfinite())
 
-    def test_isfinite_finite(self):
+    def test_isfinite_finite(self) -> None:
         """Should test if a finite DFA is finite"""
         # This DFA accepts all binary strings which have length
         # less than or equal to 5
         dfa = DFA.of_length({"0", "1"}, min_length=0, max_length=5)
         self.assertTrue(dfa.isfinite())
 
-    def test_isfinite_empty(self):
+    def test_isfinite_empty(self) -> None:
         """Should test if an empty DFA is finite"""
         # This DFA has no reachable final states and
         # therefore is finite.
@@ -850,13 +850,13 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertTrue(dfa.isfinite())
 
-    def test_isfinite_universe(self):
+    def test_isfinite_universe(self) -> None:
         # This DFA accepts all binary strings and
         # therefore is infinite.
         dfa = DFA.universal_language({"0", "1"})
         self.assertFalse(dfa.isfinite())
 
-    def test_set_laws(self):
+    def test_set_laws(self) -> None:
         """Tests many set laws that are true for all sets"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
@@ -901,7 +901,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(contains_1111 & avoids_11, avoids_11 & contains_1111)
         self.assertEqual(contains_1111 ^ avoids_11, avoids_11 ^ contains_1111)
 
-    def test_minify_dfa(self):
+    def test_minify_dfa(self) -> None:
         """Should minify a given DFA."""
         # This DFA accepts all words which are at least two characters long.
         # The states q1/q2 and q3/q4/q5/q6 are redundant.
@@ -1290,7 +1290,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(minimal_dfa.initial_state, check_dfa.initial_state)
         self.assertEqual(minimal_dfa.final_states, check_dfa.final_states)
 
-    def test_minify_minimal_dfa(self):
+    def test_minify_minimal_dfa(self) -> None:
         """Should minify an already minimal DFA."""
         # This DFA just accepts words ending in 1.
         dfa = DFA(
@@ -1318,7 +1318,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(minimal_dfa.initial_state, other_minimal_dfa.initial_state)
         self.assertEqual(minimal_dfa.final_states, other_minimal_dfa.final_states)
 
-    def test_minify_dfa_initial_state(self):
+    def test_minify_dfa_initial_state(self) -> None:
         """Should minify a DFA where the initial state is being changed."""
         # This DFA accepts all words with ones and zeroes.
         # The two states can be merged into one.
@@ -1347,7 +1347,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(minimal_dfa.initial_state, frozenset(("q0", "q1")))
         self.assertEqual(minimal_dfa.final_states, {frozenset(("q0", "q1"))})
 
-    def test_minify_dfa_no_final_states(self):
+    def test_minify_dfa_no_final_states(self) -> None:
         dfa = DFA(
             states={"q0", "q1"},
             input_symbols={"0", "1"},
@@ -1373,7 +1373,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(minimal_dfa.initial_state, frozenset(("q0", "q1")))
         self.assertEqual(minimal_dfa.final_states, set())
 
-    def test_init_nfa_simple(self):
+    def test_init_nfa_simple(self) -> None:
         """Should convert to a DFA a simple NFA."""
         nfa = NFA(
             states={"q0", "q1", "q2"},
@@ -1408,7 +1408,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dfa.initial_state, frozenset(("q0",)))
         self.assertEqual(dfa.final_states, {frozenset(("q2",))})
 
-    def test_init_nfa_more_complex(self):
+    def test_init_nfa_more_complex(self) -> None:
         """Should convert to a DFA a more complex NFA."""
         nfa = NFA(
             states={"q0", "q1", "q2"},
@@ -1458,7 +1458,7 @@ class TestDFA(test_fa.TestFA):
             dfa.final_states, {frozenset(("q0", "q1", "q2")), frozenset(("q0", "q2"))}
         )
 
-    def test_init_nfa_lambda_transition(self):
+    def test_init_nfa_lambda_transition(self) -> None:
         """Should convert to a DFA an NFA with a lambda transition."""
         dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False)
         self.assertEqual(
@@ -1479,7 +1479,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dfa.initial_state, frozenset(("q0",)))
         self.assertEqual(dfa.final_states, {frozenset(("q1", "q2"))})
 
-    def test_nfa_to_dfa_with_lambda_transitions(self):
+    def test_nfa_to_dfa_with_lambda_transitions(self) -> None:
         """Test NFA->DFA when initial state has lambda transitions"""
         nfa = NFA(
             states={"q0", "q1", "q2"},
@@ -1493,7 +1493,7 @@ class TestDFA(test_fa.TestFA):
         )  # returns an equivalent DFA
         self.assertEqual(dfa.read_input("a"), frozenset(("q1",)))
 
-    def test_partial_dfa(self):
+    def test_partial_dfa(self) -> None:
         """Should allow for partial DFA when flag is set"""
         dfa = DFA(
             states={"", "a", "b", "aa", "bb", "ab", "ba"},
@@ -1513,7 +1513,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertEqual(dfa.read_input("aa"), "aa")
 
-    def test_show_diagram_initial_final_different(self):
+    def test_show_diagram_initial_final_different(self) -> None:
         """
         Should construct the diagram for a DFA whose initial state
         is not a final state.
@@ -1540,7 +1540,7 @@ class TestDFA(test_fa.TestFA):
             },
         )
 
-    def test_show_diagram_initial_final_same(self):
+    def test_show_diagram_initial_final_same(self) -> None:
         """
         Should construct the diagram for a DFA whose initial state
         is also a final state.
@@ -1581,7 +1581,7 @@ class TestDFA(test_fa.TestFA):
             },
         )
 
-    def test_show_diagram_write_file(self):
+    def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a DFA
         and write it to the specified file.
@@ -1639,7 +1639,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(len(minimal_dfa.states), len(equiv_dfa.states))
         self.assertEqual(minimal_dfa, equiv_dfa)
 
-    def test_minimal_finite_language_large(self):
+    def test_minimal_finite_language_large(self) -> None:
         """Should compute the minimal DFA accepting the given finite language on
         large test case"""
         m = 50
@@ -1655,7 +1655,7 @@ class TestDFA(test_fa.TestFA):
         dfa_language = {word for word in equiv_dfa}
         self.assertEqual(dfa_language, language)
 
-    def test_dfa_repr(self):
+    def test_dfa_repr(self) -> None:
         """Should display proper string representation of DFA"""
         dfa = DFA(
             states={"q0"},
@@ -1671,7 +1671,7 @@ class TestDFA(test_fa.TestFA):
             "initial_state='q0', final_states={'q0'}, allow_partial=False)",
         )
 
-    def test_iter_finite(self):
+    def test_iter_finite(self) -> None:
         """
         Test that DFA for finite language generates all words
         """
@@ -1693,7 +1693,7 @@ class TestDFA(test_fa.TestFA):
         generated_set = {word for word in dfa}
         self.assertEqual(generated_set, language)
 
-    def test_iter_infinite(self):
+    def test_iter_infinite(self) -> None:
         """
         Test that language that avoids the pattern '11' generates the correct
         values in correct order
@@ -1735,7 +1735,7 @@ class TestDFA(test_fa.TestFA):
         generated_list = [next(generator) for _ in expected]
         self.assertEqual(generated_list, expected)
 
-    def test_len_finite(self):
+    def test_len_finite(self) -> None:
         input_symbols = {"a", "b"}
         dfa = DFA.from_finite_language(input_symbols, set())
         self.assertEqual(len(dfa), 0)
@@ -1752,7 +1752,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertEqual(len(dfa), 25)
 
-    def test_len_infinite(self):
+    def test_len_infinite(self) -> None:
         dfa = DFA(
             states={"p0", "p1", "p2"},
             input_symbols={"0", "1"},
@@ -1769,7 +1769,7 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.InfiniteLanguageException):
             len(~dfa)
 
-    def test_random_word(self):
+    def test_random_word(self) -> None:
         """
         Test random generation of words, the generation should be uniformly random
         """
@@ -1787,7 +1787,7 @@ class TestDFA(test_fa.TestFA):
         for i in range(10):
             self.assertIn(dfa.random_word(100), dfa)
 
-    def test_predecessor(self):
+    def test_predecessor(self) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1820,7 +1820,7 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.InfiniteLanguageException):
             [_ for _ in infinite_dfa.predecessors("000")]
 
-    def test_successor(self):
+    def test_successor(self) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1853,7 +1853,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(infinite_dfa.successor(100 * "0"), 101 * "0")
         self.assertEqual(infinite_dfa.successor(100 * "1"), 101 * "1")
 
-    def test_successor_and_predecessor(self):
+    def test_successor_and_predecessor(self) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1867,10 +1867,10 @@ class TestDFA(test_fa.TestFA):
         }
         dfa = DFA.from_finite_language(binary, language)
         for word in language:
-            self.assertEqual(dfa.successor(dfa.predecessor(word)), word)
-            self.assertEqual(dfa.predecessor(dfa.successor(word)), word)
+            self.assertEqual(dfa.successor(dfa.predecessor(word)), word)  # type: ignore
+            self.assertEqual(dfa.predecessor(dfa.successor(word)), word)  # type: ignore
 
-    def test_successor_custom_key(self):
+    def test_successor_custom_key(self) -> None:
         input_symbols = {"a", "b", "c", "d"}
         order = {"b": 0, "c": 1, "a": 2, "d": 3}
         expected = [
@@ -1895,7 +1895,7 @@ class TestDFA(test_fa.TestFA):
         actual = list(dfa.successors(None, key=order.get))
         self.assertListEqual(actual, expected)
 
-    def test_successor_partial(self):
+    def test_successor_partial(self) -> None:
         binary = {"0", "1"}
         dfa = DFA(
             states={0, 1},
@@ -1914,7 +1914,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dfa.successor("01000"), "011")
         self.assertEqual(dfa.successor("1"), None)
 
-    def test_count_words_of_length(self):
+    def test_count_words_of_length(self) -> None:
         """
         Test that language that avoids the pattern '11' is counted by fibonacci numbers
         """
@@ -1934,7 +1934,7 @@ class TestDFA(test_fa.TestFA):
         for i, fib in enumerate(fibonacci):
             self.assertEqual(dfa.count_words_of_length(i), fib)
 
-    def test_words_of_length(self):
+    def test_words_of_length(self) -> None:
         """
         Test that all words generated are accepted and that count matches
         """
@@ -1958,7 +1958,7 @@ class TestDFA(test_fa.TestFA):
                 self.assertIn(word, dfa)
             self.assertEqual(count, fib)
 
-    def test_minimum_word_length(self):
+    def test_minimum_word_length(self) -> None:
         # This DFA accepts all words which contain at least four
         # occurrences of 1
         at_least_four_ones = DFA(
@@ -2013,7 +2013,7 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.EmptyLanguageException):
             empty.minimum_word_length()
 
-    def test_maximum_word_length(self):
+    def test_maximum_word_length(self) -> None:
         # This DFA accepts all words which contain at least four
         # occurrences of 1
         at_least_four_ones = DFA(
@@ -2069,14 +2069,14 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.EmptyLanguageException):
             empty.maximum_word_length()
 
-    def test_contains_prefix(self):
+    def test_contains_prefix(self) -> None:
         input_symbols = {"a", "n", "o", "b"}
 
         prefix_dfa = DFA.from_prefix(input_symbols, "nano")
         self.assertEqual(len(prefix_dfa.states), len(prefix_dfa.minify().states))
 
         subset_dfa = DFA.from_finite_language(
-            input_symbols, ["nano", "nanobao", "nanonana", "nanonano", "nanoo"]
+            input_symbols, {"nano", "nanobao", "nanonana", "nanonano", "nanoo"}
         )
         self.assertTrue(subset_dfa < prefix_dfa)
 
@@ -2089,7 +2089,7 @@ class TestDFA(test_fa.TestFA):
                 break
             self.assertTrue(word.startswith("nano"))
 
-    def test_contains_suffix(self):
+    def test_contains_suffix(self) -> None:
         input_symbols = {"a", "n", "o", "b"}
 
         suffix_dfa = DFA.from_suffix(input_symbols, "nano")
@@ -2097,7 +2097,7 @@ class TestDFA(test_fa.TestFA):
 
         subset_dfa = DFA.from_finite_language(
             input_symbols,
-            ["nano", "annnano", "bnano", "anbonano", "nananananananananano"],
+            {"nano", "annnano", "bnano", "anbonano", "nananananananananano"},
         )
         self.assertTrue(subset_dfa < suffix_dfa)
 
@@ -2110,7 +2110,7 @@ class TestDFA(test_fa.TestFA):
                 break
             self.assertTrue(word.endswith("nano"))
 
-    def test_contains_substring(self):
+    def test_contains_substring(self) -> None:
         """Should compute the minimal DFA accepting strings with the given substring"""
 
         input_symbols = {"a", "n", "o", "b"}
@@ -2136,7 +2136,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(substring_dfa, equiv_dfa)
 
         subset_dfa = DFA.from_finite_language(
-            input_symbols, ["nano", "bananano", "nananano", "naonano"]
+            input_symbols, {"nano", "bananano", "nananano", "naonano"}
         )
         self.assertTrue(subset_dfa < substring_dfa)
 
@@ -2149,7 +2149,7 @@ class TestDFA(test_fa.TestFA):
                 break
             self.assertIn("nano", word)
 
-    def test_contains_subsequence(self):
+    def test_contains_subsequence(self) -> None:
         """Should compute the minimal DFA accepting strings with the given
         subsequence"""
 
@@ -2178,7 +2178,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(subsequence_dfa, equiv_dfa)
 
         subset_dfa = DFA.from_finite_language(
-            input_symbols, ["naooono", "bananano", "onbaonbo", "ooonano"]
+            input_symbols, {"naooono", "bananano", "onbaonbo", "ooonano"}
         )
         self.assertTrue(subset_dfa < subsequence_dfa)
 
@@ -2193,7 +2193,7 @@ class TestDFA(test_fa.TestFA):
             DFA.from_subsequence(input_symbols, "nano", contains=False),
         )
 
-    def test_of_length(self):
+    def test_of_length(self) -> None:
         binary = {"0", "1"}
         dfa1 = DFA.of_length(binary)
         self.assertFalse(dfa1.isfinite())
@@ -2300,7 +2300,7 @@ class TestDFA(test_fa.TestFA):
 
         self.assertEqual(dfa7.union(dfa8), DFA.universal_language(binary))
 
-    def test_count_mod(self):
+    def test_count_mod(self) -> None:
         binary = {"0", "1"}
         with self.assertRaises(ValueError):
             _ = DFA.count_mod(binary, 0)
@@ -2341,7 +2341,7 @@ class TestDFA(test_fa.TestFA):
             DFA.count_mod(binary, 4, remainders={0, 2}), DFA.count_mod(binary, 2)
         )
 
-    def test_nth_from_start(self):
+    def test_nth_from_start(self) -> None:
         binary = {"0", "1"}
         with self.assertRaises(ValueError):
             dfa = DFA.nth_from_start(binary, "0", 0)
@@ -2383,7 +2383,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(len(dfa.states), len(dfa.minify().states))
         self.assertEqual(dfa.minimum_word_length(), 4)
 
-    def test_nth_from_end(self):
+    def test_nth_from_end(self) -> None:
         binary = {"0", "1"}
         with self.assertRaises(ValueError):
             dfa = DFA.nth_from_end(binary, "0", 0)
@@ -2416,7 +2416,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(len(dfa.states), len(dfa.minify().states))
         self.assertEqual(dfa.minimum_word_length(), 4)
 
-    def test_empty_language(self):
+    def test_empty_language(self) -> None:
         dfa = DFA.empty_language({"0"})
         self.assertTrue(dfa.isempty())
 

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -44,7 +44,7 @@ class TestDFA(test_fa.TestFA):
     def test_dfa_immutable_attr_set(self) -> None:
         """Should disallow reassigning DFA attributes"""
         with self.assertRaises(AttributeError):
-            self.dfa.states = {} # type: ignore
+            self.dfa.states = {}  # type: ignore
 
     def test_dfa_immutable_attr_del(self) -> None:
         """Should disallow deleting DFA attributes"""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -44,7 +44,7 @@ class TestDFA(test_fa.TestFA):
     def test_dfa_immutable_attr_set(self) -> None:
         """Should disallow reassigning DFA attributes"""
         with self.assertRaises(AttributeError):
-            self.dfa.states = {}
+            self.dfa.states = {} # type: ignore
 
     def test_dfa_immutable_attr_del(self) -> None:
         """Should disallow deleting DFA attributes"""

--- a/tests/test_fa.py
+++ b/tests/test_fa.py
@@ -11,6 +11,10 @@ from automata.fa.nfa import NFA
 class TestFA(unittest.TestCase):
     """A test class for testing all finite automata."""
 
+    dfa: DFA
+    nfa: NFA
+    gnfa: GNFA
+
     def setUp(self):
         """Reset test automata before every test function."""
         # DFA which matches all binary strings ending in an odd number of '1's

--- a/tests/test_fa.py
+++ b/tests/test_fa.py
@@ -15,7 +15,7 @@ class TestFA(unittest.TestCase):
     nfa: NFA
     gnfa: GNFA
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Reset test automata before every test function."""
         # DFA which matches all binary strings ending in an odd number of '1's
         self.dfa = DFA(

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -238,7 +238,7 @@ class TestGNFA(test_fa.TestFA):
                     "q0": {"q1": "a", "q_f": None, "q2": None, "q0": None},
                     "q1": {"q1": "a", "q2": "", "q_f": "", "q0": None},
                     "q2": {"q0": "b", "q_f": None, "q2": None, "q1": None},
-                    "q_in": {"q0": "", "q_f": None, "q2": None, "q1": None, "q5": {}},
+                    "q_in": {"q0": "", "q_f": None, "q2": None, "q1": None, "q5": {}},  # type: ignore
                 },
                 initial_state="q_in",
                 final_state="q_f",

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -2,7 +2,7 @@
 """Classes and functions for testing the behavior of GNFAs."""
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa
@@ -16,35 +16,35 @@ class TestGNFA(test_fa.TestFA):
 
     temp_dir_path = tempfile.gettempdir()
 
-    def test_init_gnfa(self):
+    def test_init_gnfa(self) -> None:
         """Should copy GNFA if passed into NFA constructor."""
         new_gnfa = self.gnfa.copy()
         self.assertIsNot(new_gnfa, self.gnfa)
 
-    def test_init_nfa_missing_formal_params(self):
+    def test_init_nfa_missing_formal_params(self) -> None:
         """Should raise an error if formal NFA parameters are missing."""
         with self.assertRaises(TypeError):
-            GNFA(
+            GNFA(  # type: ignore
                 states={"q0", "q1"},
                 input_symbols={"0", "1"},
                 initial_state="q0",
                 final_state="q1",
             )
 
-    def test_copy_gnfa(self):
+    def test_copy_gnfa(self) -> None:
         """Should create exact copy of NFA if copy() method is called."""
         new_gnfa = self.gnfa.copy()
         self.assertIsNot(new_gnfa, self.gnfa)
 
-    def test_gnfa_immutable_attr_set(self):
+    def test_gnfa_immutable_attr_set(self) -> None:
         with self.assertRaises(AttributeError):
-            self.gnfa.states = {}
+            self.gnfa.states = {}  # type: ignore
 
-    def test_gnfa_immutable_attr_del(self):
+    def test_gnfa_immutable_attr_del(self) -> None:
         with self.assertRaises(AttributeError):
             del self.gnfa.states
 
-    def test_init_dfa(self):
+    def test_init_dfa(self) -> None:
         """Should convert DFA to GNFA if passed into GNFA constructor."""
         gnfa = GNFA.from_dfa(self.dfa)
         self.assertEqual(gnfa.states, {0, 1, "q2", "q0", "q1"})
@@ -60,7 +60,7 @@ class TestGNFA(test_fa.TestFA):
         )
         self.assertEqual(gnfa.initial_state, 0)
 
-    def test_init_nfa(self):
+    def test_init_nfa(self) -> None:
         """Should convert NFA to GNFA if passed into GNFA constructor."""
         gnfa = GNFA.from_nfa(self.nfa)
         self.assertEqual(gnfa.states, {0, 1, "q0", "q1", "q2"})
@@ -77,12 +77,12 @@ class TestGNFA(test_fa.TestFA):
         self.assertEqual(gnfa.initial_state, 0)
 
     @patch("automata.fa.gnfa.GNFA.validate")
-    def test_init_validation(self, validate):
+    def test_init_validation(self, validate: MagicMock) -> None:
         """Should validate NFA when initialized."""
         self.gnfa.copy()
         validate.assert_called_once_with()
 
-    def test_validate_invalid_symbol(self):
+    def test_validate_invalid_symbol(self) -> None:
         """Should raise error if a transition references an invalid symbol."""
         with self.assertRaises(exceptions.InvalidRegexError):
             GNFA(
@@ -98,7 +98,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_invalid_state(self):
+    def test_validate_invalid_state(self) -> None:
         """Should raise error if a transition references an invalid state."""
         with self.assertRaises(exceptions.InvalidStateError):
             GNFA(
@@ -114,7 +114,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_invalid_initial_state(self):
+    def test_validate_invalid_initial_state(self) -> None:
         """Should raise error if the initial state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             GNFA(
@@ -130,7 +130,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_initial_state_transitions(self):
+    def test_validate_initial_state_transitions(self) -> None:
         """Should raise error if the initial state has no transitions."""
         with self.assertRaises(exceptions.MissingStateError):
             GNFA(
@@ -145,7 +145,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_invalid_final_state(self):
+    def test_validate_invalid_final_state(self) -> None:
         """Should raise error if the final state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             GNFA(
@@ -161,7 +161,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q3",
             )
 
-    def test_validate_final_state_transition(self):
+    def test_validate_final_state_transition(self) -> None:
         """Should raise error if there are transitions from final state"""
         with self.assertRaises(exceptions.InvalidStateError):
             GNFA(
@@ -178,7 +178,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_missing_state(self):
+    def test_validate_missing_state(self) -> None:
         """Should raise an error if some transitions are missing."""
         with self.assertRaises(exceptions.MissingStateError):
             GNFA(
@@ -194,7 +194,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_validate_incomplete_transitions(self):
+    def test_validate_incomplete_transitions(self) -> None:
         """
         Should raise error if transitions from (except final state)
         and to (except initial state) every state is missing.
@@ -244,7 +244,7 @@ class TestGNFA(test_fa.TestFA):
                 final_state="q_f",
             )
 
-    def test_from_dfa(self):
+    def test_from_dfa(self) -> None:
         """
         Check if GNFA is generated properly from DFA
         """
@@ -275,7 +275,7 @@ class TestGNFA(test_fa.TestFA):
 
         self.assertEqual(gnfa.input_parameters, gnfa2.input_parameters)
 
-    def test_from_dfa_single_state(self):
+    def test_from_dfa_single_state(self) -> None:
         nfa = NFA.from_regex("")
         dfa = DFA.from_nfa(nfa)
         gnfa = GNFA.from_dfa(dfa)
@@ -290,7 +290,7 @@ class TestGNFA(test_fa.TestFA):
 
         self.assertEqual(gnfa.to_regex(), gnfa2.to_regex())
 
-    def test_from_nfa_single_state(self):
+    def test_from_nfa_single_state(self) -> None:
         nfa = NFA.from_regex("")
         gnfa = GNFA.from_nfa(nfa)
 
@@ -304,7 +304,7 @@ class TestGNFA(test_fa.TestFA):
 
         self.assertEqual(gnfa.to_regex(), gnfa2.to_regex())
 
-    def test_from_nfa(self):
+    def test_from_nfa(self) -> None:
         """Should convert NFA to GNFA properly"""
 
         nfa = NFA(
@@ -337,7 +337,7 @@ class TestGNFA(test_fa.TestFA):
 
         self.assertEqual(gnfa.input_parameters, gnfa2.input_parameters)
 
-    def test_to_regex(self):
+    def test_to_regex(self) -> None:
         """
         We generate GNFA from DFA then convert it to regex
         then generate NFA from regex (already tested method)
@@ -366,41 +366,41 @@ class TestGNFA(test_fa.TestFA):
             # Test equality through DFA regex conversion
             self.assertEqual(dfa_1, dfa_2)
 
-    def test_read_input_step_not_implemented(self):
+    def test_read_input_step_not_implemented(self) -> None:
         """Should not implement read_input_stepwise() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.read_input_stepwise("aaa")
 
-    def test_union_not_implemented(self):
+    def test_union_not_implemented(self) -> None:
         """Should not implement union() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.union(self.gnfa)
 
-    def test_concatenate_not_implemented(self):
+    def test_concatenate_not_implemented(self) -> None:
         """Should not implement concatenate() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.concatenate(self.gnfa)
 
-    def test_kleene_star_not_implemented(self):
+    def test_kleene_star_not_implemented(self) -> None:
         """Should not implement kleene_star() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.kleene_star()
 
-    def test_option_not_implemented(self):
+    def test_option_not_implemented(self) -> None:
         """Should not implement option() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.option()
 
-    def test_reverse_not_implemented(self):
+    def test_reverse_not_implemented(self) -> None:
         """Should not implement reverse() for GNFA."""
         with self.assertRaises(NotImplementedError):
             self.gnfa.reverse()
 
-    def test_eq_not_implemented(self):
+    def test_eq_not_implemented(self) -> None:
         """Should not implement equality for GNFA."""
         self.assertNotEqual(self.gnfa, GNFA.from_nfa(self.nfa))
 
-    def test_show_diagram_showNone(self):
+    def test_show_diagram_showNone(self) -> None:
         """
         Should construct the diagram for a GNFA when show_None = False
         """
@@ -427,7 +427,7 @@ class TestGNFA(test_fa.TestFA):
             },
         )
 
-    def test_show_diagram(self):
+    def test_show_diagram(self) -> None:
         """
         Should construct the diagram for a GNFA when show_None = True
         """
@@ -464,7 +464,7 @@ class TestGNFA(test_fa.TestFA):
             },
         )
 
-    def test_show_diagram_write_file(self):
+    def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a NFA
         and write it to the specified file.

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -238,7 +238,13 @@ class TestGNFA(test_fa.TestFA):
                     "q0": {"q1": "a", "q_f": None, "q2": None, "q0": None},
                     "q1": {"q1": "a", "q2": "", "q_f": "", "q0": None},
                     "q2": {"q0": "b", "q_f": None, "q2": None, "q1": None},
-                    "q_in": {"q0": "", "q_f": None, "q2": None, "q1": None, "q5": {}},  # type: ignore
+                    "q_in": {
+                        "q0": "",
+                        "q_f": None,
+                        "q2": None,
+                        "q1": None,
+                        "q5": {},  # type: ignore
+                    },
                 },
                 initial_state="q_in",
                 final_state="q_f",

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -366,40 +366,6 @@ class TestGNFA(test_fa.TestFA):
             # Test equality through DFA regex conversion
             self.assertEqual(dfa_1, dfa_2)
 
-    def test_read_input_step_not_implemented(self) -> None:
-        """Should not implement read_input_stepwise() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.read_input_stepwise("aaa")
-
-    def test_union_not_implemented(self) -> None:
-        """Should not implement union() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.union(self.gnfa)
-
-    def test_concatenate_not_implemented(self) -> None:
-        """Should not implement concatenate() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.concatenate(self.gnfa)
-
-    def test_kleene_star_not_implemented(self) -> None:
-        """Should not implement kleene_star() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.kleene_star()
-
-    def test_option_not_implemented(self) -> None:
-        """Should not implement option() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.option()
-
-    def test_reverse_not_implemented(self) -> None:
-        """Should not implement reverse() for GNFA."""
-        with self.assertRaises(NotImplementedError):
-            self.gnfa.reverse()
-
-    def test_eq_not_implemented(self) -> None:
-        """Should not implement equality for GNFA."""
-        self.assertNotEqual(self.gnfa, GNFA.from_nfa(self.nfa))
-
     def test_show_diagram_showNone(self) -> None:
         """
         Should construct the diagram for a GNFA when show_None = False

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,5 +1,6 @@
 """Tests for lexer-related code."""
 
+import re
 import unittest
 
 import automata.base.exceptions as exceptions
@@ -7,15 +8,22 @@ from automata.regex.lexer import Lexer, TokenRegistry
 from automata.regex.postfix import LeftParen, RightParen, Token
 
 
-def register_parens(lexer):
+def register_parens(lexer: Lexer) -> None:
     lexer.register_token(LeftParen.from_match, r"\(")
     lexer.register_token(RightParen.from_match, r"\)")
+
+
+def make_trivial_match(input_str: str) -> re.Match:
+    pattern = re.compile(input_str)
+    match_obj = pattern.match(input_str)
+    assert match_obj is not None
+    return match_obj
 
 
 class TestTokenRegistryTestCase(unittest.TestCase):
     """Tests for token registry class."""
 
-    def test_add_token(self):
+    def test_add_token(self) -> None:
         """Test adding tokens to registry."""
 
         class AToken(Token):
@@ -24,49 +32,49 @@ class TestTokenRegistryTestCase(unittest.TestCase):
         class BToken(Token):
             pass
 
-        registry = TokenRegistry()
+        registry: TokenRegistry = TokenRegistry()
         self.assertEqual(0, len(registry._tokens))
 
-        registry.register(AToken, r"a+")
+        registry.register(AToken.from_match, r"a+")
         self.assertEqual(1, len(registry._tokens))
 
-        registry.register(BToken, r"b+")
+        registry.register(BToken.from_match, r"b+")
         self.assertEqual(2, len(registry._tokens))
 
-    def test_get_matches_no_tokens_notext(self):
+    def test_get_matches_no_tokens_notext(self) -> None:
         """Test for no matching tokens in registry with empty string."""
-        registry = TokenRegistry()
+        registry: TokenRegistry = TokenRegistry()
         self.assertEqual([], list(registry.matching_tokens("", 0)))
 
-    def test_get_matches_no_tokens_text(self):
+    def test_get_matches_no_tokens_text(self) -> None:
         """Test for no matching tokens in registry with text."""
-        registry = TokenRegistry()
+        registry: TokenRegistry = TokenRegistry()
         self.assertEqual([], list(registry.matching_tokens("foo", 0)))
 
-    def test_get_matches_notext(self):
+    def test_get_matches_notext(self) -> None:
         """Test for no matches when given a non-empty registry."""
 
         class AToken(Token):
             pass
 
-        registry = TokenRegistry()
-        registry.register(AToken, r"a")
+        registry: TokenRegistry = TokenRegistry()
+        registry.register(AToken.from_match, r"a")
         self.assertEqual([], list(registry.matching_tokens("", 0)))
 
-    def test_get_matches(self):
+    def test_get_matches(self) -> None:
         """Test for matching a single token."""
 
         class AToken(Token):
             pass
 
-        registry = TokenRegistry()
-        registry.register(AToken, r"a")
+        registry: TokenRegistry = TokenRegistry()
+        registry.register(AToken.from_match, r"a")
 
         matches = list(registry.matching_tokens("aaa", 0))
         self.assertEqual(1, len(matches))
-        self.assertTrue(isinstance(matches[0][0]("a"), AToken))
+        self.assertTrue(isinstance(matches[0][0](make_trivial_match("a")), AToken))
 
-    def test_multiple_matches(self):
+    def test_multiple_matches(self) -> None:
         """Test for multiple matches."""
 
         class AToken(Token):
@@ -75,16 +83,16 @@ class TestTokenRegistryTestCase(unittest.TestCase):
         class AAToken(Token):
             pass
 
-        registry = TokenRegistry()
-        registry.register(AToken, r"a")
-        registry.register(AAToken, r"aa")
+        registry: TokenRegistry = TokenRegistry()
+        registry.register(AToken.from_match, r"a")
+        registry.register(AAToken.from_match, r"aa")
 
         matches = list(registry.matching_tokens("aaa", 0))
         self.assertEqual(2, len(matches))
-        self.assertTrue(isinstance(matches[0][0]("a"), AToken))
-        self.assertTrue(isinstance(matches[1][0]("aa"), AAToken))
+        self.assertTrue(isinstance(matches[0][0](make_trivial_match("a")), AToken))
+        self.assertTrue(isinstance(matches[1][0](make_trivial_match("aa")), AAToken))
 
-    def test_get_token_multiple(self):
+    def test_get_token_multiple(self) -> None:
         """Test getting best match token."""
 
         class AToken(Token):
@@ -93,15 +101,17 @@ class TestTokenRegistryTestCase(unittest.TestCase):
         class AAToken(Token):
             pass
 
-        registry = TokenRegistry()
-        registry.register(AToken, r"a")
-        registry.register(AAToken, r"aa")
+        registry: TokenRegistry = TokenRegistry()
+        registry.register(AToken.from_match, r"a")
+        registry.register(AAToken.from_match, r"aa")
 
         match = registry.get_token("aaa")
-        self.assertIsNotNone(match)
-        self.assertTrue(isinstance(match[0]("aa"), AAToken))
 
-    def test_get_token_multiple_inverted(self):
+        # Using assert here because mypy doesn't like the unittest methods
+        assert match is not None
+        self.assertTrue(isinstance(match[0](make_trivial_match("aa")), AAToken))
+
+    def test_get_token_multiple_inverted(self) -> None:
         """Test getting best match token in reverse order"""
 
         class AToken(Token):
@@ -110,83 +120,83 @@ class TestTokenRegistryTestCase(unittest.TestCase):
         class AAToken(Token):
             pass
 
-        registry = TokenRegistry()
-        registry.register(AAToken, r"aa")
-        registry.register(AToken, r"a")
+        registry: TokenRegistry = TokenRegistry()
+        registry.register(AAToken.from_match, r"aa")
+        registry.register(AToken.from_match, r"a")
 
         match = registry.get_token("aaa")
-        self.assertIsNotNone(match)
-        self.assertTrue(isinstance(match[0]("aa"), AAToken))
+        assert match is not None
+        self.assertTrue(isinstance(match[0](make_trivial_match("aa")), AAToken))
 
 
 class TestGetTokenTestCase(unittest.TestCase):
     """Test token registry in lexer."""
 
-    def test_get_token_no_text(self):
+    def test_get_token_no_text(self) -> None:
         """Test getting a token given an empty string."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         token_match = lexer.tokens.get_token("")
         self.assertIsNone(token_match)
 
-    def test_get_token_no_text_no_tokens(self):
+    def test_get_token_no_text_no_tokens(self) -> None:
         """Test getting a token on an empty string."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         token_match = lexer.tokens.get_token("")
         self.assertIsNone(token_match)
 
-    def test_get_token_unmatched(self):
+    def test_get_token_unmatched(self) -> None:
         """Test getting a token without any in the registry."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         token_match = lexer.tokens.get_token("aaa")
         self.assertIsNone(token_match)
 
-    def test_get_token_no_tokens(self):
+    def test_get_token_no_tokens(self) -> None:
         """Test getting a token with an empty registry."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
 
         token_match = lexer.tokens.get_token("aaa")
         self.assertIsNone(token_match)
 
-    def test_get_token(self):
+    def test_get_token(self) -> None:
         """Test getting left paren tokens."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         match = lexer.tokens.get_token("(((")
-        self.assertIsNotNone(match)
+        assert match is not None
         token_factory_fn, re_match = match
 
         self.assertTrue(isinstance(token_factory_fn(re_match), LeftParen))
         self.assertIsNotNone(re_match)
 
-    def test_get_token_picks_first(self):
+    def test_get_token_picks_first(self) -> None:
         """Test that tokens are retrieved from the start."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         token_match = lexer.tokens.get_token("aa(((")
         self.assertIsNone(token_match)
 
-    def test_get_token_scans_all_possible_tokens(self):
+    def test_get_token_scans_all_possible_tokens(self) -> None:
         """Test that the lexer scans all tokens in registry."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         match = lexer.tokens.get_token(")(")
-        self.assertIsNotNone(match)
+        assert match is not None
         token_factory_fn, re_match = match
 
         self.assertTrue(isinstance(token_factory_fn(re_match), RightParen))
         self.assertIsNotNone(re_match)
 
-    def test_longest_match(self):
+    def test_longest_match(self) -> None:
         """Test that the returned match is the longest one."""
 
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
 
         class AToken(Token):
             pass
@@ -194,32 +204,32 @@ class TestGetTokenTestCase(unittest.TestCase):
         class AAToken(Token):
             pass
 
-        lexer.register_token(AToken, r"a")
-        lexer.register_token(AAToken, r"aa")
+        lexer.register_token(AToken.from_match, r"a")
+        lexer.register_token(AAToken.from_match, r"aa")
 
         match = lexer.tokens.get_token("aaa")
-        self.assertIsNotNone(match)
+        assert match is not None
 
         token_factory_fn, re_match = match
-        self.assertTrue(isinstance(token_factory_fn("aa"), AAToken))
+        self.assertTrue(isinstance(token_factory_fn(make_trivial_match("aa")), AAToken))
 
 
 class TestRegisterTokensTestCase(unittest.TestCase):
     """Tests for Lexer.register_token."""
 
-    def test_register_token(self):
+    def test_register_token(self) -> None:
         """Test basic token registration."""
 
         class AToken(Token):
             pass
 
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         self.assertEqual(0, len(lexer.tokens))
 
-        lexer.register_token(AToken, r"a")
+        lexer.register_token(AToken.from_match, r"a")
         self.assertEqual(1, len(lexer.tokens))
 
-    def test_register_tokens(self):
+    def test_register_tokens(self) -> None:
         """Test registering multiple tokens."""
 
         class AToken(Token):
@@ -228,42 +238,42 @@ class TestRegisterTokensTestCase(unittest.TestCase):
         class BToken(Token):
             pass
 
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         self.assertEqual(0, len(lexer.tokens))
 
-        lexer.register_token(AToken, r"a")
-        lexer.register_token(BToken, r"b")
+        lexer.register_token(AToken.from_match, r"a")
+        lexer.register_token(BToken.from_match, r"b")
         self.assertEqual(2, len(lexer.tokens))
 
         match_a = lexer.tokens.get_token("a")
-        self.assertIsNotNone(match_a)
+        assert match_a is not None
         token_factory_fn_a, re_match_a = match_a
 
-        self.assertTrue(isinstance(token_factory_fn_a("a"), AToken))
+        self.assertTrue(isinstance(token_factory_fn_a(make_trivial_match("a")), AToken))
         self.assertIsNotNone(re_match_a)
 
         match_b = lexer.tokens.get_token("b")
-        self.assertIsNotNone(match_b)
+        assert match_b is not None
         token_factory_fn_b, re_match_b = match_b
 
-        self.assertTrue(isinstance(token_factory_fn_b("b"), BToken))
+        self.assertTrue(isinstance(token_factory_fn_b(make_trivial_match("b")), BToken))
         self.assertIsNotNone(re_match_b)
 
 
 class TestLexTestCase(unittest.TestCase):
     """Tests for the Lexer class."""
 
-    def test_lex_empty(self):
+    def test_lex_empty(self) -> None:
         """Test lexing an empty string."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         tokens = lexer.lex("")
         self.assertEqual(0, len(tokens))
 
-    def test_lex_tokens(self):
+    def test_lex_tokens(self) -> None:
         """Test lexing parenthesis."""
 
         text = "((((((()()()))))))((((((("
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         tokens = lexer.lex(text)
@@ -275,10 +285,10 @@ class TestLexTestCase(unittest.TestCase):
             else:
                 self.assertTrue(isinstance(token, RightParen))
 
-    def test_lex_skips_blank(self):
+    def test_lex_skips_blank(self) -> None:
         """Test that the lexer skips blank characters."""
 
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         register_parens(lexer)
 
         tokens = lexer.lex("  (")
@@ -286,10 +296,10 @@ class TestLexTestCase(unittest.TestCase):
         self.assertEqual("(", tokens[0].text)
         self.assertTrue(isinstance(tokens[0], LeftParen))
 
-    def test_lex_custom_blank_chars(self):
+    def test_lex_custom_blank_chars(self) -> None:
         """Test lexing custom blank characters."""
 
-        lexer = Lexer(blank_chars={"a", " "})
+        lexer: Lexer = Lexer(blank_chars={"a", " "})
         register_parens(lexer)
 
         tokens = lexer.lex(" a(")
@@ -297,21 +307,21 @@ class TestLexTestCase(unittest.TestCase):
         self.assertEqual("(", tokens[0].text)
         self.assertTrue(isinstance(tokens[0], LeftParen))
 
-    def test_lex_invalid_char(self):
+    def test_lex_invalid_char(self) -> None:
         """Test that the lexer throws an exception on invalid characters."""
-        lexer = Lexer()
+        lexer: Lexer = Lexer()
         with self.assertRaises(exceptions.LexerError) as cm:
             lexer.lex("foo")
         self.assertEqual(cm.exception.position, 0)
 
-    def test_lex_error_position(self):
+    def test_lex_error_position(self) -> None:
         """Test the position for the lexer error."""
 
         class AToken(Token):
             pass
 
-        lexer = Lexer()
-        lexer.register_token(AToken, r"a")
+        lexer: Lexer = Lexer()
+        lexer.register_token(AToken.from_match, r"a")
 
         with self.assertRaises(exceptions.LexerError) as cm:
             lexer.lex("aaaabaaa")

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -122,15 +122,6 @@ class TestTokenRegistryTestCase(unittest.TestCase):
 class TestGetTokenTestCase(unittest.TestCase):
     """Test token registry in lexer."""
 
-    def test_token_precedence(self):
-        """Test that get_precedence starts as not implemented."""
-
-        class AToken(Token):
-            pass
-
-        with self.assertRaises(NotImplementedError):
-            AToken("").get_precedence()
-
     def test_get_token_no_text(self):
         """Test getting a token given an empty string."""
         lexer = Lexer()

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -5,7 +5,7 @@ import string
 import tempfile
 import types
 from itertools import product
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from frozendict import frozendict
 
@@ -20,39 +20,39 @@ class TestNFA(test_fa.TestFA):
 
     temp_dir_path = tempfile.gettempdir()
 
-    def test_init_nfa(self):
+    def test_init_nfa(self) -> None:
         """Should copy NFA if passed into NFA constructor."""
         new_nfa = self.nfa.copy()
         self.assertIsNot(new_nfa, self.nfa)
 
-    def test_init_nfa_missing_formal_params(self):
+    def test_init_nfa_missing_formal_params(self) -> None:
         """Should raise an error if formal NFA parameters are missing."""
         with self.assertRaises(TypeError):
-            NFA(
+            NFA(  # type: ignore
                 states={"q0", "q1"},
                 input_symbols={"0", "1"},
                 initial_state="q0",
                 final_states={"q1"},
             )
 
-    def test_copy_nfa(self):
+    def test_copy_nfa(self) -> None:
         """Should create exact copy of NFA if copy() method is called."""
         new_nfa = self.nfa.copy()
         self.assertIsNot(new_nfa, self.nfa)
 
-    def test_nfa_immutable_attr_set(self):
+    def test_nfa_immutable_attr_set(self) -> None:
         with self.assertRaises(AttributeError):
-            self.nfa.states = {}
+            self.nfa.states = {}  # type: ignore
 
-    def test_nfa_immutable_attr_del(self):
+    def test_nfa_immutable_attr_del(self) -> None:
         with self.assertRaises(AttributeError):
             del self.nfa.states
 
-    def test_nfa_immutable_dict(self):
+    def test_nfa_immutable_dict(self) -> None:
         """Should create an NFA whose contents are fully immutable/hashable"""
         self.assertIsInstance(hash(frozendict(self.nfa.input_parameters)), int)
 
-    def test_init_dfa(self):
+    def test_init_dfa(self) -> None:
         """Should convert DFA to NFA if passed into NFA constructor."""
         nfa = NFA.from_dfa(self.dfa)
         self.assertEqual(nfa.states, {"q0", "q1", "q2"})
@@ -68,12 +68,12 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa.initial_state, "q0")
 
     @patch("automata.fa.nfa.NFA.validate")
-    def test_init_validation(self, validate):
+    def test_init_validation(self, validate: MagicMock) -> None:
         """Should validate NFA when initialized."""
         self.nfa.copy()
         validate.assert_called_once_with()
 
-    def test_nfa_equal(self):
+    def test_nfa_equal(self) -> None:
         """Should correctly determine if two NFAs are equal."""
         nfa1 = NFA(
             states={"q0", "q1", "q2", "q3"},
@@ -102,7 +102,7 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa1, nfa2)
         self.assertEqual(nfa1.eliminate_lambda(), nfa2.eliminate_lambda())
 
-    def test_nfa_not_equal(self):
+    def test_nfa_not_equal(self) -> None:
         """Should correctly determine if two NFAs are not equal."""
         nfa1 = NFA(
             states={"q0", "q1", "q2"},
@@ -124,7 +124,7 @@ class TestNFA(test_fa.TestFA):
         )
         self.assertNotEqual(nfa1, nfa2)
 
-    def test_validate_invalid_symbol(self):
+    def test_validate_invalid_symbol(self) -> None:
         """Should raise error if a transition references an invalid symbol."""
         with self.assertRaises(exceptions.InvalidSymbolError):
             NFA(
@@ -135,7 +135,7 @@ class TestNFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_state(self):
+    def test_validate_invalid_state(self) -> None:
         """Should raise error if a transition references an invalid state."""
         with self.assertRaises(exceptions.InvalidStateError):
             NFA(
@@ -146,7 +146,7 @@ class TestNFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_invalid_initial_state(self):
+    def test_validate_invalid_initial_state(self) -> None:
         """Should raise error if the initial state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             NFA(
@@ -157,7 +157,7 @@ class TestNFA(test_fa.TestFA):
                 final_states={"q0"},
             )
 
-    def test_validate_initial_state_transitions(self):
+    def test_validate_initial_state_transitions(self) -> None:
         """Should raise error if the initial state has no transitions."""
         with self.assertRaises(exceptions.MissingStateError):
             NFA(
@@ -168,7 +168,7 @@ class TestNFA(test_fa.TestFA):
                 final_states={"q1"},
             )
 
-    def test_validate_invalid_final_state(self):
+    def test_validate_invalid_final_state(self) -> None:
         """Should raise error if the final state is invalid."""
         with self.assertRaises(exceptions.InvalidStateError):
             NFA(
@@ -179,7 +179,7 @@ class TestNFA(test_fa.TestFA):
                 final_states={"q1"},
             )
 
-    def test_validate_invalid_final_state_non_str(self):
+    def test_validate_invalid_final_state_non_str(self) -> None:
         """Should raise InvalidStateError even for non-string final states."""
         with self.assertRaises(exceptions.InvalidStateError):
             NFA(
@@ -191,11 +191,11 @@ class TestNFA(test_fa.TestFA):
             )
             self.nfa.validate()
 
-    def test_read_input_accepted(self):
+    def test_read_input_accepted(self) -> None:
         """Should return correct states if acceptable NFA input is given."""
         self.assertEqual(self.nfa.read_input("aba"), {"q1", "q2"})
 
-    def test_validate_missing_state(self):
+    def test_validate_missing_state(self) -> None:
         """Should silently ignore states without transitions defined."""
         NFA(
             states={"q0"},
@@ -206,17 +206,17 @@ class TestNFA(test_fa.TestFA):
         )
         self.assertIsNotNone(self.nfa.transitions)
 
-    def test_read_input_rejection(self):
+    def test_read_input_rejection(self) -> None:
         """Should raise error if the stop state is not a final state."""
         with self.assertRaises(exceptions.RejectionException):
             self.nfa.read_input("abba")
 
-    def test_read_input_rejection_invalid_symbol(self):
+    def test_read_input_rejection_invalid_symbol(self) -> None:
         """Should raise error if an invalid symbol is read."""
         with self.assertRaises(exceptions.RejectionException):
             self.nfa.read_input("abc")
 
-    def test_read_input_step(self):
+    def test_read_input_step(self) -> None:
         """Should return validation generator if step flag is supplied."""
         validation_generator = self.nfa.read_input_stepwise("aba")
         self.assertIsInstance(validation_generator, types.GeneratorType)
@@ -224,15 +224,15 @@ class TestNFA(test_fa.TestFA):
             list(validation_generator), [{"q0"}, {"q1", "q2"}, {"q0"}, {"q1", "q2"}]
         )
 
-    def test_accepts_input_true(self):
+    def test_accepts_input_true(self) -> None:
         """Should return True if NFA input is accepted."""
         self.assertTrue(self.nfa.accepts_input("aba"))
 
-    def test_accepts_input_false(self):
+    def test_accepts_input_false(self) -> None:
         """Should return False if NFA input is rejected."""
         self.assertFalse(self.nfa.accepts_input("abba"))
 
-    def test_cyclic_lambda_transitions(self):
+    def test_cyclic_lambda_transitions(self) -> None:
         """Should traverse NFA containing cyclic lambda transitions."""
         # NFA which matches zero or more occurrences of 'a'
         nfa = NFA(
@@ -250,11 +250,11 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa.read_input(""), {"q0", "q1", "q3"})
         self.assertEqual(nfa.read_input("a"), {"q0", "q1", "q2", "q3"})
 
-    def test_non_str_states(self):
+    def test_non_str_states(self) -> None:
         """Should handle non-string state names"""
         nfa = NFA(
             states={0},
-            input_symbols={0},
+            input_symbols={"0"},
             transitions={0: {}},
             initial_state=0,
             final_states=set(),
@@ -263,7 +263,7 @@ class TestNFA(test_fa.TestFA):
         # raised
         self.assertIsNotNone(nfa.accepts_input(""))
 
-    def test_operations_other_type(self):
+    def test_operations_other_type(self) -> None:
         """Should raise TypeError for concatenate."""
         nfa = NFA(
             states={"q1", "q2", "q3", "q4"},
@@ -279,9 +279,9 @@ class TestNFA(test_fa.TestFA):
         )
         other = 42
         with self.assertRaises(TypeError):
-            nfa + other
+            nfa + other  # type: ignore
 
-    def test_concatenate(self):
+    def test_concatenate(self) -> None:
         nfa_a = NFA(
             states={"q1", "q2", "q3", "q4"},
             input_symbols={"0", "1"},
@@ -320,7 +320,7 @@ class TestNFA(test_fa.TestFA):
         self.assertTrue(concat_nfa.accepts_input("101100"))
         self.assertTrue(concat_nfa.accepts_input("1010"))
 
-    def test_kleene_star(self):
+    def test_kleene_star(self) -> None:
         """Should perform the Kleene Star operation on an NFA"""
         # This NFA accepts aa and ab
         nfa = NFA(
@@ -355,7 +355,7 @@ class TestNFA(test_fa.TestFA):
         self.assertTrue(kleene_nfa.accepts_input("aaabababaaaaab"))
         self.assertFalse(kleene_nfa.accepts_input("aaabababaaaaba"))
 
-    def test_reverse(self):
+    def test_reverse(self) -> None:
         """Should reverse an NFA"""
         nfa = NFA(
             states={0, 1, 2, 4},
@@ -369,14 +369,15 @@ class TestNFA(test_fa.TestFA):
             initial_state=0,
             final_states={2},
         )
-        reverse_nfa = reversed(nfa)
+
+        reverse_nfa = nfa.reverse()
         self.assertFalse(reverse_nfa.accepts_input("a"))
         self.assertFalse(reverse_nfa.accepts_input("ab"))
         self.assertTrue(reverse_nfa.accepts_input("ba"))
         self.assertTrue(reverse_nfa.accepts_input("bba"))
         self.assertTrue(reverse_nfa.accepts_input("bbba"))
 
-    def test_from_regex(self):
+    def test_from_regex(self) -> None:
         """Test if from_regex produces correct NFA"""
         input_symbols = {"a", "b", "c", "d"}
         nfa1 = NFA.from_regex("ab(cd*|dc)|a?", input_symbols=input_symbols)
@@ -401,10 +402,10 @@ class TestNFA(test_fa.TestFA):
 
         self.assertEqual(nfa1, nfa2)
 
-    def test_from_regex_empty_string(self):
+    def test_from_regex_empty_string(self) -> None:
         NFA.from_regex("")
 
-    def test_eliminate_lambda(self):
+    def test_eliminate_lambda(self) -> None:
         original_nfa = NFA(
             states={0, 1, 2, 3, 4, 5, 6},
             initial_state=0,
@@ -438,7 +439,7 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
         self.assertNotEqual(nfa1._lambda_closures, original_nfa._lambda_closures)
 
-    def test_eliminate_lambda_other(self):
+    def test_eliminate_lambda_other(self) -> None:
         original_nfa = NFA(
             states={0, 1, 2},
             initial_state=0,
@@ -464,7 +465,7 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
         self.assertNotEqual(nfa1._lambda_closures, original_nfa._lambda_closures)
 
-    def test_eliminate_lambda_regex(self):
+    def test_eliminate_lambda_regex(self) -> None:
         nfa = NFA.from_regex(
             "a(aaa*bbcd|abbcd)d*|aa*bb(dcc*|(d|c)b|a?bb(dcc*|(d|c)))ab(c|d)*(ccd)?"
         )
@@ -475,7 +476,7 @@ class TestNFA(test_fa.TestFA):
             for char in transition.keys():
                 self.assertNotEqual(char, "")
 
-    def test_option(self):
+    def test_option(self) -> None:
         """
         Given a NFA recognizing language L, should return NFA
         such that it accepts the language 'L?'
@@ -496,7 +497,7 @@ class TestNFA(test_fa.TestFA):
             )
         )
 
-    def test_union(self):
+    def test_union(self) -> None:
         input_symbols = {"a", "b"}
         nfa1 = NFA.from_regex("ab*", input_symbols=input_symbols)
         nfa2 = NFA.from_regex("ba*", input_symbols=input_symbols)
@@ -533,9 +534,9 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa | self.dfa
+            self.nfa | self.dfa  # type: ignore
 
-    def test_intersection(self):
+    def test_intersection(self) -> None:
         nfa1 = NFA.from_regex("aaaa*")
         nfa2 = NFA.from_regex("(a)|(aa)|(aaa)")
 
@@ -558,9 +559,9 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa & self.dfa
+            self.nfa & self.dfa  # type: ignore
 
-    def test_validate_regex(self):
+    def test_validate_regex(self) -> None:
         """Should raise an error if invalid regex is passed into NFA.from_regex()"""
 
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "ab|")
@@ -577,7 +578,7 @@ class TestNFA(test_fa.TestFA):
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "a(*)")
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "ab(|)")
 
-    def test_show_diagram_initial_final_same(self):
+    def test_show_diagram_initial_final_same(self) -> None:
         """
         Should construct the diagram for a NFA whose initial state
         is also a final state.
@@ -610,7 +611,7 @@ class TestNFA(test_fa.TestFA):
             {("q0", "a", "q1"), ("q1", "a", "q1"), ("q1", "", "q2"), ("q2", "b", "q0")},
         )
 
-    def test_show_diagram_write_file(self):
+    def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a NFA
         and write it to the specified file.
@@ -625,7 +626,7 @@ class TestNFA(test_fa.TestFA):
         self.assertTrue(os.path.exists(diagram_path))
         os.remove(diagram_path)
 
-    def test_add_new_state_type_integrity(self):
+    def test_add_new_state_type_integrity(self) -> None:
         """
         Should properly add new state of different type than original states;
         see <https://github.com/caleb531/automata/issues/60> for more details
@@ -646,7 +647,7 @@ class TestNFA(test_fa.TestFA):
             "DFA and NFA are not equivalent when they should be",
         )
 
-    def test_nfa_equality(self):
+    def test_nfa_equality(self) -> None:
         input_symbols = {"0", "1"}
         nfa1 = NFA(
             states={"s", "a", "b", "c", "d", "e", "f", "g", "h"},
@@ -760,7 +761,7 @@ class TestNFA(test_fa.TestFA):
             ),
         )
 
-    def test_nfa_levenshtein_distance(self):
+    def test_nfa_levenshtein_distance(self) -> None:
         alphabet = {"f", "o", "d", "a"}
 
         nfa = NFA(
@@ -876,7 +877,7 @@ class TestNFA(test_fa.TestFA):
                 alphabet, "food", 2, insertion=False, deletion=False, substitution=False
             )
 
-    def test_nfa_hamming_distance(self):
+    def test_nfa_hamming_distance(self) -> None:
         alphabet = {"f", "o", "d", "a"}
 
         nfa = NFA(
@@ -991,7 +992,7 @@ class TestNFA(test_fa.TestFA):
         for close_string in close_strings_insertion_deletion:
             self.assertFalse(nice_nfa.accepts_input(close_string))
 
-    def test_nfa_LCS_distance(self):
+    def test_nfa_LCS_distance(self) -> None:
         alphabet = {"f", "o", "d", "a"}
 
         nfa = NFA(
@@ -1103,7 +1104,7 @@ class TestNFA(test_fa.TestFA):
             self.assertTrue(nice_nfa_deletion.accepts_input(close_string))
             self.assertFalse(nice_nfa_insertion.accepts_input(close_string))
 
-    def test_nfa_shuffle_product(self):
+    def test_nfa_shuffle_product(self) -> None:
         """
         Test shuffle product of two NFAs.
 
@@ -1154,9 +1155,9 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa.shuffle_product(self.dfa)
+            self.nfa.shuffle_product(self.dfa)  # type: ignore
 
-    def test_nfa_shuffle_product_set_laws(self):
+    def test_nfa_shuffle_product_set_laws(self) -> None:
         """Test set laws for shuffle product"""
         alphabet = {"a", "b"}
 
@@ -1178,7 +1179,7 @@ class TestNFA(test_fa.TestFA):
             nfa1.shuffle_product(nfa2).union(nfa1.shuffle_product(nfa3)),
         )
 
-    def test_right_quotient(self):
+    def test_right_quotient(self) -> None:
         """
         Tests for right quotient operator,
         based on https://www.geeksforgeeks.org/quotient-operation-in-automata/
@@ -1239,9 +1240,9 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa.right_quotient(self.dfa)
+            self.nfa.right_quotient(self.dfa)  # type: ignore
 
-    def test_left_quotient(self):
+    def test_left_quotient(self) -> None:
         """
         Tests for left quotient operator,
         based on https://www.geeksforgeeks.org/quotient-operation-in-automata/
@@ -1291,9 +1292,9 @@ class TestNFA(test_fa.TestFA):
 
         # raise error if other is not NFA
         with self.assertRaises(TypeError):
-            self.nfa.left_quotient(self.dfa)
+            self.nfa.left_quotient(self.dfa)  # type: ignore
 
-    def test_quotient_properties(self):
+    def test_quotient_properties(self) -> None:
         """Test some properties of quotients, based on
         https://planetmath.org/quotientoflanguages"""
 

--- a/tests/test_postfix.py
+++ b/tests/test_postfix.py
@@ -1,62 +1,65 @@
 """Tests of the postfix conversion and parsing utility functions."""
 
 import unittest
+from typing import List, TypeVar
 
 import automata.base.exceptions as exceptions
 import automata.regex.postfix as postfix
-from automata.regex.lexer import Lexer
+from automata.regex.lexer import Lexer, Token
+
+ResultT = TypeVar("ResultT")
 
 
-class Integer(postfix.Literal):
-    def val(self):
+class Integer(postfix.Literal[int]):
+    def val(self) -> int:
         """It evaluates to its (integer) value."""
         return int(self.text)
 
 
-class Add(postfix.InfixOperator):
+class Add(postfix.InfixOperator[int]):
     """Addition."""
 
-    def get_precedence(self):
+    def get_precedence(self) -> int:
         return 10  # Precedence: higher than integers, lower than mult
 
-    def op(self, left, right):
+    def op(self, left: int, right: int) -> int:
         return left + right
 
 
-class Minus(postfix.InfixOperator):
+class Minus(postfix.InfixOperator[int]):
     """Subtraction."""
 
-    def get_precedence(self):
+    def get_precedence(self) -> int:
         return 10  # Precedence: higher than integers, lower than mult
 
-    def op(self, left, right):
+    def op(self, left: int, right: int) -> int:
         return left - right
 
 
-class Mult(postfix.InfixOperator):
+class Mult(postfix.InfixOperator[int]):
     """Multiplication."""
 
-    def get_precedence(self):
+    def get_precedence(self) -> int:
         return 20  # Higher precedence than addition/substraction.
 
-    def op(self, left, right):
+    def op(self, left, right) -> int:
         return left * right
 
 
-class Divide(postfix.InfixOperator):
+class Divide(postfix.InfixOperator[int]):
     """Division."""
 
-    def get_precedence(self):
+    def get_precedence(self) -> int:
         return 20  # Same precedence than multiplication
 
-    def op(self, left, right):
+    def op(self, left: int, right: int) -> int:
         return left // right
 
 
 class TestTokens(unittest.TestCase):
     """Test token subclasses for not implemented errors."""
 
-    def test_token_abstract_methods_not_implemented(self):
+    def test_token_abstract_methods_not_implemented(self) -> None:
         """Should raise NotImplementedError when calling abstract methods."""
 
         with self.assertRaises(NotImplementedError):
@@ -75,12 +78,12 @@ class TestTokens(unittest.TestCase):
 class TestArithmeticParser(unittest.TestCase):
     """Test parsing arithmetic expressions."""
 
-    def test_parse_invalid_token(self):
+    def test_parse_invalid_token(self) -> None:
         """Test exception for invalid input tokens."""
         with self.assertRaises(exceptions.InvalidRegexError):
-            postfix.parse_postfix_tokens([""])
+            postfix.parse_postfix_tokens([""])  # type: ignore
 
-    def test_nested_parenthesized_expression(self):
+    def test_nested_parenthesized_expression(self) -> None:
         """Test parsing parenthesized expression."""
         # Parsing:
         # "( 4 + ( 1 + 2 * 3 * ( 4 + 5 ) + 6 ) ) * 7 + 8"
@@ -114,8 +117,8 @@ class TestArithmeticParser(unittest.TestCase):
         res = postfix.parse_postfix_tokens(postfix_tokens)
         self.assertEqual((4 + (1 + 2 * 3 * (4 + 5) + 6)) * 7 + 8, res)
 
-    def setUp(self):
-        self.arithmetic_lexer = Lexer()
+    def setUp(self) -> None:
+        self.arithmetic_lexer: Lexer = Lexer()
 
         self.arithmetic_lexer.register_token(postfix.LeftParen.from_match, r"\(")
         self.arithmetic_lexer.register_token(postfix.RightParen.from_match, r"\)")
@@ -125,7 +128,7 @@ class TestArithmeticParser(unittest.TestCase):
         self.arithmetic_lexer.register_token(Mult.from_match, r"\*")
         self.arithmetic_lexer.register_token(Divide.from_match, r"/")
 
-    def test_expression_invalid_ordering(self):
+    def test_expression_invalid_ordering(self) -> None:
         """Check for exception raised when lexing invalid regular expressions."""
 
         with self.assertRaises(exceptions.InvalidRegexError):
@@ -152,22 +155,22 @@ class TestArithmeticParser(unittest.TestCase):
         with self.assertRaises(exceptions.InvalidRegexError):
             postfix.validate_tokens(self.arithmetic_lexer.lex("6/)"))
 
-    def parse(self, tokens):
+    def parse(self, tokens: List[Token[ResultT]]) -> ResultT:
         """Helper function for parsing token list tokens"""
         postfix_tokens = postfix.tokens_to_postfix(tokens)
         return postfix.parse_postfix_tokens(postfix_tokens)
 
-    def test_single_number(self):
+    def test_single_number(self) -> None:
         """Test parsing a single number."""
         val = self.parse(self.arithmetic_lexer.lex("13"))
         self.assertEqual(13, val)
 
-    def test_negative_number(self):
+    def test_negative_number(self) -> None:
         """Test parsing a negative number."""
         val = self.parse(self.arithmetic_lexer.lex("0-13"))
         self.assertEqual(-13, val)
 
-    def test_simple_mult(self):
+    def test_simple_mult(self) -> None:
         """Test parsing simple multiplication."""
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("2 * 4")))
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("2 * 2 * 2")))
@@ -175,18 +178,18 @@ class TestArithmeticParser(unittest.TestCase):
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("(2 * 2) * 2")))
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("(2 + 2) * 2")))
 
-    def test_precedence(self):
+    def test_precedence(self) -> None:
         """Test checking for correct precedence."""
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("2 * 3 + 2")))
         self.assertEqual(10, self.parse(self.arithmetic_lexer.lex("2 * (3+2)")))
 
-    def test_negative_mult(self):
+    def test_negative_mult(self) -> None:
         """Test multiplying negative numbers."""
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("(0-2) * (0- 4)")))
         self.assertEqual(8, self.parse(self.arithmetic_lexer.lex("(0-2) * 2 * (0-2)")))
         self.assertEqual(-5, self.parse(self.arithmetic_lexer.lex("1 + (0-2) * 3")))
 
-    def test_division(self):
+    def test_division(self) -> None:
         """Test dividing numbers."""
         self.assertEqual(2, self.parse(self.arithmetic_lexer.lex("4 / 2")))
         self.assertEqual(2, self.parse(self.arithmetic_lexer.lex("5 / 2")))

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -13,12 +13,12 @@ from automata.regex.parser import StringToken, WildcardToken
 class TestRegex(unittest.TestCase):
     """A test class for testing regular expression tools"""
 
-    def test_validate_valid(self):
+    def test_validate_valid(self) -> None:
         """Should pass validation for valid regular expression"""
         re.validate("a*")
         re.validate("b|a?*")
 
-    def test_validate_invalid(self):
+    def test_validate_invalid(self) -> None:
         """Should raise error for invalid regular expressions"""
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "ab|")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "?")
@@ -33,17 +33,17 @@ class TestRegex(unittest.TestCase):
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "a{-1,}")
         self.assertRaises(exceptions.InvalidRegexError, re.validate, "a{-2,-1}")
 
-    def test_invalid_token_creation(self):
+    def test_invalid_token_creation(self) -> None:
         """Should raise error for invalid class creation"""
         match_obj = regex.compile("a").match("a")
         self.assertRaises(NotImplementedError, StringToken.from_match, match_obj)
         self.assertRaises(NotImplementedError, WildcardToken.from_match, match_obj)
 
-    def test_helper_validate_invalid(self):
+    def test_helper_validate_invalid(self) -> None:
         """Should pass validation for valid regular expression"""
         self.assertFalse(re._validate("a(|)"))
 
-    def test_isequal(self):
+    def test_isequal(self) -> None:
         """Should correctly check equivalence of two regular expressions"""
 
         self.assertTrue(re.isequal("aa?", "a|aa"))
@@ -62,7 +62,7 @@ class TestRegex(unittest.TestCase):
             )
         )
 
-    def test_not_isequal(self):
+    def test_not_isequal(self) -> None:
         """Should correctly check non-equivalence of two regular expressions"""
 
         self.assertFalse(
@@ -72,21 +72,21 @@ class TestRegex(unittest.TestCase):
             )
         )
 
-    def test_issubset(self):
+    def test_issubset(self) -> None:
         """Should correctly verify if re1 is subset of re2"""
 
         self.assertTrue(re.issubset("aa?", "a*"))
         self.assertFalse(re.issubset("a*", "a?"))
         self.assertTrue(re.issubset("aaa*b|bc", "a*b|b*c*"))
 
-    def test_issuperset(self):
+    def test_issuperset(self) -> None:
         """Should correctly verify if re1 is superset of re2"""
 
         self.assertFalse(re.issuperset("aa?", "a*"))
         self.assertTrue(re.issuperset("a*", "a?"))
         self.assertTrue(re.issuperset("a*b|b*c*", "aaa*b|bc"))
 
-    def test_intersection(self):
+    def test_intersection(self) -> None:
         """Should correctly check intersection of two regular expressions"""
         # Basic test
         nfa_1 = NFA.from_regex("(0|(01))&(01)")
@@ -117,7 +117,7 @@ class TestRegex(unittest.TestCase):
 
         self.assertEqual(nfa_7, nfa_8)
 
-    def test_kleene_plus(self):
+    def test_kleene_plus(self) -> None:
         """Should correctly check kleene plus of two regular expressions"""
         # Basic test
         self.assertTrue(re.isequal("aa*", "a+"))
@@ -127,7 +127,7 @@ class TestRegex(unittest.TestCase):
         self.assertFalse(re.isequal("a*", "a+"))
         self.assertTrue(re.issuperset("a*", "a+"))
 
-    def test_wildcard(self):
+    def test_wildcard(self) -> None:
         """Should correctly check wildcard"""
 
         input_symbols = {"a", "b", "c"}
@@ -141,7 +141,7 @@ class TestRegex(unittest.TestCase):
         self.assertTrue(re.issubset("a.b", "...", input_symbols=input_symbols))
         self.assertTrue(re.issuperset(".", "a|b", input_symbols=input_symbols))
 
-    def test_shuffle(self):
+    def test_shuffle(self) -> None:
         """Should correctly check shuffle"""
 
         input_symbols = {"a", "b", "c", "d"}
@@ -168,7 +168,7 @@ class TestRegex(unittest.TestCase):
         other_nfa = NFA.shuffle_product(NFA.from_regex("a*"), NFA.from_regex("ba"))
         self.assertEqual(reference_nfa, other_nfa)
 
-    def test_quantifier(self):
+    def test_quantifier(self) -> None:
         """Should correctly check quantifier"""
 
         input_symbols = {"a", "b", "c", "d"}
@@ -202,14 +202,14 @@ class TestRegex(unittest.TestCase):
             )
         )
 
-    def test_blank(self):
+    def test_blank(self) -> None:
         """Should correctly parse blank"""
         self.assertTrue(re.isequal("()", ""))
         self.assertTrue(re.isequal("a|()", "a?"))
         self.assertTrue(re.isequal("a()", "a"))
         self.assertTrue(re.isequal("a()b()()c()", "abc"))
 
-    def test_invalid_symbols(self):
+    def test_invalid_symbols(self) -> None:
         """Should throw exception if reserved character is in input symbols"""
         with self.assertRaises(exceptions.InvalidSymbolError):
             NFA.from_regex("a+", input_symbols={"a", "+"})


### PR DESCRIPTION
@caleb531 See title. A number of small changes accompanied this, to make the adoption of type hints simpler.

- `GNFA` no longer inherits from `NFA`. There was very little actual logic sharing between these classes. This eliminated the need for some redundant tests.
- Some minor changes to the internals of the regex lexer (some methods were just not needed).
- Removed `__reversed__` method for `NFA` class, since this method has different intended usage (should be used on sequences).