### PR TITLE
Proper support for allow_partial

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -307,7 +307,7 @@ class DFA(fa.FA):
     ) -> Self:
 
         added_trap_state = False
-        new_transitions: Dict[DFAStateT, DFAPathT] = {}
+        new_transitions: Dict[DFAStateT, Dict[str, DFAStateT]] = {}
 
         for state, state_path in transitions.items():
             new_state_path = new_transitions.setdefault(state, state_path)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1241,7 +1241,7 @@ class DFA(fa.FA):
         prefix: str,
         *,
         contains: bool = True,
-        as_partial: bool = False,
+        as_partial: bool = True,
     ) -> Self:
         """
         Directly computes the minimal DFA recognizing strings with the

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1834,7 +1834,7 @@ class DFA(fa.FA):
             current_state_name = get_name(current_states)
 
             # Add NFA states to DFA as it is constructed from NFA.
-            dfa_transitions[current_state_name] = {}
+            path_dict = dfa_transitions.setdefault(current_state_name, {})
             if not current_states.isdisjoint(target_nfa.final_states):
                 dfa_final_states.add(current_state_name)
 
@@ -1843,10 +1843,9 @@ class DFA(fa.FA):
                 input_symbol,
                 next_current_states,
             ) in target_nfa._iterate_through_symbol_path_pairs(current_states):
+                
                 next_current_states_name = get_name(next_current_states)
-                dfa_transitions[current_state_name][
-                    input_symbol
-                ] = next_current_states_name
+                path_dict[input_symbol] = next_current_states_name
 
                 # Only enqueue a state if it has not been seen yet.
                 if next_current_states_name not in dfa_states:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -2,6 +2,7 @@
 """Classes and methods for working with deterministic finite automata."""
 from __future__ import annotations
 
+import array
 from collections import defaultdict, deque
 from itertools import chain, count
 from random import Random
@@ -1397,7 +1398,9 @@ class DFA(fa.FA):
         If contains is set to False then the complement is constructed instead.
         If must_be_suffix is set to True, then the substring must be a suffix instead.
         """
-        transitions: DFATransitionsT = {i: {} for i in range(len(substring))}
+        transitions: Dict[DFAStateT, Dict[str, DFAStateT]] = {
+            i: {} for i in range(len(substring))
+        }
         transitions[len(substring)] = {
             symbol: len(substring) for symbol in input_symbols
         }
@@ -1405,7 +1408,7 @@ class DFA(fa.FA):
         # Computing failure function for partial matches as is done in the
         # Knuth-Morris-Pratt string algorithm so we can quickly compute the
         # next state from another state
-        kmp_table = [-1 for _ in substring]
+        kmp_table = array.array("i", (-1 for _ in substring))
         candidate = 0
         for i, char in enumerate(substring):
             if i == 0:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1843,22 +1843,15 @@ class DFA(fa.FA):
                 input_symbol,
                 next_current_states,
             ) in target_nfa._iterate_through_symbol_path_pairs(current_states):
-                #print(input_symbol, next_current_states)
-                # next_current_states = target_nfa._get_next_current_states(
-                #    current_states, input_symbol
-                # )
+                next_current_states_name = get_name(next_current_states)
+                dfa_transitions[current_state_name][
+                    input_symbol
+                ] = next_current_states_name
 
-                # Can ignore trivial trap state (going to the empty set)
-                if next_current_states:
-                    next_current_states_name = get_name(next_current_states)
-                    dfa_transitions[current_state_name][
-                        input_symbol
-                    ] = next_current_states_name
-
-                    # Only enqueue a state if it has not been seen yet.
-                    if next_current_states_name not in dfa_states:
-                        dfa_states.add(next_current_states_name)
-                        state_queue.append(next_current_states)
+                # Only enqueue a state if it has not been seen yet.
+                if next_current_states_name not in dfa_states:
+                    dfa_states.add(next_current_states_name)
+                    state_queue.append(next_current_states)
 
         # if minify:
         #    return cls._minify(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1737,11 +1737,6 @@ class DFA(fa.FA):
         def subset_function(current_states: FrozenSet[DFAStateT]) -> bool:
             return not current_states.isdisjoint(target_nfa.final_states)
 
-        def expand_state_fn(
-            current_states: FrozenSet[DFAStateT],
-        ) -> ExpandStateReturnType:
-            yield from target_nfa._iterate_through_symbol_path_pairs(current_states)
-
         initial_state = frozenset(
             target_nfa._get_lambda_closures()[target_nfa.initial_state]
         )
@@ -1749,7 +1744,7 @@ class DFA(fa.FA):
         result = cls._expand_dfa(
             subset_function,
             initial_state,
-            expand_state_fn,
+            target_nfa._iterate_through_symbol_path_pairs,
             target_nfa.input_symbols,
             retain_names=retain_names,
             minify=minify,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1560,7 +1560,7 @@ class DFA(fa.FA):
         cls: Type[Self],
         input_symbols: AbstractSet[str],
         language: AbstractSet[str],
-        as_partial_dfa: bool = True,
+        as_partial: bool = True,
     ) -> Self:
         """
         Directly computes the minimal DFA corresponding to a finite language.
@@ -1651,14 +1651,14 @@ class DFA(fa.FA):
 
         compress(prev_word, "")
 
-        if as_partial_dfa:
+        if as_partial:
             return cls(
                 states=frozenset(transitions.keys()),
                 input_symbols=input_symbols,
                 transitions=transitions,
                 initial_state="",
                 final_states=final_states,
-                allow_partial=as_partial_dfa,
+                allow_partial=as_partial,
             )
 
         return cls._to_complete(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -783,6 +783,7 @@ class DFA(fa.FA):
         """
 
         if retain_names:
+
             def get_name_original(state: DFAStateT) -> DFAStateT:
                 return state
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -238,7 +238,7 @@ class DFA(fa.FA):
         return self.cardinality()
 
     # Supports partial (test)
-    def as_partial(self) -> Self:
+    def to_partial(self) -> Self:
         """
         Turns a DFA (complete or not) into a partial DFA.
         Removes dead states and trap states (except the initial state)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -858,6 +858,7 @@ class DFA(fa.FA):
         """
 
         if retain_names:
+
             def get_name_original(state: DFAStateT) -> DFAStateT:
                 return state
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1386,10 +1386,9 @@ class DFA(fa.FA):
 
         if not as_partial:
             err_state = -1
-            for i, _ in enumerate(prefix):
-                transitions_i = transitions[i]
+            for state_path in transitions.values():
                 for symbol in input_symbols:
-                    transitions_i.setdefault(symbol, err_state)
+                    state_path.setdefault(symbol, err_state)
             transitions[err_state] = {symbol: err_state for symbol in input_symbols}
 
         states = frozenset(transitions.keys())

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1179,14 +1179,11 @@ class DFA(fa.FA):
         """
         Populate word cache up to length k
         """
-        if not self.allow_partial:
-            sorted_symbols = sorted(self.input_symbols)
-            sorted_transition_symbols = {state: sorted_symbols for state in self.states}
-        else:
-            sorted_transition_symbols = {
-                state: sorted(lookup.keys())
-                for state, lookup in self.transitions.items()
-            }
+
+        # Weird construction to account for partial DFAs.
+        sorted_transition_symbols = {
+            state: sorted(lookup.keys()) for state, lookup in self.transitions.items()
+        }
 
         while len(self._word_cache) <= k:
             i = len(self._word_cache)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -285,7 +285,9 @@ class DFA(fa.FA):
             return self.copy()
 
         trap_state = self.get_trap_state_id()
-        default_to_trap = {symbol: trap_state for symbol in self.input_symbols}
+        default_to_trap: DFAPathT = {
+            symbol: trap_state for symbol in self.input_symbols
+        }
         transitions: DFATransitionsT = {
             state: {**default_to_trap, **lookup}
             for state, lookup in self.transitions.items()

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1469,6 +1469,7 @@ class DFA(fa.FA):
             transitions={0: {symbol: 0 for symbol in input_symbols}},
             initial_state=0,
             final_states={0},
+            allow_patial=False,
         )
 
     @classmethod
@@ -1482,6 +1483,7 @@ class DFA(fa.FA):
             transitions={0: {symbol: 0 for symbol in input_symbols}},
             initial_state=0,
             final_states=frozenset(),
+            allow_partial=False,
         )
 
     @classmethod

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -17,7 +17,6 @@ from typing import (
     Generator,
     Iterator,
     List,
-    Literal,
     Mapping,
     Optional,
     Set,
@@ -45,7 +44,6 @@ ExpandStateReturnType = Iterator[Tuple[DFASymbolT, DFAStateT]]
 ExpandStateFn = Callable[[DFAStateT], ExpandStateReturnType]
 IsFinalStateFn = Callable[[DFAStateT], bool]
 TargetStateFn = Callable[[DFAStateT], bool]
-BooleanLiteral = Literal[True, False]
 
 
 class DFA(fa.FA):
@@ -570,7 +568,7 @@ class DFA(fa.FA):
             return q_a in self.final_states or q_b in other.final_states
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, True, True
+            self, other, lhs_relevant=True, rhs_relevant=True
         )
 
         return self.__class__._expand_dfa(
@@ -596,7 +594,7 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b in other.final_states
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, False, False
+            self, other, lhs_relevant=False, rhs_relevant=False
         )
 
         return self.__class__._expand_dfa(
@@ -622,7 +620,7 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b not in other.final_states
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, False, True
+            self, other, lhs_relevant=False, rhs_relevant=True
         )
 
         return self.__class__._expand_dfa(
@@ -650,7 +648,7 @@ class DFA(fa.FA):
             return (q_a in self.final_states) ^ (q_b in other.final_states)
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, True, True
+            self, other, lhs_relevant=True, rhs_relevant=True
         )
 
         return self.__class__._expand_dfa(
@@ -831,7 +829,7 @@ class DFA(fa.FA):
 
     @staticmethod
     def _cross_product(
-        lhs: DFA, rhs: DFA, lhs_relevant: BooleanLiteral, rhs_relevant: BooleanLiteral
+        lhs: DFA, rhs: DFA, *, lhs_relevant: bool, rhs_relevant: bool
     ) -> Tuple[DFAStateT, ExpandStateFn]:
         """
         Builds the cross product between the two DFAs.
@@ -883,7 +881,7 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b not in other.final_states
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, False, True
+            self, other, lhs_relevant=False, rhs_relevant=True
         )
 
         return not self.__class__._find_state(
@@ -903,7 +901,7 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b in other.final_states
 
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, False, False
+            self, other, lhs_relevant=False, rhs_relevant=False
         )
 
         return not self.__class__._find_state(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1469,7 +1469,7 @@ class DFA(fa.FA):
             transitions={0: {symbol: 0 for symbol in input_symbols}},
             initial_state=0,
             final_states={0},
-            allow_patial=False,
+            allow_partial=False,
         )
 
     @classmethod

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1384,25 +1384,23 @@ class DFA(fa.FA):
         transitions = {i: {char: i + 1} for i, char in enumerate(prefix)}
         transitions[last_state] = {symbol: last_state for symbol in input_symbols}
 
+        if not as_partial:
+            err_state = -1
+            for i, _ in enumerate(prefix):
+                transitions_i = transitions[i]
+                for symbol in input_symbols:
+                    transitions_i.setdefault(symbol, err_state)
+            transitions[err_state] = {symbol: err_state for symbol in input_symbols}
+
         states = frozenset(transitions.keys())
         final_states = {last_state}
-
-        if as_partial:
-            return cls(
-                states=states,
-                input_symbols=input_symbols,
-                transitions=transitions,
-                initial_state=0,
-                final_states=final_states if contains else states - final_states,
-                allow_partial=as_partial,
-            )
-
-        return cls._to_complete(
+        return cls(
+            states=states,
             input_symbols=input_symbols,
             transitions=transitions,
             initial_state=0,
             final_states=final_states if contains else states - final_states,
-            trap_state=-1,
+            allow_partial=as_partial,
         )
 
     # Supports partial (but have a second look later)
@@ -1803,7 +1801,7 @@ class DFA(fa.FA):
                 final_states=final_states,
                 allow_partial=as_partial_dfa,
             )
-        
+
         return cls._to_complete(
             input_symbols=input_symbols,
             transitions=transitions,
@@ -1811,8 +1809,6 @@ class DFA(fa.FA):
             final_states=final_states,
             trap_state=0,
         )
-
-
 
     # Supports partial
     @classmethod

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -259,7 +259,7 @@ class DFA(fa.FA):
             allow_partial=True,
         )
 
-    def get_trap_state_id(self) -> DFAStateT:
+    def _get_trap_state_id(self) -> DFAStateT:
         return next(x for x in count(-1, -1) if x not in self.states)
 
     def to_complete(self, trap_state: Optional[DFAStateT] = None) -> Self:
@@ -271,7 +271,7 @@ class DFA(fa.FA):
             return self.copy()
 
         if trap_state is None:
-            trap_state = self.get_trap_state_id()
+            trap_state = self._get_trap_state_id()
         elif trap_state in self.states:
             raise exceptions.InvalidStateError(
                 f"state {trap_state} is already in the state set and "
@@ -842,8 +842,8 @@ class DFA(fa.FA):
                 "The input symbols between the two given DFAs do not match"
             )
 
-        trap_a = lhs.get_trap_state_id()
-        trap_b = rhs.get_trap_state_id()
+        trap_a = lhs._get_trap_state_id()
+        trap_b = rhs._get_trap_state_id()
 
         # TODO if anyone ever has issues with this function being too slow,
         # there is a way to speed this up in special cases with some complicated

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -411,19 +411,21 @@ class DFA(fa.FA):
         if not ignore_rejection:
             self._check_for_input_rejection(current_state)
 
-
     # Supports partial
     @cached_method
     def _get_digraph(self) -> nx.DiGraph:
         """Return a digraph corresponding to this DFA with transition symbols ignored"""
-        return nx.DiGraph(
+
+        graph = nx.DiGraph()
+        graph.add_nodes_from(self.states)
+        graph.add_edges_from(
             (
                 (start_state, end_state)
                 for start_state, transition in self.transitions.items()
                 for end_state in transition.values()
             )
         )
-        graph.update(nodes=(state for state in self.states))
+
         return graph
 
     # Supports partial
@@ -732,7 +734,7 @@ class DFA(fa.FA):
                 complete_dfa.initial_state,
                 lambda state: iter(complete_dfa.transitions[state].items()),
             )
-            
+
             reachable_states = set(bfs_states)
             reachable_final_states = complete_dfa.final_states & reachable_states
 
@@ -990,7 +992,6 @@ class DFA(fa.FA):
             self.initial_state,
             lambda state: iter(self.transitions[state].items()),
         )
-
 
     # Supports partial
     @cached_method
@@ -1257,7 +1258,6 @@ class DFA(fa.FA):
                         for state in self.states
                     }
                 )
-
 
     # Supports partial
     @cached_method

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1397,9 +1397,7 @@ class DFA(fa.FA):
         If contains is set to False then the complement is constructed instead.
         If must_be_suffix is set to True, then the substring must be a suffix instead.
         """
-        transitions: Dict[DFAStateT, Dict[str, DFAStateT]] = {
-            i: {} for i in range(len(substring))
-        }
+        transitions: DFATransitionsT = {i: {} for i in range(len(substring))}
         transitions[len(substring)] = {
             symbol: len(substring) for symbol in input_symbols
         }

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -588,7 +588,9 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states or q_b in other.final_states
 
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, True, True
+        )
 
         return self.__class__._expand_dfa(
             union_function,
@@ -613,7 +615,9 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b in other.final_states
 
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, False)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, False, False
+        )
 
         return self.__class__._expand_dfa(
             intersection_function,
@@ -638,7 +642,9 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b not in other.final_states
 
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, False, True
+        )
 
         return self.__class__._expand_dfa(
             difference_function,
@@ -665,7 +671,9 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return (q_a in self.final_states) ^ (q_b in other.final_states)
 
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, True, True
+        )
 
         return self.__class__._expand_dfa(
             symmetric_difference_function,
@@ -897,7 +905,9 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b not in other.final_states
 
         # TODO maybe fix this
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, False, True
+        )
 
         return not self.__class__._find_state(
             subset_state_fn, initial_state, expand_state_fn
@@ -918,7 +928,9 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b in other.final_states
 
         # TODO maybe change this
-        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, False)
+        initial_state, expand_state_fn = self.__class__._cross_product(
+            self, other, True, False
+        )
 
         return not self.__class__._find_state(
             disjoint_state_fn,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -442,11 +442,9 @@ class DFA(fa.FA):
         graph = nx.DiGraph()
         graph.add_nodes_from(self.states)
         graph.add_edges_from(
-            (
-                (start_state, end_state)
-                for start_state, transition in self.transitions.items()
-                for end_state in transition.values()
-            )
+            (start_state, end_state)
+            for start_state, transition in self.transitions.items()
+            for end_state in transition.values()
         )
 
         return graph

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -588,11 +588,11 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states or q_b in other.final_states
 
-        expand_state_fn = self.__class__._cross_product(self, other, True, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, True)
 
         return self.__class__._expand_dfa(
             union_function,
-            (self.initial_state, other.initial_state),
+            initial_state,
             expand_state_fn,
             self.input_symbols,
             retain_names=retain_names,
@@ -613,11 +613,11 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b in other.final_states
 
-        expand_state_fn = self.__class__._cross_product(self, other, False, False)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, False)
 
         return self.__class__._expand_dfa(
             intersection_function,
-            (self.initial_state, other.initial_state),
+            initial_state,
             expand_state_fn,
             self.input_symbols,
             retain_names=retain_names,
@@ -638,11 +638,11 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b not in other.final_states
 
-        expand_state_fn = self.__class__._cross_product(self, other, False, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, True)
 
         return self.__class__._expand_dfa(
             difference_function,
-            (self.initial_state, other.initial_state),
+            initial_state,
             expand_state_fn,
             self.input_symbols,
             retain_names=retain_names,
@@ -665,11 +665,11 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return (q_a in self.final_states) ^ (q_b in other.final_states)
 
-        expand_state_fn = self.__class__._cross_product(self, other, True, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, True)
 
         return self.__class__._expand_dfa(
             symmetric_difference_function,
-            (self.initial_state, other.initial_state),
+            initial_state,
             expand_state_fn,
             self.input_symbols,
             retain_names=retain_names,
@@ -851,7 +851,7 @@ class DFA(fa.FA):
     @staticmethod
     def _cross_product(
         lhs: DFA, rhs: DFA, lhs_relevant: bool, rhs_relevant: bool
-    ) -> ExpandStateFn:
+    ) -> Tuple[DFAStateT, ExpandStateFn]:
         """
         Builds the cross product between the two DFAs.
         Keeps expanding the lhs and rhs if the trap state is encountered based on the
@@ -883,7 +883,9 @@ class DFA(fa.FA):
                     transitions_b.get(chr, trap_b),
                 )
 
-        return expand_state_fn
+        initial_state = (lhs.initial_state, rhs.initial_state)
+
+        return initial_state, expand_state_fn
 
     # Supports partial (test)
     def issubset(self, other: DFA) -> bool:
@@ -895,10 +897,10 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b not in other.final_states
 
         # TODO maybe fix this
-        expand_state_fn = self.__class__._cross_product(self, other, False, True)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, False, True)
 
         return not self.__class__._find_state(
-            subset_state_fn, (self.initial_state, other.initial_state), expand_state_fn
+            subset_state_fn, initial_state, expand_state_fn
         )
 
     # Supports partial (test)
@@ -916,11 +918,11 @@ class DFA(fa.FA):
             return q_a in self.final_states and q_b in other.final_states
 
         # TODO maybe change this
-        expand_state_fn = self.__class__._cross_product(self, other, True, False)
+        initial_state, expand_state_fn = self.__class__._cross_product(self, other, True, False)
 
         return not self.__class__._find_state(
             disjoint_state_fn,
-            (self.initial_state, other.initial_state),
+            initial_state,
             expand_state_fn,
         )
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -260,6 +260,9 @@ class DFA(fa.FA):
             allow_partial=True,
         )
 
+    def get_trap_state_id(self) -> int:
+        return next(x for x in count(-1, -1) if x not in self.states)
+
     # Supports partial (test)
     def to_complete(self) -> DFA:
         """
@@ -269,7 +272,7 @@ class DFA(fa.FA):
         if not self.allow_partial:
             return self.copy()
 
-        trap_state = None
+        trap_state = self.get_trap_state_id()
         default_to_trap = {symbol: trap_state for symbol in self.input_symbols}
         transitions = {
             state: {**default_to_trap, **lookup}
@@ -551,8 +554,8 @@ class DFA(fa.FA):
         initial_state, expand_state_fn = self.__class__._cross_product(self, other)
 
         if self.allow_partial or other.allow_partial:
-            trap_a = None
-            trap_b = None
+            trap_a = self.get_trap_state_id()
+            trap_b = other.get_trap_state_id()
 
             def partial_union_expand_state_fn(state):
                 q_a, q_b = state
@@ -634,7 +637,7 @@ class DFA(fa.FA):
 
         # We stop if we reach a trap state for A
         if self.allow_partial and other.allow_partial:
-            trap_b = None
+            trap_b = other.get_trap_state_id()
 
             def partial_difference_expand_state_fn(state):
                 q_a, q_b = state
@@ -676,8 +679,8 @@ class DFA(fa.FA):
 
         # The benefit here is not so clear, but for very linear DFAs it pays off
         if self.allow_partial or other.allow_partial:
-            trap_a = None
-            trap_b = None
+            trap_a = self.get_trap_state_id()
+            trap_b = other.get_trap_state_id()
 
             def partial_sym_diff_expand_state_fn(state):
                 q_a, q_b = state
@@ -911,7 +914,7 @@ class DFA(fa.FA):
         # Looking for counter example state that is final in A but not in B
         #   therefore we only expand characters in A
         if self.allow_partial or other.allow_partial:
-            trap_b = None
+            trap_b = other.get_trap_state_id()
 
             def partial_intersection_expand_state_fn(state):
                 q_a, q_b = state
@@ -1318,7 +1321,7 @@ class DFA(fa.FA):
         transitions[last_state] = {symbol: last_state for symbol in input_symbols}
 
         if not as_partial:
-            err_state = None
+            err_state = -1
             for i, _ in enumerate(prefix):
                 transitions_i = transitions[i]
                 for symbol in input_symbols:
@@ -1727,7 +1730,7 @@ class DFA(fa.FA):
 
         if not as_partial_dfa:
             # Add trap state. Always needed since dict is finite
-            trap_state = None
+            trap_state = 0
             transitions[trap_state] = {symbol: trap_state for symbol in input_symbols}
 
             for path in transitions.values():

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1865,29 +1865,23 @@ class DFA(fa.FA):
                     dfa_states.add(next_current_states_name)
                     state_queue.append(next_current_states)
 
-        # if minify:
-        #    return cls._minify(
-        #        reachable_states=dfa_states,
-        #        input_symbols=dfa_symbols,
-        #        transitions=dfa_transitions,
-        #        initial_state=dfa_initial_state,
-        #        reachable_final_states=dfa_final_states,
-        #        retain_names=retain_names,
-        #    )
-        # TODO change this back once _minify has compatibility with partial DFAs.
+        if minify:
+            return cls._minify(
+                reachable_states=dfa_states,
+                input_symbols=dfa_symbols,
+                transitions=dfa_transitions,
+                initial_state=dfa_initial_state,
+                reachable_final_states=dfa_final_states,
+                retain_names=retain_names,
+            )
 
-        final_dfa = cls._to_complete(
+        return cls._to_complete(
             input_symbols=dfa_symbols,
             transitions=dfa_transitions,
             initial_state=dfa_initial_state,
             final_states=dfa_final_states,
             trap_state=frozenset(),
         )
-
-        if minify:
-            final_dfa = final_dfa.minify(retain_names=retain_names)
-
-        return final_dfa
 
     def iter_transitions(
         self,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -237,7 +237,7 @@ class DFA(fa.FA):
         return self.cardinality()
 
     # Supports partial (test)
-    def as_partial(self) -> DFA:
+    def as_partial(self) -> Self:
         """
         Turns a DFA (complete or not) into a partial DFA.
         Removes dead states and trap states (except the initial state)
@@ -255,7 +255,7 @@ class DFA(fa.FA):
         new_states = live_states & non_trap_states
         new_states.add(self.initial_state)
 
-        return DFA(
+        return self.__class__(
             states=new_states,
             input_symbols=self.input_symbols,
             transitions={
@@ -276,7 +276,7 @@ class DFA(fa.FA):
         return next(x for x in count(-1, -1) if x not in self.states)
 
     # Supports partial (test)
-    def to_complete(self) -> DFA:
+    def to_complete(self) -> Self:
         """
         Turns a DFA (complete or not) into a complete DFA.
         Might add trap state if the DFA does not have any
@@ -286,13 +286,13 @@ class DFA(fa.FA):
 
         trap_state = self.get_trap_state_id()
         default_to_trap = {symbol: trap_state for symbol in self.input_symbols}
-        transitions = {
+        transitions: DFATransitionsT = {
             state: {**default_to_trap, **lookup}
             for state, lookup in self.transitions.items()
         }
         transitions[trap_state] = default_to_trap
 
-        return DFA(
+        return self.__class__(
             states=frozenset(transitions.keys()),
             input_symbols=self.input_symbols,
             transitions=transitions,
@@ -727,7 +727,7 @@ class DFA(fa.FA):
         """Return the complement of this DFA."""
 
         # We can't do much here, we must turn it into a complete DFA
-        complete_dfa = self.to_complete() if self.allow_partial else self
+        complete_dfa: Self = self.to_complete() if self.allow_partial else self
 
         if minify:
             bfs_states = self.__class__._bfs_states(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1743,9 +1743,11 @@ class DFA(fa.FA):
         *,
         retain_names: bool = False,
         minify: bool = True,
-        as_partial: bool = True,
     ) -> Self:
-        """Initialize this DFA as one equivalent to the given NFA."""
+        """
+        Initialize this DFA as one equivalent to the given NFA. Note
+        that this usually returns a partial DFA by default.
+        """
 
         def subset_function(current_states: FrozenSet[DFAStateT]) -> bool:
             return not current_states.isdisjoint(target_nfa.final_states)
@@ -1754,7 +1756,7 @@ class DFA(fa.FA):
             target_nfa._get_lambda_closures()[target_nfa.initial_state]
         )
 
-        result = cls._expand_dfa(
+        return cls._expand_dfa(
             subset_function,
             initial_state,
             target_nfa._iterate_through_symbol_path_pairs,
@@ -1762,11 +1764,6 @@ class DFA(fa.FA):
             retain_names=retain_names,
             minify=minify,
         )
-
-        if as_partial:
-            return result
-
-        return result.to_complete(frozenset())
 
     def iter_transitions(
         self,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1839,10 +1839,14 @@ class DFA(fa.FA):
                 dfa_final_states.add(current_state_name)
 
             # Enqueue the next set of current states for the generated DFA.
-            for input_symbol in target_nfa._get_used_input_symbols(current_states):
-                next_current_states = target_nfa._get_next_current_states(
-                    current_states, input_symbol
-                )
+            for (
+                input_symbol,
+                next_current_states,
+            ) in target_nfa._iterate_through_symbol_path_pairs(current_states):
+                #print(input_symbol, next_current_states)
+                # next_current_states = target_nfa._get_next_current_states(
+                #    current_states, input_symbol
+                # )
 
                 # Can ignore trivial trap state (going to the empty set)
                 if next_current_states:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1252,7 +1252,8 @@ class DFA(fa.FA):
         transitions = {i: {char: i + 1} for i, char in enumerate(prefix)}
         transitions[last_state] = {symbol: last_state for symbol in input_symbols}
 
-        if not as_partial:
+        # Can't construct this as a partial if we need to take the complement
+        if not as_partial or not contains:
             err_state = -1
             for state_path in transitions.values():
                 for symbol in input_symbols:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -272,6 +272,9 @@ class DFA(fa.FA):
             final_states=self.final_states & new_states,
             allow_partial=True,
         )
+    
+    def get_trap_state_id(self) -> DFAStateT:
+        return next(x for x in count(-1, -1) if x not in self.states)
 
     # Supports partial (test)
     def to_complete(self) -> Self:
@@ -282,7 +285,14 @@ class DFA(fa.FA):
         if not self.allow_partial:
             return self.copy()
 
-        return self._to_complete(states=self.states)
+        return self._to_complete(
+            states=self.states,
+            input_symbols=self.input_symbols,
+            transitions=self.transitions,
+            initial_state=self.initial_state,
+            final_states=self.final_states,
+            trap_state=self.get_trap_state_id()
+        )
 
     @classmethod
     def _to_complete(
@@ -293,10 +303,8 @@ class DFA(fa.FA):
         transitions: DFATransitionsT,
         initial_state: DFAStateT,
         final_states: AbstractSet[DFAStateT],
-        trap_state: Optional[DFAStateT] = None,
+        trap_state: DFAStateT,
     ) -> Self:
-        if trap_state is None:
-            trap_state = next(x for x in count(-1, -1) if x not in states)
 
         added_trap_state = False
         new_transitions: Dict[DFAStateT, DFAPathT] = {}

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -859,7 +859,11 @@ class DFA(fa.FA):
         """
 
         if retain_names:
-            get_name = lambda state: state
+
+            def get_name_original(state):
+                return state
+
+            get_name = get_name_original
         else:
             get_name = get_renaming_function(count(0))
 
@@ -967,7 +971,9 @@ class DFA(fa.FA):
         if self.allow_partial or other.allow_partial:
             trap_b = other.get_trap_state_id()
 
-            def partial_intersection_expand_state_fn(state):
+            def partial_intersection_expand_state_fn(
+                state: DFAStateT,
+            ) -> ExpandStateReturnType:
                 q_a, q_b = state
                 transitions_a = self.transitions[q_a]
                 transitions_b = other.transitions.get(q_b, {})

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1384,23 +1384,25 @@ class DFA(fa.FA):
         transitions = {i: {char: i + 1} for i, char in enumerate(prefix)}
         transitions[last_state] = {symbol: last_state for symbol in input_symbols}
 
-        if not as_partial:
-            err_state = -1
-            for i, _ in enumerate(prefix):
-                transitions_i = transitions[i]
-                for symbol in input_symbols:
-                    transitions_i.setdefault(symbol, err_state)
-            transitions[err_state] = {symbol: err_state for symbol in input_symbols}
-
         states = frozenset(transitions.keys())
         final_states = {last_state}
-        return cls(
-            states=states,
+
+        if as_partial:
+            return cls(
+                states=states,
+                input_symbols=input_symbols,
+                transitions=transitions,
+                initial_state=0,
+                final_states=final_states if contains else states - final_states,
+                allow_partial=as_partial,
+            )
+
+        return cls._to_complete(
             input_symbols=input_symbols,
             transitions=transitions,
             initial_state=0,
             final_states=final_states if contains else states - final_states,
-            allow_partial=as_partial,
+            trap_state=-1,
         )
 
     # Supports partial (but have a second look later)
@@ -1792,23 +1794,25 @@ class DFA(fa.FA):
 
         compress(prev_word, "")
 
-        if not as_partial_dfa:
-            return cls._to_complete(
+        if as_partial_dfa:
+            return cls(
+                states=frozenset(transitions.keys()),
                 input_symbols=input_symbols,
                 transitions=transitions,
                 initial_state="",
                 final_states=final_states,
-                trap_state=0,
+                allow_partial=as_partial_dfa,
             )
-
-        return cls(
-            states=frozenset(transitions.keys()),
+        
+        return cls._to_complete(
             input_symbols=input_symbols,
             transitions=transitions,
             initial_state="",
             final_states=final_states,
-            allow_partial=as_partial_dfa,
+            trap_state=0,
         )
+
+
 
     # Supports partial
     @classmethod

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -68,8 +68,7 @@ class DFA(fa.FA):
     allow_partial: bool
     _word_cache: List[DefaultDict[DFAStateT, List[str]]]
     _count_cache: List[DefaultDict[DFAStateT, int]]
-
-    # Supports partial
+    
     def __init__(
         self,
         *,
@@ -100,7 +99,6 @@ class DFA(fa.FA):
         object.__setattr__(self, "_word_cache", [])
         object.__setattr__(self, "_count_cache", [])
 
-    # Supports partial (no modification, but test)
     def __eq__(self, other: Any) -> bool:
         """
         Return True if two DFAs are equivalent. Uses an optimized version of
@@ -152,7 +150,6 @@ class DFA(fa.FA):
 
         return True
 
-    # Supports partial
     def __le__(self, other: DFA) -> bool:
         """Return True if this DFA is a subset of (or equal to) another DFA."""
         if isinstance(other, DFA):
@@ -160,7 +157,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __ge__(self, other: DFA) -> bool:
         """Return True if this DFA is a superset of another DFA."""
         if isinstance(other, DFA):
@@ -168,7 +164,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __lt__(self, other: DFA) -> bool:
         """Return True if this DFA is a strict subset of another DFA."""
         if isinstance(other, DFA):
@@ -176,7 +171,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __gt__(self, other: DFA) -> bool:
         """Return True if this DFA is a strict superset of another DFA."""
         if isinstance(other, DFA):
@@ -184,7 +178,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __sub__(self, other: DFA) -> Self:
         """Return a DFA that is the difference of this DFA and another DFA."""
         if isinstance(other, DFA):
@@ -192,7 +185,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __or__(self, other: DFA) -> Self:
         """Return the union of this DFA and another DFA."""
         if isinstance(other, DFA):
@@ -200,7 +192,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __and__(self, other: DFA) -> Self:
         """Return the intersection of this DFA and another DFA."""
         if isinstance(other, DFA):
@@ -208,7 +199,6 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __xor__(self, other: DFA) -> Self:
         """Return the symmetric difference of this DFA and another DFA."""
         if isinstance(other, DFA):
@@ -216,12 +206,10 @@ class DFA(fa.FA):
         else:
             return NotImplemented
 
-    # Supports partial
     def __invert__(self) -> Self:
         """Return the complement of this DFA and another DFA."""
         return self.complement()
 
-    # Supports partial
     def __iter__(self) -> Iterator[str]:
         """
         Iterates through all words in the language represented by the DFA. The
@@ -234,12 +222,10 @@ class DFA(fa.FA):
             yield from self.words_of_length(i)
             i += 1
 
-    # Supports partial
     def __len__(self) -> int:
         """Returns the cardinality of the language represented by the DFA."""
         return self.cardinality()
 
-    # Supports partial (test)
     def to_partial(self) -> Self:
         """
         Turns a DFA (complete or not) into a partial DFA.
@@ -278,7 +264,6 @@ class DFA(fa.FA):
     def get_trap_state_id(self) -> DFAStateT:
         return next(x for x in count(-1, -1) if x not in self.states)
 
-    # Supports partial (test)
     def to_complete(self, trap_state: Optional[DFAStateT] = None) -> Self:
         """
         Turns a DFA (complete or not) into a complete DFA.
@@ -337,7 +322,6 @@ class DFA(fa.FA):
             allow_partial=False,
         )
 
-    # Supports partial
     def _validate_transition_missing_symbols(
         self, start_state: DFAStateT, paths: DFAPathT
     ) -> None:
@@ -351,7 +335,6 @@ class DFA(fa.FA):
                     f'for symbol "{input_symbol}"'
                 )
 
-    # Supports partial
     def _validate_transition_invalid_symbols(
         self, start_state: DFAStateT, paths: DFAPathT
     ) -> None:
@@ -363,7 +346,6 @@ class DFA(fa.FA):
                     f' "{input_symbol}"'
                 )
 
-    # Supports partial
     def _validate_transition_start_states(self) -> None:
         """Raise an error if transition start states are missing."""
         for state in self.states:
@@ -372,7 +354,6 @@ class DFA(fa.FA):
                     f"transition start state {state} is missing"
                 )
 
-    # Supports partial
     def _validate_transition_end_states(
         self, start_state: DFAStateT, paths: DFAPathT
     ) -> None:
@@ -384,14 +365,12 @@ class DFA(fa.FA):
                     f"{start_state} is not valid"
                 )
 
-    # Supports partial
     def _validate_transitions(self, start_state: DFAStateT, paths: DFAPathT) -> None:
         """Raise an error if transitions are missing or invalid."""
         self._validate_transition_missing_symbols(start_state, paths)
         self._validate_transition_invalid_symbols(start_state, paths)
         self._validate_transition_end_states(start_state, paths)
 
-    # Supports partial
     def validate(self) -> None:
         """Return True if this DFA is internally consistent."""
         self._validate_transition_start_states()
@@ -400,7 +379,6 @@ class DFA(fa.FA):
         self._validate_initial_state()
         self._validate_final_states()
 
-    # Supports partial
     def _get_next_current_state(
         self, current_state: DFAStateT, input_symbol: str
     ) -> Optional[DFAStateT]:
@@ -416,7 +394,6 @@ class DFA(fa.FA):
             return self.transitions[current_state][input_symbol]
         return None
 
-    # Supports partial
     def _check_for_input_rejection(self, current_state: DFAStateT) -> None:
         """Raise an error if the given config indicates rejected input."""
         if current_state not in self.final_states:
@@ -424,7 +401,6 @@ class DFA(fa.FA):
                 f"the DFA stopped on a non-final state ({current_state})"
             )
 
-    # Supports partial
     def read_input_stepwise(
         self, input_str: str, ignore_rejection: bool = False
     ) -> Generator[AbstractSet[DFAStateT], None, None]:
@@ -443,7 +419,6 @@ class DFA(fa.FA):
         if not ignore_rejection:
             self._check_for_input_rejection(current_state)
 
-    # Supports partial
     @cached_method
     def _get_digraph(self) -> nx.DiGraph:
         """Return a digraph corresponding to this DFA with transition symbols ignored"""
@@ -458,7 +433,6 @@ class DFA(fa.FA):
 
         return graph
 
-    # Supports partial
     def minify(self, retain_names: bool = False) -> Self:
         """
         Create a minimal DFA which accepts the same inputs as this DFA.
@@ -485,7 +459,6 @@ class DFA(fa.FA):
             retain_names=retain_names,
         )
 
-    # Supports partial (test)
     @classmethod
     def _minify(
         cls: Type[Self],
@@ -583,7 +556,6 @@ class DFA(fa.FA):
             allow_partial=allow_partial,
         )
 
-    # Supports partial (test)
     def union(
         self, other: DFA, *, retain_names: bool = False, minify: bool = True
     ) -> Self:
@@ -610,7 +582,6 @@ class DFA(fa.FA):
             minify=minify,
         )
 
-    # Supports partial (test)
     def intersection(
         self, other: DFA, *, retain_names: bool = False, minify: bool = True
     ) -> Self:
@@ -637,7 +608,6 @@ class DFA(fa.FA):
             minify=minify,
         )
 
-    # Supports partial (test)
     def difference(
         self, other: DFA, *, retain_names: bool = False, minify: bool = True
     ) -> Self:
@@ -664,7 +634,6 @@ class DFA(fa.FA):
             minify=minify,
         )
 
-    # Supports partial (test)
     def symmetric_difference(
         self, other: DFA, *, retain_names: bool = False, minify: bool = True
     ) -> Self:
@@ -693,7 +662,6 @@ class DFA(fa.FA):
             minify=minify,
         )
 
-    # Supports partial (test)
     def complement(self, *, retain_names: bool = False, minify: bool = True) -> Self:
         """Return the complement of this DFA."""
 
@@ -726,7 +694,6 @@ class DFA(fa.FA):
             final_states=complete_dfa.states - complete_dfa.final_states,
         )
 
-    # Supports partial
     @staticmethod
     def _bfs_edges(
         initial_state: DFAStateT,
@@ -749,7 +716,6 @@ class DFA(fa.FA):
                     visited_set.add(tgt_state)
                     queue.append(tgt_state)
 
-    # Supports partial
     @staticmethod
     def _bfs_states(
         initial_state: DFAStateT, expand_state_fn: ExpandStateFn
@@ -771,7 +737,6 @@ class DFA(fa.FA):
                     visited_set.add(tgt_state)
                     queue.append(tgt_state)
 
-    # Supports partial (test)
     @classmethod
     def _expand_dfa(
         cls: Type[Self],
@@ -848,7 +813,6 @@ class DFA(fa.FA):
             allow_partial=is_partial,
         )
 
-    # Supports partial
     @classmethod
     def _find_state(
         cls: Type[Self],
@@ -910,7 +874,6 @@ class DFA(fa.FA):
 
         return initial_state, expand_state_fn
 
-    # Supports partial (test)
     def issubset(self, other: DFA) -> bool:
         """Return True if this DFA is a subset of another DFA."""
 
@@ -928,12 +891,10 @@ class DFA(fa.FA):
             subset_state_fn, initial_state, expand_state_fn
         )
 
-    # Supports partial (test)
     def issuperset(self, other: DFA) -> bool:
         """Return True if this DFA is a superset of another DFA."""
         return other.issubset(self)
 
-    # Supports partial (test)
     def isdisjoint(self, other: DFA) -> bool:
         """Return True if this DFA has no common elements with another DFA."""
 
@@ -953,7 +914,6 @@ class DFA(fa.FA):
             expand_state_fn,
         )
 
-    # Supports partial
     @cached_method
     def isempty(self) -> bool:
         """Return True if this DFA is completely empty."""
@@ -963,7 +923,6 @@ class DFA(fa.FA):
             lambda state: iter(self.transitions[state].items()),
         )
 
-    # Supports partial
     @cached_method
     def isfinite(self) -> bool:
         """
@@ -974,7 +933,6 @@ class DFA(fa.FA):
         except exceptions.EmptyLanguageException:
             return True
 
-    # Supports partial
     def random_word(self, k: int, *, seed: Optional[int] = None) -> str:
         self._populate_count_cache_up_to_len(k)
         state = self.initial_state
@@ -998,7 +956,6 @@ class DFA(fa.FA):
         assert state in self.final_states
         return "".join(result)
 
-    # Supports partial
     def predecessor(
         self,
         input_str: str,
@@ -1018,7 +975,6 @@ class DFA(fa.FA):
             return word
         return None
 
-    # Supports partial
     def predecessors(
         self,
         input_str: str,
@@ -1037,7 +993,6 @@ class DFA(fa.FA):
         """
         yield from self.successors(input_str, strict=strict, reverse=True, key=key)
 
-    # Supports partial
     def successor(
         self,
         input_str: Optional[str],
@@ -1057,7 +1012,6 @@ class DFA(fa.FA):
             return word
         return None
 
-    # Supports partial (no modification, but need to test)
     def successors(
         self,
         input_str: Optional[str],
@@ -1154,7 +1108,6 @@ class DFA(fa.FA):
         ):
             yield "".join(char_stack)
 
-    # Supports partial
     def count_words_of_length(self, k: int) -> int:
         """
         Counts words of length `k` accepted by the DFA
@@ -1162,13 +1115,11 @@ class DFA(fa.FA):
         self._populate_count_cache_up_to_len(k)
         return self._count_cache[k][self.initial_state]
 
-    # Supports partial
     def _populate_count_cache_up_to_len(self, k: int) -> None:
         """
         Populate count cache up to length k
         """
-        # TODO this leads to bugs if the count_cache is not "continuously" populated
-        #   (same for _populate_word_cache_up_to_len)
+
         while len(self._count_cache) <= k:
             i = len(self._count_cache)
             self._count_cache.append(defaultdict(int))
@@ -1187,7 +1138,6 @@ class DFA(fa.FA):
                     }
                 )
 
-    # Supports partial
     def words_of_length(self, k: int) -> Generator[str, None, None]:
         """
         Generates all words of size k in the language represented by the DFA
@@ -1196,7 +1146,6 @@ class DFA(fa.FA):
         for word in self._word_cache[k][self.initial_state]:
             yield word
 
-    # Supports partial (test)
     def _populate_word_cache_up_to_len(self, k: int) -> None:
         """
         Populate word cache up to length k
@@ -1226,7 +1175,6 @@ class DFA(fa.FA):
                     }
                 )
 
-    # Supports partial
     @cached_method
     def cardinality(self) -> int:
         """Returns the cardinality of the language represented by the DFA."""
@@ -1241,7 +1189,6 @@ class DFA(fa.FA):
             )
         return sum(self.count_words_of_length(j) for j in range(i, limit + 1))
 
-    # Supports partial
     @cached_method
     def minimum_word_length(self) -> int:
         """
@@ -1262,7 +1209,6 @@ class DFA(fa.FA):
             "The language represented by the DFA is empty"
         )
 
-    # Supports partial (no modification, but need to test)
     @cached_method
     def maximum_word_length(self) -> Optional[int]:
         """
@@ -1290,7 +1236,6 @@ class DFA(fa.FA):
         except nx.exception.NetworkXUnfeasible:
             return None
 
-    # Supports partial (test)
     @classmethod
     def from_prefix(
         cls: Type[Self],
@@ -1327,7 +1272,6 @@ class DFA(fa.FA):
             allow_partial=as_partial,
         )
 
-    # Supports partial (but have a second look later)
     @classmethod
     def from_suffix(
         cls: Type[Self],
@@ -1345,7 +1289,6 @@ class DFA(fa.FA):
             input_symbols, suffix, contains=contains, must_be_suffix=True
         )
 
-    # Supports partial (but have a second look later)
     @classmethod
     def from_substring(
         cls: Type[Self],
@@ -1407,7 +1350,6 @@ class DFA(fa.FA):
             final_states=final_states if contains else states - final_states,
         )
 
-    # Supports partial
     @classmethod
     def from_subsequence(
         cls: Type[Self],
@@ -1438,7 +1380,6 @@ class DFA(fa.FA):
             final_states=final_states if contains else states - final_states,
         )
 
-    # Supports partial
     @classmethod
     def of_length(
         cls: Type[Self],
@@ -1482,7 +1423,6 @@ class DFA(fa.FA):
             final_states=final_states,
         )
 
-    # Supports partial
     @classmethod
     def count_mod(
         cls: Type[Self],
@@ -1519,7 +1459,6 @@ class DFA(fa.FA):
             final_states=remainders,
         )
 
-    # Supports partial
     @classmethod
     def universal_language(cls: Type[Self], input_symbols: AbstractSet[str]) -> Self:
         """
@@ -1533,7 +1472,6 @@ class DFA(fa.FA):
             final_states={0},
         )
 
-    # Supports partial
     @classmethod
     def empty_language(cls: Type[Self], input_symbols: AbstractSet[str]) -> Self:
         """
@@ -1547,7 +1485,6 @@ class DFA(fa.FA):
             final_states=frozenset(),
         )
 
-    # Supports partial
     @classmethod
     def nth_from_start(
         cls: Type[Self], input_symbols: AbstractSet[str], symbol: str, n: int
@@ -1578,7 +1515,6 @@ class DFA(fa.FA):
             allow_partial=False,
         )
 
-    # Supports partial
     @classmethod
     def nth_from_end(
         cls: Type[Self], input_symbols: AbstractSet[str], symbol: str, n: int
@@ -1620,7 +1556,6 @@ class DFA(fa.FA):
             allow_partial=False,
         )
 
-    # Supports partial (test)
     @classmethod
     def from_finite_language(
         cls: Type[Self],
@@ -1735,7 +1670,6 @@ class DFA(fa.FA):
             trap_state=0,
         )
 
-    # Supports partial
     @classmethod
     def from_nfa(
         cls: Type[Self],

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -355,7 +355,8 @@ class DFA(fa.FA):
         for input_symbol in paths.keys():
             if input_symbol not in self.input_symbols:
                 raise exceptions.InvalidSymbolError(
-                    f'state {start_state} has invalid transition symbol "{input_symbol}"'
+                    f"state {start_state} has invalid transition symbol"
+                    f' "{input_symbol}"'
                 )
 
     # Supports partial

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -328,11 +328,6 @@ class DFA(fa.FA):
             allow_partial=False,
         )
 
-    # Supports partial (test)
-    def edge_count(self) -> int:
-        """Returns the number of DFA edges"""
-        return sum(len(lookup) for lookup in self.transitions.values())
-
     # Supports partial
     def _validate_transition_missing_symbols(
         self, start_state: DFAStateT, paths: DFAPathT

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1843,7 +1843,6 @@ class DFA(fa.FA):
                 input_symbol,
                 next_current_states,
             ) in target_nfa._iterate_through_symbol_path_pairs(current_states):
-                
                 next_current_states_name = get_name(next_current_states)
                 path_dict[input_symbol] = next_current_states_name
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -272,7 +272,7 @@ class DFA(fa.FA):
             final_states=self.final_states & new_states,
             allow_partial=True,
         )
-    
+
     def get_trap_state_id(self) -> DFAStateT:
         return next(x for x in count(-1, -1) if x not in self.states)
 
@@ -286,31 +286,28 @@ class DFA(fa.FA):
             return self.copy()
 
         return self._to_complete(
-            states=self.states,
             input_symbols=self.input_symbols,
             transitions=self.transitions,
             initial_state=self.initial_state,
             final_states=self.final_states,
-            trap_state=self.get_trap_state_id()
+            trap_state=self.get_trap_state_id(),
         )
 
     @classmethod
     def _to_complete(
         cls: Type[Self],
         *,
-        states: AbstractSet[DFAStateT],
         input_symbols: AbstractSet[str],
         transitions: DFATransitionsT,
         initial_state: DFAStateT,
         final_states: AbstractSet[DFAStateT],
         trap_state: DFAStateT,
     ) -> Self:
-
         added_trap_state = False
         new_transitions: Dict[DFAStateT, Dict[str, DFAStateT]] = {}
 
         for state, state_path in transitions.items():
-            new_state_path = new_transitions.setdefault(state, state_path)
+            new_state_path = new_transitions.setdefault(state, dict(state_path))
 
             for symbol in input_symbols:
                 if symbol not in new_state_path:
@@ -1870,7 +1867,6 @@ class DFA(fa.FA):
         # TODO change this back once _minify has compatibility with partial DFAs.
 
         final_dfa = cls._to_complete(
-            states=dfa_states,
             input_symbols=dfa_symbols,
             transitions=dfa_transitions,
             initial_state=dfa_initial_state,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -288,7 +288,7 @@ class DFA(fa.FA):
         default_to_trap: DFAPathT = {
             symbol: trap_state for symbol in self.input_symbols
         }
-        transitions: DFATransitionsT = {
+        transitions: Dict[DFAStateT, DFAPathT] = {
             state: {**default_to_trap, **lookup}
             for state, lookup in self.transitions.items()
         }

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -399,13 +399,15 @@ class DFA(fa.FA):
     # Supports partial
     def _get_digraph(self) -> nx.DiGraph:
         """Return a digraph corresponding to this DFA with transition symbols ignored"""
-        return nx.DiGraph(
+        graph = nx.DiGraph(
             [
                 (start_state, end_state)
                 for start_state, transition in self.transitions.items()
                 for end_state in transition.values()
             ]
         )
+        graph.update(nodes=(state for state in self.states))
+        return graph
 
     # Supports partial
     def minify(self, retain_names: bool = False) -> Self:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -68,7 +68,7 @@ class DFA(fa.FA):
     allow_partial: bool
     _word_cache: List[DefaultDict[DFAStateT, List[str]]]
     _count_cache: List[DefaultDict[DFAStateT, int]]
-    
+
     def __init__(
         self,
         *,
@@ -882,7 +882,6 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b not in other.final_states
 
-        # TODO maybe fix this
         initial_state, expand_state_fn = self.__class__._cross_product(
             self, other, False, True
         )
@@ -903,9 +902,8 @@ class DFA(fa.FA):
             q_a, q_b = state_pair
             return q_a in self.final_states and q_b in other.final_states
 
-        # TODO maybe change this
         initial_state, expand_state_fn = self.__class__._cross_product(
-            self, other, True, False
+            self, other, False, False
         )
 
         return not self.__class__._find_state(

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -539,7 +539,7 @@ class DFA(fa.FA):
         new_transitions = {
             name: {
                 letter: back_map[transitions[next(iter(eq))][letter]]
-                for letter, tgt_state in transitions[next(iter(eq))].items()
+                for letter in transitions[next(iter(eq))].keys()
             }
             for name, eq in eq_class_name_pairs
         }
@@ -1559,7 +1559,7 @@ class DFA(fa.FA):
         cls: Type[Self],
         input_symbols: AbstractSet[str],
         language: AbstractSet[str],
-        as_partial_dfa: bool = False,
+        as_partial_dfa: bool = True,
     ) -> Self:
         """
         Directly computes the minimal DFA corresponding to a finite language.

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -67,6 +67,7 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         of the form (from_state, to_state, symbol)
         """
 
+    # Supports partial DFA
     def show_diagram(
         self,
         input_str: Optional[str] = None,

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -67,7 +67,6 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         of the form (from_state, to_state, symbol)
         """
 
-    # Supports partial DFA
     def show_diagram(
         self,
         input_str: Optional[str] = None,

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -204,7 +204,9 @@ class NFA(fa.FA):
     def _iterate_through_symbol_path_pairs(
         self, current_states: AbstractSet[NFAStateT]
     ) -> Generator[Tuple[str, FrozenSet[NFAStateT]], None, None]:
-        """Iterate through input symbols with set of end transitions which are nonempty."""
+        """
+        Iterate through input symbols with set of end transitions which are nonempty.
+        """
 
         lambda_closures = self._get_lambda_closures()
         res_dict: Dict[str, Set[NFAStateT]] = {}

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -203,7 +203,7 @@ class NFA(fa.FA):
 
     def _get_used_input_symbols(
         self, current_states: AbstractSet[NFAStateT]
-    ) -> FrozenSet[str]:
+    ) -> Set[str]:
         """Return all input symbols with transitions in current_states"""
         return set().union(
             *(

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -204,33 +204,22 @@ class NFA(fa.FA):
     def _iterate_through_symbol_path_pairs(
         self, current_states: AbstractSet[NFAStateT]
     ) -> Generator[Tuple[str, FrozenSet[NFAStateT]], None, None]:
-        """Return all input symbols with transitions in current_states"""
+        """Iterate through input symbols with set of end transitions which are nonempty."""
 
-        all_keys = set().union(
-            *(
-                self.transitions[state].keys()
-                for state in current_states
-                if state in self.transitions
-            )
-        ) - {""}
-
-        for key in all_keys:
-            yield (key, self._get_next_current_states(current_states, key))
-
-        """
-        res_dict = {}
+        lambda_closures = self._get_lambda_closures()
+        res_dict: Dict[str, Set[NFAStateT]] = {}
 
         for input_symbol, next_states in chain.from_iterable(
             self.transitions[state].items() for state in current_states
         ):
-            # Ignore empty string
-            if input_symbol:
+            # Ignore empty string and empty end states
+            if input_symbol and next_states:
                 input_symbol_set = res_dict.setdefault(input_symbol, set())
-                input_symbol_set |= next_states
+                for end_state in next_states:
+                    input_symbol_set.update(lambda_closures[end_state])
 
         for input_symbol, next_states in res_dict.items():
             yield (input_symbol, frozenset(next_states))
-        """
 
     def _get_next_current_states(
         self, current_states: AbstractSet[NFAStateT], input_symbol: str

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -201,6 +201,18 @@ class NFA(fa.FA):
         self._validate_initial_state_transitions()
         self._validate_final_states()
 
+    def _get_used_input_symbols(
+        self, current_states: AbstractSet[NFAStateT]
+    ) -> FrozenSet[str]:
+        """Return all input symbols with transitions in current_states"""
+        return set().union(
+            *(
+                self.transitions[state].keys()
+                for state in current_states
+                if state in self.transitions
+            )
+        ) - {""}
+
     def _get_next_current_states(
         self, current_states: AbstractSet[NFAStateT], input_symbol: str
     ) -> FrozenSet[NFAStateT]:

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -212,7 +212,7 @@ class NFA(fa.FA):
         res_dict: Dict[str, Set[NFAStateT]] = {}
 
         for input_symbol, next_states in chain.from_iterable(
-            self.transitions[state].items() for state in current_states
+            self.transitions.get(state, {}).items() for state in current_states
         ):
             # Ignore empty string and empty end states
             if input_symbol and next_states:

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -201,17 +201,36 @@ class NFA(fa.FA):
         self._validate_initial_state_transitions()
         self._validate_final_states()
 
-    def _get_used_input_symbols(
+    def _iterate_through_symbol_path_pairs(
         self, current_states: AbstractSet[NFAStateT]
-    ) -> Set[str]:
+    ) -> Generator[Tuple[str, FrozenSet[NFAStateT]], None, None]:
         """Return all input symbols with transitions in current_states"""
-        return set().union(
+
+        all_keys = set().union(
             *(
                 self.transitions[state].keys()
                 for state in current_states
                 if state in self.transitions
             )
         ) - {""}
+
+        for key in all_keys:
+            yield (key, self._get_next_current_states(current_states, key))
+
+        """
+        res_dict = {}
+
+        for input_symbol, next_states in chain.from_iterable(
+            self.transitions[state].items() for state in current_states
+        ):
+            # Ignore empty string
+            if input_symbol:
+                input_symbol_set = res_dict.setdefault(input_symbol, set())
+                input_symbol_set |= next_states
+
+        for input_symbol, next_states in res_dict.items():
+            yield (input_symbol, frozenset(next_states))
+        """
 
     def _get_next_current_states(
         self, current_states: AbstractSet[NFAStateT], input_symbol: str

--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -463,6 +463,7 @@ dfa = DFA.nth_from_end({'0', '1'}, '1', 4)
 
 Creates a DFA that is equivalent to the given NFA. States are renamed by
 default unless `retain_names` is set to `True`. Minifies by default.
+Always attempts to return a partial DFA.
 
 ```python
 from automata.fa.dfa import DFA

--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -25,7 +25,9 @@ a state (the value).
 6. `allow_partial`: by default, each DFA state must have a transition to
 every input symbol; if `allow_partial` is `True`, you can disable this
 characteristic (such that any DFA state can have fewer transitions than input
-symbols)
+symbols). Note that a DFA must always have every state represented in the
+transition dictionary, even if there are no transitions on input symbols
+leaving a state (dictionary is left empty in that case).
 
 ```python
 from automata.fa.dfa import DFA
@@ -85,11 +87,30 @@ else:
 dfa.copy()  # returns deep copy of dfa
 ```
 
+## DFA.to_partial(self)
+
+Creates an equivalent partial DFA with all unnecessary transitions removed. If the DFA is
+already partial, just returns a copy.
+
+```python
+dfa.to_partial()  # returns deep copy of dfa
+```
+## DFA.to_complete(self, trap_state = None)
+
+Creates an equivalent complete DFA with `trap_state` used as the name for an added trap
+state. If `trap_state` is not passed in, defaults to the largest negative integer
+which is not already a state name. If the DFA is already complete, just returns a copy.
+
+```python
+dfa.to_partial()  # returns deep copy of dfa
+```
+
 ## DFA.minify(self, retain_names=False)
 
 Creates a minimal DFA which accepts the same inputs as the old one.
 Unreachable states are removed and equivalent states are merged.
-States are renamed by default.
+States are renamed by default. If the input DFA is partial, the
+result is also partial.
 
 ```python
 minimal_dfa = dfa.minify()
@@ -108,7 +129,8 @@ dfa1 == dfa2
 ## DFA.complement(self, retain_names=False, minify=True)
 
 Creates a DFA which accepts an input if and only if the old one does not.
-Minifies by default. Unreachable states are always removed.
+Minifies by default. Unreachable states are always removed. Partial DFAs
+are converted into complete ones.
 
 ```python
 minimal_complement_dfa = ~dfa
@@ -119,7 +141,8 @@ complement_dfa = dfa.complement(minify=False)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the union of A and B. Minifies by default.
-Unreachable states are always removed.
+Unreachable states are always removed. If either input DFA is partial,
+the result is partial.
 
 ```python
 minimal_union_dfa = dfa | other_dfa
@@ -130,7 +153,8 @@ union_dfa = dfa.union(other_dfa, minify=False)
 
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the intersection of A and B. Minifies by default.
-Unreachable states are always removed.
+Unreachable states are always removed. If either input DFA is partial,
+the result is partial.
 
 ```python
 minimal_intersection_dfa = dfa & other_dfa
@@ -142,7 +166,8 @@ intersection_dfa = dfa.intersection(other_dfa, minify=False)
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the set difference of A and B, often
 denoted A \ B or A - B. Minifies by default.
-Unreachable states are always removed.
+Unreachable states are always removed. If either input DFA is partial,
+the result is partial.
 
 ```python
 minimal_difference_dfa = dfa - other_dfa
@@ -154,6 +179,7 @@ difference_dfa = dfa.difference(other_dfa, minify=False)
 Given two DFAs which accept the languages A and B respectively,
 creates a DFA which accepts the symmetric difference of A and B.
 Minifies by default. Unreachable states are always removed.
+If either input DFA is partial, the result is partial.
 
 ```python
 minimal_symmetric_difference_dfa = dfa ^ other_dfa
@@ -327,11 +353,13 @@ dfa.cardinality()
 len(dfa)
 ```
 
-## DFA.from_prefix(cls, input_symbols, prefix, contains=True)
+## DFA.from_prefix(cls, input_symbols, prefix, contains=True, as_partial=True)
 
 Directly computes the minimal DFA recognizing strings with the
 given prefix.
 If `contains` is set to `False` then the complement is constructed instead.
+If `as_partial` is set to `True` then will attempt to construct this DFA as a
+partial DFA.
 
 ```python
 contains_prefix_nano = DFA.from_prefix({'a', 'n', 'o', 'b'}, 'nano')
@@ -442,9 +470,11 @@ from automata.fa.nfa import NFA
 dfa = DFA.from_nfa(nfa)  # returns an equivalent DFA
 ```
 
-## DFA.from_finite_language(cls, input_symbols, language)
+## DFA.from_finite_language(cls, input_symbols, language, as_partial=True)
 
 Constructs the minimal DFA corresponding to the given finite language and input symbols.
+If `as_partial` is set to `True` then will attempt to construct this DFA as a
+partial DFA.
 
 ```python
 DFA.from_finite_language(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
     {name = 'Caleb Evans', email = 'caleb@calebevans.me'}
 ]
 maintainers = [
-    {name = 'Caleb Evans', email = 'caleb@calebevans.me'}
+    {name = 'Caleb Evans', email = 'caleb@calebevans.me'},
+    {name = 'Eliot W. Robson', email = 'eliot.robson24@gmail.com'},
 ]
 dependencies = [
     "networkx>=2.6.2",
@@ -44,7 +45,8 @@ module = [
   "setuptools.*",
   "networkx.*",
   "pygraphviz.*",
-  "cached_method.*"
+  "cached_method.*",
+  "nose2.tools.*"
 ]
 ignore_missing_imports = true
 

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -7,7 +7,7 @@ import random
 import tempfile
 import types
 from itertools import permutations, product
-from typing import Tuple, TypeVar
+from typing import Iterable, Tuple, TypeVar, cast
 from unittest.mock import MagicMock, patch
 
 from frozendict import frozendict
@@ -22,7 +22,7 @@ ArgT = TypeVar("ArgT")
 
 
 def get_permutation_tuples(*args: ArgT) -> Tuple[Tuple[ArgT, ArgT], ...]:
-    return tuple(permutations(args, 2))
+    return tuple(cast(Iterable[Tuple[ArgT, ArgT]], permutations(args, 2)))
 
 
 class TestDFA(test_fa.TestFA):
@@ -2315,9 +2315,13 @@ class TestDFA(test_fa.TestFA):
         dfa = DFA.empty_language({"0", "1", "a", "b"})
         self.assertTrue(dfa.isempty())
 
-    def test_reset_word_cache(self) -> None:
+    @params(True, False)
+    def test_reset_word_cache(self, as_partial_dfa: bool) -> None:
         max_len = 4
         dfa = DFA.of_length({"0", "1"}, min_length=0, max_length=max_len)
+
+        if as_partial_dfa:
+            dfa = dfa.to_partial()
 
         self.assertEqual(len(dfa._word_cache), 0)
         self.assertEqual(len(dfa._count_cache), 0)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -598,7 +598,7 @@ class TestDFA(test_fa.TestFA):
         self.assertFalse(self.no_consecutive_11_dfa <= self.zero_or_one_1_dfa)
 
         single_string_dfa = DFA.from_finite_language(
-            {"0", "1"}, {"101"}, as_partial_dfa=True
+            {"0", "1"}, {"101"}, as_partial=True
         )
 
         # Test interop with partial DFA
@@ -619,7 +619,7 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(self.no_consecutive_11_dfa >= self.zero_or_one_1_dfa)
 
         single_string_dfa = DFA.from_finite_language(
-            {"0", "1"}, {"101"}, as_partial_dfa=True
+            {"0", "1"}, {"101"}, as_partial=True
         )
 
         # Test interop with partial DFA
@@ -1550,7 +1550,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(graph.graph_attr["size"], "3.3")
 
     @params(True, False)
-    def test_minimal_finite_language(self, as_partial_dfa: bool) -> None:
+    def test_minimal_finite_language(self, as_partial: bool) -> None:
         """Should compute the minimal DFA accepting the given finite language"""
 
         # Same language described in the book this algorithm comes from
@@ -1588,18 +1588,18 @@ class TestDFA(test_fa.TestFA):
             final_states={4, 9},
         )
 
-        if as_partial_dfa:
+        if as_partial:
             equiv_dfa = equiv_dfa.to_partial()
 
         minimal_dfa = DFA.from_finite_language(
-            {"a", "b"}, language, as_partial_dfa=as_partial_dfa
+            {"a", "b"}, language, as_partial=as_partial
         )
 
         self.assertEqual(len(minimal_dfa.states), len(equiv_dfa.states))
         self.assertEqual(minimal_dfa, equiv_dfa)
 
     @params(True, False)
-    def test_minimal_finite_language_large(self, as_partial_dfa: bool) -> None:
+    def test_minimal_finite_language_large(self, as_partial: bool) -> None:
         """Should compute the minimal DFA accepting the given finite language on
         large test case"""
         m = 50
@@ -1607,7 +1607,7 @@ class TestDFA(test_fa.TestFA):
         language = {("a" * i + "b" * j) for i, j in product(range(n), range(m))}
 
         equiv_dfa = DFA.from_finite_language(
-            {"a", "b"}, language, as_partial_dfa=as_partial_dfa
+            {"a", "b"}, language, as_partial=as_partial
         )
         minimal_dfa = equiv_dfa.minify()
 
@@ -1642,7 +1642,7 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(repr(dfa2))
 
     @params(True, False)
-    def test_iter_finite(self, as_partial_dfa: bool) -> None:
+    def test_iter_finite(self, as_partial: bool) -> None:
         """
         Test that DFA for finite language generates all words
         """
@@ -1660,9 +1660,7 @@ class TestDFA(test_fa.TestFA):
             "bbabb",
             "bbbab",
         }
-        dfa = DFA.from_finite_language(
-            {"a", "b"}, language, as_partial_dfa=as_partial_dfa
-        )
+        dfa = DFA.from_finite_language({"a", "b"}, language, as_partial=as_partial)
         generated_set = {word for word in dfa}
         self.assertEqual(generated_set, language)
 
@@ -1709,24 +1707,24 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(generated_list, expected)
 
     @params(True, False)
-    def test_len_finite(self, as_partial_dfa: bool) -> None:
+    def test_len_finite(self, as_partial: bool) -> None:
         input_symbols = {"a", "b"}
-        dfa = DFA.from_finite_language(input_symbols, set(), as_partial_dfa)
+        dfa = DFA.from_finite_language(input_symbols, set(), as_partial)
         self.assertEqual(len(dfa), 0)
-        dfa = DFA.from_finite_language(input_symbols, {""}, as_partial_dfa)
+        dfa = DFA.from_finite_language(input_symbols, {""}, as_partial)
         self.assertEqual(len(dfa), 1)
-        dfa = DFA.from_finite_language(input_symbols, {"a"}, as_partial_dfa)
+        dfa = DFA.from_finite_language(input_symbols, {"a"}, as_partial)
         self.assertEqual(len(dfa), 1)
-        dfa = DFA.from_finite_language(input_symbols, {"ababababab"}, as_partial_dfa)
+        dfa = DFA.from_finite_language(input_symbols, {"ababababab"}, as_partial)
         self.assertEqual(len(dfa), 1)
         dfa = DFA.from_finite_language(
-            input_symbols, {"a" * i for i in range(5)}, as_partial_dfa
+            input_symbols, {"a" * i for i in range(5)}, as_partial
         )
         self.assertEqual(len(dfa), 5)
         dfa = DFA.from_finite_language(
             input_symbols,
             {"a" * i + "b" * j for i in range(5) for j in range(5)},
-            as_partial_dfa,
+            as_partial,
         )
         self.assertEqual(len(dfa), 25)
 
@@ -1766,7 +1764,7 @@ class TestDFA(test_fa.TestFA):
             self.assertIn(dfa.random_word(100), dfa)
 
     @params(True, False)
-    def test_predecessor(self, as_partial_dfa: bool) -> None:
+    def test_predecessor(self, as_partial: bool) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1778,7 +1776,7 @@ class TestDFA(test_fa.TestFA):
             "110",
             "010101111111101011010100",
         }
-        dfa = DFA.from_finite_language(binary, language, as_partial_dfa)
+        dfa = DFA.from_finite_language(binary, language, as_partial)
         expected = sorted(language, reverse=True)
         actual = list(dfa.predecessors("11111111111111111111111111111111"))
         self.assertListEqual(actual, expected)
@@ -1800,7 +1798,7 @@ class TestDFA(test_fa.TestFA):
             [_ for _ in infinite_dfa.predecessors("000")]
 
     @params(True, False)
-    def test_successor(self, as_partial_dfa: bool) -> None:
+    def test_successor(self, as_partial: bool) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1812,7 +1810,7 @@ class TestDFA(test_fa.TestFA):
             "110",
             "010101111111101011010100",
         }
-        dfa = DFA.from_finite_language(binary, language, as_partial_dfa)
+        dfa = DFA.from_finite_language(binary, language, as_partial)
         expected = sorted(language)
         actual = list(dfa.successors("", strict=False))
         self.assertListEqual(actual, expected)
@@ -1834,7 +1832,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(infinite_dfa.successor(100 * "1"), 101 * "1")
 
     @params(True, False)
-    def test_successor_and_predecessor(self, as_partial_dfa: bool) -> None:
+    def test_successor_and_predecessor(self, as_partial: bool) -> None:
         binary = {"0", "1"}
         language = {
             "",
@@ -1846,7 +1844,7 @@ class TestDFA(test_fa.TestFA):
             "110",
             "010101111111101011010100",
         }
-        dfa = DFA.from_finite_language(binary, language, as_partial_dfa)
+        dfa = DFA.from_finite_language(binary, language, as_partial)
         for word in language:
             self.assertEqual(dfa.successor(dfa.predecessor(word)), word)  # type: ignore
             self.assertEqual(dfa.predecessor(dfa.successor(word)), word)  # type: ignore
@@ -1995,23 +1993,23 @@ class TestDFA(test_fa.TestFA):
             empty.maximum_word_length()
 
     @params(True, False)
-    def test_contains_prefix(self, as_partial_dfa: bool) -> None:
+    def test_contains_prefix(self, as_partial: bool) -> None:
         input_symbols = {"a", "n", "o", "b"}
 
-        prefix_dfa = DFA.from_prefix(input_symbols, "nano", as_partial=as_partial_dfa)
+        prefix_dfa = DFA.from_prefix(input_symbols, "nano", as_partial=as_partial)
         self.assertEqual(len(prefix_dfa.states), len(prefix_dfa.minify().states))
 
         subset_dfa = DFA.from_finite_language(
             input_symbols,
             {"nano", "nanobao", "nanonana", "nanonano", "nanoo"},
-            as_partial_dfa,
+            as_partial,
         )
         self.assertTrue(subset_dfa < prefix_dfa)
 
         self.assertEqual(
             ~prefix_dfa,
             DFA.from_prefix(
-                input_symbols, "nano", contains=False, as_partial=as_partial_dfa
+                input_symbols, "nano", contains=False, as_partial=as_partial
             ),
         )
 
@@ -2021,7 +2019,7 @@ class TestDFA(test_fa.TestFA):
             self.assertTrue(word.startswith("nano"))
 
     @params(True, False)
-    def test_contains_suffix(self, as_partial_dfa: bool) -> None:
+    def test_contains_suffix(self, as_partial: bool) -> None:
         input_symbols = {"a", "n", "o", "b"}
 
         suffix_dfa = DFA.from_suffix(input_symbols, "nano")
@@ -2030,7 +2028,7 @@ class TestDFA(test_fa.TestFA):
         subset_dfa = DFA.from_finite_language(
             input_symbols,
             {"nano", "annnano", "bnano", "anbonano", "nananananananananano"},
-            as_partial_dfa,
+            as_partial,
         )
         self.assertTrue(subset_dfa < suffix_dfa)
 
@@ -2044,7 +2042,7 @@ class TestDFA(test_fa.TestFA):
             self.assertTrue(word.endswith("nano"))
 
     @params(True, False)
-    def test_contains_substring(self, as_partial_dfa: bool) -> None:
+    def test_contains_substring(self, as_partial: bool) -> None:
         """Should compute the minimal DFA accepting strings with the given substring"""
 
         input_symbols = {"a", "n", "o", "b"}
@@ -2070,7 +2068,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(substring_dfa, equiv_dfa)
 
         subset_dfa = DFA.from_finite_language(
-            input_symbols, {"nano", "bananano", "nananano", "naonano"}, as_partial_dfa
+            input_symbols, {"nano", "bananano", "nananano", "naonano"}, as_partial
         )
         self.assertTrue(subset_dfa < substring_dfa)
 
@@ -2084,7 +2082,7 @@ class TestDFA(test_fa.TestFA):
             self.assertIn("nano", word)
 
     @params(True, False)
-    def test_contains_subsequence(self, as_partial_dfa: bool) -> None:
+    def test_contains_subsequence(self, as_partial: bool) -> None:
         """Should compute the minimal DFA accepting strings with the given
         subsequence"""
 
@@ -2115,7 +2113,7 @@ class TestDFA(test_fa.TestFA):
         subset_dfa = DFA.from_finite_language(
             input_symbols,
             {"naooono", "bananano", "onbaonbo", "ooonano"},
-            as_partial_dfa,
+            as_partial,
         )
         self.assertTrue(subset_dfa < subsequence_dfa)
 
@@ -2131,7 +2129,7 @@ class TestDFA(test_fa.TestFA):
         )
 
     @params(True, False)
-    def test_of_length(self, as_partial_dfa: bool) -> None:
+    def test_of_length(self, as_partial: bool) -> None:
         binary = {"0", "1"}
         dfa1 = DFA.of_length(binary)
         self.assertFalse(dfa1.isfinite())
@@ -2189,7 +2187,7 @@ class TestDFA(test_fa.TestFA):
         ]
         self.assertListEqual(list(dfa3), expected)
         self.assertEqual(
-            dfa3, DFA.from_finite_language(binary, set(expected), as_partial_dfa)
+            dfa3, DFA.from_finite_language(binary, set(expected), as_partial)
         )
         self.assertEqual(dfa1, dfa2.union(dfa3))
         self.assertEqual(dfa3.minimum_word_length(), 0)
@@ -2370,11 +2368,11 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(dfa.isempty())
 
     @params(True, False)
-    def test_reset_word_cache(self, as_partial_dfa: bool) -> None:
+    def test_reset_word_cache(self, as_partial: bool) -> None:
         max_len = 4
         dfa = DFA.of_length({"0", "1"}, min_length=0, max_length=max_len)
 
-        if as_partial_dfa:
+        if as_partial:
             dfa = dfa.to_partial()
 
         self.assertEqual(len(dfa._word_cache), 0)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -2082,7 +2082,9 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(subsequence_dfa, equiv_dfa)
 
         subset_dfa = DFA.from_finite_language(
-            input_symbols, {"naooono", "bananano", "onbaonbo", "ooonano"}, as_partial_dfa
+            input_symbols,
+            {"naooono", "bananano", "onbaonbo", "ooonano"},
+            as_partial_dfa,
         )
         self.assertTrue(subset_dfa < subsequence_dfa)
 
@@ -2155,7 +2157,9 @@ class TestDFA(test_fa.TestFA):
             "1111",
         ]
         self.assertListEqual(list(dfa3), expected)
-        self.assertEqual(dfa3, DFA.from_finite_language(binary, set(expected), as_partial_dfa))
+        self.assertEqual(
+            dfa3, DFA.from_finite_language(binary, set(expected), as_partial_dfa)
+        )
         self.assertEqual(dfa1, dfa2.union(dfa3))
         self.assertEqual(dfa3.minimum_word_length(), 0)
         self.assertEqual(dfa3.maximum_word_length(), 4)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1247,7 +1247,9 @@ class TestDFA(test_fa.TestFA):
             initial_state="q0",
             final_states={"q2"},
         )
-        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False, as_partial=False)
+        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False).to_complete(
+            frozenset()
+        )
         self.assertEqual(
             dfa.states,
             {
@@ -1327,7 +1329,9 @@ class TestDFA(test_fa.TestFA):
 
     def test_init_nfa_lambda_transition(self) -> None:
         """Should convert to a DFA an NFA with a lambda transition."""
-        dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False, as_partial=False)
+        dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False).to_complete(
+            frozenset()
+        )
         self.assertEqual(
             dfa.states,
             frozenset({frozenset(), frozenset(("q0",)), frozenset(("q1", "q2"))}),

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1247,7 +1247,7 @@ class TestDFA(test_fa.TestFA):
             initial_state="q0",
             final_states={"q2"},
         )
-        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False)
+        dfa = DFA.from_nfa(nfa, retain_names=True, minify=False, as_partial=False)
         self.assertEqual(
             dfa.states,
             {
@@ -1327,7 +1327,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_init_nfa_lambda_transition(self) -> None:
         """Should convert to a DFA an NFA with a lambda transition."""
-        dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False)
+        dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False, as_partial=False)
         self.assertEqual(
             dfa.states,
             frozenset({frozenset(), frozenset(("q0",)), frozenset(("q1", "q2"))}),

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -598,12 +598,15 @@ class TestDFA(test_fa.TestFA):
         self.assertFalse(self.no_consecutive_11_dfa <= self.zero_or_one_1_dfa)
 
         single_string_dfa = DFA.from_finite_language(
-            {"0", "1"}, "101", as_partial_dfa=True
+            {"0", "1"}, {"101"}, as_partial_dfa=True
         )
 
         # Test interop with partial DFA
+        self.assertFalse(self.partial_dfa < self.zero_or_one_1_dfa)
+        self.assertFalse(self.partial_dfa <= self.zero_or_one_1_dfa)
+
         self.assertTrue(single_string_dfa < self.no_consecutive_11_dfa)
-        self.assertTrue(single_string_dfa < self.zero_or_one_1_dfa)
+        self.assertTrue(single_string_dfa <= self.no_consecutive_11_dfa)
 
     def test_issuperset(self) -> None:
         """Should test if one DFA is a superset of another"""
@@ -611,8 +614,20 @@ class TestDFA(test_fa.TestFA):
         # Test both proper subset and subset with each set as left hand side
         self.assertFalse(self.zero_or_one_1_dfa > self.no_consecutive_11_dfa)
         self.assertFalse(self.zero_or_one_1_dfa >= self.no_consecutive_11_dfa)
+
         self.assertTrue(self.no_consecutive_11_dfa > self.zero_or_one_1_dfa)
         self.assertTrue(self.no_consecutive_11_dfa >= self.zero_or_one_1_dfa)
+
+        single_string_dfa = DFA.from_finite_language(
+            {"0", "1"}, {"101"}, as_partial_dfa=True
+        )
+
+        # Test interop with partial DFA
+        self.assertFalse(self.zero_or_one_1_dfa > self.partial_dfa)
+        self.assertFalse(self.zero_or_one_1_dfa >= self.partial_dfa)
+
+        self.assertTrue(self.no_consecutive_11_dfa > single_string_dfa)
+        self.assertTrue(self.no_consecutive_11_dfa >= single_string_dfa)
 
     def test_symbol_mismatch(self) -> None:
         """Should test if symbol mismatch is raised"""
@@ -647,8 +662,16 @@ class TestDFA(test_fa.TestFA):
 
         self.assertTrue(at_least_three_1.isdisjoint(self.zero_or_one_1_dfa))
         self.assertTrue(self.zero_or_one_1_dfa.isdisjoint(at_least_three_1))
+
         self.assertFalse(at_least_three_1.isdisjoint(at_least_one_1))
         self.assertFalse(self.zero_or_one_1_dfa.isdisjoint(at_least_one_1))
+
+        # Test interop with partial DFA
+        self.assertTrue(self.zero_or_one_1_dfa.isdisjoint(self.partial_dfa))
+        self.assertTrue(self.partial_dfa.isdisjoint(self.zero_or_one_1_dfa))
+
+        self.assertFalse(at_least_three_1.isdisjoint(self.partial_dfa))
+        self.assertFalse(self.partial_dfa.isdisjoint(at_least_three_1))
 
     def test_isempty_non_empty(self) -> None:
         """Should test if a non-empty DFA is empty"""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -30,6 +30,7 @@ class TestDFA(test_fa.TestFA):
 
     temp_dir_path = tempfile.gettempdir()
 
+    # A partial DFA that accepts the string "111" only
     partial_dfa = DFA(
         states=set(range(4)),
         input_symbols={"0", "1"},
@@ -595,6 +596,12 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(self.zero_or_one_1_dfa <= self.no_consecutive_11_dfa)
         self.assertFalse(self.no_consecutive_11_dfa < self.zero_or_one_1_dfa)
         self.assertFalse(self.no_consecutive_11_dfa <= self.zero_or_one_1_dfa)
+
+        single_string_dfa = DFA.from_finite_language({"0", "1"}, "101", as_partial_dfa=True)
+
+        # Test interop with partial DFA
+        self.assertTrue(single_string_dfa < self.no_consecutive_11_dfa)
+        self.assertTrue(single_string_dfa < self.zero_or_one_1_dfa)
 
     def test_issuperset(self) -> None:
         """Should test if one DFA is a superset of another"""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -597,7 +597,9 @@ class TestDFA(test_fa.TestFA):
         self.assertFalse(self.no_consecutive_11_dfa < self.zero_or_one_1_dfa)
         self.assertFalse(self.no_consecutive_11_dfa <= self.zero_or_one_1_dfa)
 
-        single_string_dfa = DFA.from_finite_language({"0", "1"}, "101", as_partial_dfa=True)
+        single_string_dfa = DFA.from_finite_language(
+            {"0", "1"}, "101", as_partial_dfa=True
+        )
 
         # Test interop with partial DFA
         self.assertTrue(single_string_dfa < self.no_consecutive_11_dfa)
@@ -639,26 +641,14 @@ class TestDFA(test_fa.TestFA):
         # three occurrences of 1
         input_symbols = {"0", "1"}
         at_least_three_1 = DFA.from_subsequence(input_symbols, "111")
-        # This DFA accepts all words which contain either zero
-        # or one occurrence of 1
-        at_most_one_1 = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols=input_symbols,
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
         # This DFA accepts all words which contain at least
         # one occurrence of 1
         at_least_one_1 = DFA.from_subsequence(input_symbols, "1")
-        self.assertTrue(at_least_three_1.isdisjoint(at_most_one_1))
-        self.assertTrue(at_most_one_1.isdisjoint(at_least_three_1))
+
+        self.assertTrue(at_least_three_1.isdisjoint(self.zero_or_one_1_dfa))
+        self.assertTrue(self.zero_or_one_1_dfa.isdisjoint(at_least_three_1))
         self.assertFalse(at_least_three_1.isdisjoint(at_least_one_1))
-        self.assertFalse(at_most_one_1.isdisjoint(at_least_one_1))
+        self.assertFalse(self.zero_or_one_1_dfa.isdisjoint(at_least_one_1))
 
     def test_isempty_non_empty(self) -> None:
         """Should test if a non-empty DFA is empty"""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -288,6 +288,10 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(TypeError):
             self.dfa >= other  # type: ignore
 
+    def test_to_complete_trap_state_exception(self) -> None:
+        with self.assertRaises(exceptions.InvalidStateError):
+            self.dfa.to_complete("q0")
+
     def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""
         self.assertNotEqual(self.no_consecutive_11_dfa, self.zero_or_one_1_dfa)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1998,7 +1998,7 @@ class TestDFA(test_fa.TestFA):
     def test_contains_prefix(self, as_partial_dfa: bool) -> None:
         input_symbols = {"a", "n", "o", "b"}
 
-        prefix_dfa = DFA.from_prefix(input_symbols, "nano")
+        prefix_dfa = DFA.from_prefix(input_symbols, "nano", as_partial=as_partial_dfa)
         self.assertEqual(len(prefix_dfa.states), len(prefix_dfa.minify().states))
 
         subset_dfa = DFA.from_finite_language(
@@ -2009,7 +2009,10 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(subset_dfa < prefix_dfa)
 
         self.assertEqual(
-            ~prefix_dfa, DFA.from_prefix(input_symbols, "nano", contains=False)
+            ~prefix_dfa,
+            DFA.from_prefix(
+                input_symbols, "nano", contains=False, as_partial=as_partial_dfa
+            ),
         )
 
         for word in prefix_dfa:

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -67,6 +67,35 @@ class TestDFA(test_fa.TestFA):
         final_states={"q4"},
     )
 
+    # This DFA accepts all words which contain either zero
+    # or one occurrence of 1
+    zero_or_one_1_dfa = DFA(
+        states={"q0", "q1", "q2"},
+        input_symbols={"0", "1"},
+        transitions={
+            "q0": {"0": "q0", "1": "q1"},
+            "q1": {"0": "q1", "1": "q2"},
+            "q2": {"0": "q2", "1": "q2"},
+        },
+        initial_state="q0",
+        final_states={"q0", "q1"},
+    )
+
+    # This DFA has no reachable final states and
+    # therefore is finite.
+    no_reachable_final_dfa = DFA(
+        states={"q0", "q1", "q2", "q3"},
+        input_symbols={"0", "1"},
+        transitions={
+            "q0": {"0": "q0", "1": "q1"},
+            "q1": {"0": "q1", "1": "q2"},
+            "q2": {"0": "q0", "1": "q1"},
+            "q3": {"0": "q2", "1": "q1"},
+        },
+        initial_state="q0",
+        final_states={"q3"},
+    )
+
     def test_init_dfa(self) -> None:
         """Should copy DFA if passed into DFA constructor."""
         new_dfa = self.dfa.copy()
@@ -254,21 +283,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""
-
-        # This DFA accepts all words which contain either zero
-        # or one occurrence of 1
-        zero_or_one_1_dfa = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
-        self.assertNotEqual(self.no_consecutive_11_dfa, zero_or_one_1_dfa)
+        self.assertNotEqual(self.no_consecutive_11_dfa, self.zero_or_one_1_dfa)
 
     def test_equivalence_partials(self) -> None:
         self.assertEqual(self.partial_dfa, self.partial_dfa.to_complete())
@@ -553,45 +568,21 @@ class TestDFA(test_fa.TestFA):
 
     def test_issubset(self) -> None:
         """Should test if one DFA is a subset of another"""
-        # This DFA accepts all words which contain either zero
-        # or one occurrence of 1
-        zero_or_one_1_dfa = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
+
         # Test both proper subset and subset with each set as left hand side
-        self.assertTrue(zero_or_one_1_dfa < self.no_consecutive_11_dfa)
-        self.assertTrue(zero_or_one_1_dfa <= self.no_consecutive_11_dfa)
-        self.assertFalse(self.no_consecutive_11_dfa < zero_or_one_1_dfa)
-        self.assertFalse(self.no_consecutive_11_dfa <= zero_or_one_1_dfa)
+        self.assertTrue(self.zero_or_one_1_dfa < self.no_consecutive_11_dfa)
+        self.assertTrue(self.zero_or_one_1_dfa <= self.no_consecutive_11_dfa)
+        self.assertFalse(self.no_consecutive_11_dfa < self.zero_or_one_1_dfa)
+        self.assertFalse(self.no_consecutive_11_dfa <= self.zero_or_one_1_dfa)
 
     def test_issuperset(self) -> None:
         """Should test if one DFA is a superset of another"""
-        # This DFA accepts all words which contain either zero
-        # or one occurrence of 1
-        zero_or_one_1_dfa = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
+
         # Test both proper subset and subset with each set as left hand side
-        self.assertFalse(zero_or_one_1_dfa > self.no_consecutive_11_dfa)
-        self.assertFalse(zero_or_one_1_dfa >= self.no_consecutive_11_dfa)
-        self.assertTrue(self.no_consecutive_11_dfa > zero_or_one_1_dfa)
-        self.assertTrue(self.no_consecutive_11_dfa >= zero_or_one_1_dfa)
+        self.assertFalse(self.zero_or_one_1_dfa > self.no_consecutive_11_dfa)
+        self.assertFalse(self.zero_or_one_1_dfa >= self.no_consecutive_11_dfa)
+        self.assertTrue(self.no_consecutive_11_dfa > self.zero_or_one_1_dfa)
+        self.assertTrue(self.no_consecutive_11_dfa >= self.zero_or_one_1_dfa)
 
     def test_symbol_mismatch(self) -> None:
         """Should test if symbol mismatch is raised"""
@@ -650,21 +641,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_isempty_empty(self) -> None:
         """Should test if an empty DFA is empty"""
-        # This DFA has no reachable final states and
-        # therefore accepts the empty language
-        dfa1 = DFA(
-            states={"q0", "q1", "q2", "q3"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q0", "1": "q1"},
-                "q3": {"0": "q2", "1": "q1"},
-            },
-            initial_state="q0",
-            final_states={"q3"},
-        )
-        self.assertTrue(dfa1.isempty())
+        self.assertTrue(self.no_reachable_final_dfa.isempty())
 
     def test_isfinite_infinite(self) -> None:
         """Should test if an infinite DFA is finite (case #1)"""
@@ -703,21 +680,8 @@ class TestDFA(test_fa.TestFA):
 
     def test_isfinite_empty(self) -> None:
         """Should test if an empty DFA is finite"""
-        # This DFA has no reachable final states and
-        # therefore is finite.
-        dfa = DFA(
-            states={"q0", "q1", "q2", "q3"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q0", "1": "q1"},
-                "q3": {"0": "q2", "1": "q1"},
-            },
-            initial_state="q0",
-            final_states={"q3"},
-        )
-        self.assertTrue(dfa.isfinite())
+
+        self.assertTrue(self.no_reachable_final_dfa.isfinite())
 
     def test_isfinite_universe(self) -> None:
         # This DFA accepts all binary strings and

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -40,15 +40,15 @@ class TestDFA(test_fa.TestFA):
     # This DFA accepts all words which do not contain two
     # consecutive occurrences of 1
     no_consecutive_11_dfa = DFA(
-        states={"q0", "q1", "q2"},
+        states={"p0", "p1", "p2"},
         input_symbols={"0", "1"},
         transitions={
-            "q0": {"0": "q0", "1": "q1"},
-            "q1": {"0": "q0", "1": "q2"},
-            "q2": {"0": "q2", "1": "q2"},
+            "p0": {"0": "p0", "1": "p1"},
+            "p1": {"0": "p0", "1": "p2"},
+            "p2": {"0": "p2", "1": "p2"},
         },
-        initial_state="q0",
-        final_states={"q0", "q1"},
+        initial_state="p0",
+        final_states={"p0", "p1"},
     )
 
     def test_init_dfa(self) -> None:
@@ -217,37 +217,24 @@ class TestDFA(test_fa.TestFA):
 
     def test_operations_other_types(self) -> None:
         """Should raise TypeError for all but equals."""
-        # This DFA accepts all words which do not contain two
-        # consecutive occurrences of 1
-        dfa = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q0", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
         other = 42
-        self.assertNotEqual(dfa, other)
+        self.assertNotEqual(self.dfa, other)
         with self.assertRaises(TypeError):
-            dfa | other  # type: ignore
+            self.dfa | other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa & other  # type: ignore
+            self.dfa & other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa - other  # type: ignore
+            self.dfa - other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa ^ other  # type: ignore
+            self.dfa ^ other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa < other  # type: ignore
+            self.dfa < other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa <= other  # type: ignore
+            self.dfa <= other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa > other  # type: ignore
+            self.dfa > other  # type: ignore
         with self.assertRaises(TypeError):
-            dfa >= other  # type: ignore
+            self.dfa >= other  # type: ignore
 
     def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""
@@ -308,7 +295,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(
             complement_dfa.initial_state, self.no_consecutive_11_dfa.initial_state
         )
-        self.assertEqual(complement_dfa.final_states, {"q2"})
+        self.assertEqual(complement_dfa.final_states, {"p2"})
 
     def test_union(self) -> None:
         """Should compute the union between two DFAs"""
@@ -329,17 +316,7 @@ class TestDFA(test_fa.TestFA):
         )
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
-        dfa2 = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+        dfa2 = self.no_consecutive_11_dfa
         new_dfa = dfa1.union(dfa2, retain_names=True, minify=False)
         self.assertEqual(
             new_dfa.states,
@@ -415,17 +392,7 @@ class TestDFA(test_fa.TestFA):
         )
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
-        dfa2 = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+        dfa2 = self.no_consecutive_11_dfa
         new_dfa = dfa1.intersection(dfa2, retain_names=True, minify=False)
         self.assertEqual(
             new_dfa.states,
@@ -495,17 +462,7 @@ class TestDFA(test_fa.TestFA):
         )
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
-        dfa2 = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+        dfa2 = self.no_consecutive_11_dfa
         new_dfa = dfa1.difference(dfa2, retain_names=True, minify=False)
         self.assertEqual(
             new_dfa.states,
@@ -569,17 +526,7 @@ class TestDFA(test_fa.TestFA):
         )
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
-        dfa2 = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+        dfa2 = self.no_consecutive_11_dfa
         new_dfa = dfa1.symmetric_difference(dfa2, retain_names=True, minify=False)
         self.assertEqual(
             new_dfa.states,
@@ -1533,34 +1480,24 @@ class TestDFA(test_fa.TestFA):
         """
         # This DFA accepts all words which do not contain two consecutive
         # occurrences of 1
-        dfa = DFA(
-            states={"q0", "q1", "q2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q0", "1": "q2"},
-                "q2": {"0": "q2", "1": "q2"},
-            },
-            initial_state="q0",
-            final_states={"q0", "q1"},
-        )
+        dfa = self.no_consecutive_11_dfa
 
         graph = dfa.show_diagram()
         node_names = {node.get_name() for node in graph.nodes()}
         self.assertTrue(set(dfa.states).issubset(node_names))
         self.assertEqual(len(dfa.states) + 1, len(node_names))
 
-        for state in self.dfa.states:
+        for state in dfa.states:
             node = graph.get_node(state)
             expected_shape = "doublecircle" if state in dfa.final_states else "circle"
             self.assertEqual(node.attr["shape"], expected_shape)
 
         expected_transitions = {
-            ("q0", "0", "q0"),
-            ("q0", "1", "q1"),
-            ("q1", "0", "q0"),
-            ("q1", "1", "q2"),
-            ("q2", "0,1", "q2"),
+            ("p0", "0", "p0"),
+            ("p0", "1", "p1"),
+            ("p1", "0", "p0"),
+            ("p1", "1", "p2"),
+            ("p2", "0,1", "p2"),
         }
         seen_transitions = {
             (edge[0], edge.attr["label"], edge[1]) for edge in graph.edges()
@@ -2006,19 +1943,7 @@ class TestDFA(test_fa.TestFA):
             initial_state="q0",
             final_states={"q4"},
         )
-        # This DFA accepts all words which do not contain two
-        # consecutive occurrences of 1
-        no_11_occurrence = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+
         # This DFA accepts all binary strings except the empty string
         at_least_one_symbol = DFA(
             states={"q0", "q1"},
@@ -2040,7 +1965,7 @@ class TestDFA(test_fa.TestFA):
         )
 
         self.assertEqual(at_least_four_ones.minimum_word_length(), 4)
-        self.assertEqual(no_11_occurrence.minimum_word_length(), 0)
+        self.assertEqual(self.no_consecutive_11_dfa.minimum_word_length(), 0)
         self.assertEqual(at_least_one_symbol.minimum_word_length(), 1)
         with self.assertRaises(exceptions.EmptyLanguageException):
             empty.minimum_word_length()
@@ -2061,19 +1986,7 @@ class TestDFA(test_fa.TestFA):
             initial_state="q0",
             final_states={"q4"},
         )
-        # This DFA accepts all words which do not contain two
-        # consecutive occurrences of 1
-        no_11_occurrence = DFA(
-            states={"p0", "p1", "p2"},
-            input_symbols={"0", "1"},
-            transitions={
-                "p0": {"0": "p0", "1": "p1"},
-                "p1": {"0": "p0", "1": "p2"},
-                "p2": {"0": "p2", "1": "p2"},
-            },
-            initial_state="p0",
-            final_states={"p0", "p1"},
-        )
+
         # This DFA accepts all binary strings except the empty string
         at_most_one_symbol = DFA(
             states={"q0", "q1", "q2"},
@@ -2096,7 +2009,7 @@ class TestDFA(test_fa.TestFA):
         )
 
         self.assertEqual(at_least_four_ones.maximum_word_length(), None)
-        self.assertEqual(no_11_occurrence.maximum_word_length(), None)
+        self.assertEqual(self.no_consecutive_11_dfa.maximum_word_length(), None)
         self.assertEqual(at_most_one_symbol.maximum_word_length(), 1)
         with self.assertRaises(exceptions.EmptyLanguageException):
             empty.maximum_word_length()

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -299,6 +299,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_equivalence_partials(self) -> None:
         complete_dfa = self.partial_dfa.to_complete()
+        self.assertEqual(self.partial_dfa, self.partial_dfa)
         self.assertEqual(self.partial_dfa, complete_dfa)
         self.assertEqual(self.partial_dfa, complete_dfa.to_partial())
 

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1522,7 +1522,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(graph.graph_attr["size"], "3.3")
 
     @params(True, False)
-    def test_minimal_finite_language(self, allow_partial: bool) -> None:
+    def test_minimal_finite_language(self, as_partial_dfa: bool) -> None:
         """Should compute the minimal DFA accepting the given finite language"""
 
         # Same language described in the book this algorithm comes from
@@ -1560,24 +1560,27 @@ class TestDFA(test_fa.TestFA):
             final_states={4, 9},
         )
 
-        if allow_partial:
+        if as_partial_dfa:
             equiv_dfa = equiv_dfa.to_partial()
 
         minimal_dfa = DFA.from_finite_language(
-            {"a", "b"}, language, as_partial_dfa=allow_partial
+            {"a", "b"}, language, as_partial_dfa=as_partial_dfa
         )
 
         self.assertEqual(len(minimal_dfa.states), len(equiv_dfa.states))
         self.assertEqual(minimal_dfa, equiv_dfa)
 
-    def test_minimal_finite_language_large(self) -> None:
+    @params(True, False)
+    def test_minimal_finite_language_large(self, as_partial_dfa: bool) -> None:
         """Should compute the minimal DFA accepting the given finite language on
         large test case"""
         m = 50
         n = 50
         language = {("a" * i + "b" * j) for i, j in product(range(n), range(m))}
 
-        equiv_dfa = DFA.from_finite_language({"a", "b"}, language)
+        equiv_dfa = DFA.from_finite_language(
+            {"a", "b"}, language, as_partial_dfa=as_partial_dfa
+        )
         minimal_dfa = equiv_dfa.minify()
 
         self.assertEqual(equiv_dfa, minimal_dfa)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -1428,12 +1428,14 @@ class TestDFA(test_fa.TestFA):
         dfa = DFA.from_nfa(nfa, retain_names=True, minify=False)
         self.assertEqual(
             dfa.states,
-            {
-                frozenset(("q0",)),
-                frozenset(("q0", "q1")),
-                frozenset(("q0", "q2")),
-                frozenset(("q0", "q1", "q2")),
-            },
+            frozenset(
+                {
+                    frozenset(("q0",)),
+                    frozenset(("q0", "q1")),
+                    frozenset(("q0", "q2")),
+                    frozenset(("q0", "q1", "q2")),
+                }
+            ),
         )
         self.assertEqual(dfa.input_symbols, {"0", "1"})
         self.assertEqual(
@@ -1466,7 +1468,8 @@ class TestDFA(test_fa.TestFA):
         """Should convert to a DFA an NFA with a lambda transition."""
         dfa = DFA.from_nfa(self.nfa, retain_names=True, minify=False)
         self.assertEqual(
-            dfa.states, {frozenset(), frozenset(("q0",)), frozenset(("q1", "q2"))}
+            dfa.states,
+            frozenset({frozenset(), frozenset(("q0",)), frozenset(("q1", "q2"))}),
         )
         self.assertEqual(dfa.input_symbols, {"a", "b"})
         self.assertEqual(

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -290,7 +290,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_to_complete_trap_state_exception(self) -> None:
         with self.assertRaises(exceptions.InvalidStateError):
-            self.dfa.to_complete("q0")
+            self.partial_dfa.to_complete(0)
 
     def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -51,6 +51,22 @@ class TestDFA(test_fa.TestFA):
         final_states={"p0", "p1"},
     )
 
+    # This DFA accepts all words which contain at least four
+    # occurrences of 1
+    at_least_four_ones = DFA(
+        states={"q0", "q1", "q2", "q3", "q4"},
+        input_symbols={"0", "1"},
+        transitions={
+            "q0": {"0": "q0", "1": "q1"},
+            "q1": {"0": "q1", "1": "q2"},
+            "q2": {"0": "q2", "1": "q3"},
+            "q3": {"0": "q3", "1": "q4"},
+            "q4": {"0": "q4", "1": "q4"},
+        },
+        initial_state="q0",
+        final_states={"q4"},
+    )
+
     def test_init_dfa(self) -> None:
         """Should copy DFA if passed into DFA constructor."""
         new_dfa = self.dfa.copy()
@@ -301,19 +317,7 @@ class TestDFA(test_fa.TestFA):
         """Should compute the union between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
-        dfa1 = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
+        dfa1 = self.at_least_four_ones
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
         dfa2 = self.no_consecutive_11_dfa
@@ -377,19 +381,7 @@ class TestDFA(test_fa.TestFA):
         """Should compute the intersection between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
-        dfa1 = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
+        dfa1 = self.at_least_four_ones
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
         dfa2 = self.no_consecutive_11_dfa
@@ -447,19 +439,7 @@ class TestDFA(test_fa.TestFA):
         """Should compute the difference between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
-        dfa1 = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
+        dfa1 = self.at_least_four_ones
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
         dfa2 = self.no_consecutive_11_dfa
@@ -511,19 +491,7 @@ class TestDFA(test_fa.TestFA):
         """Should compute the symmetric difference between two DFAs"""
         # This DFA accepts all words which contain at least four
         # occurrences of 1
-        dfa1 = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
+        dfa1 = self.at_least_four_ones
         # This DFA accepts all words which do not contain two
         # consecutive occurrences of 1
         dfa2 = self.no_consecutive_11_dfa
@@ -1928,22 +1896,6 @@ class TestDFA(test_fa.TestFA):
             self.assertEqual(count, fib)
 
     def test_minimum_word_length(self) -> None:
-        # This DFA accepts all words which contain at least four
-        # occurrences of 1
-        at_least_four_ones = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
-
         # This DFA accepts all binary strings except the empty string
         at_least_one_symbol = DFA(
             states={"q0", "q1"},
@@ -1964,29 +1916,13 @@ class TestDFA(test_fa.TestFA):
             final_states=set(),
         )
 
-        self.assertEqual(at_least_four_ones.minimum_word_length(), 4)
+        self.assertEqual(self.at_least_four_ones.minimum_word_length(), 4)
         self.assertEqual(self.no_consecutive_11_dfa.minimum_word_length(), 0)
         self.assertEqual(at_least_one_symbol.minimum_word_length(), 1)
         with self.assertRaises(exceptions.EmptyLanguageException):
             empty.minimum_word_length()
 
     def test_maximum_word_length(self) -> None:
-        # This DFA accepts all words which contain at least four
-        # occurrences of 1
-        at_least_four_ones = DFA(
-            states={"q0", "q1", "q2", "q3", "q4"},
-            input_symbols={"0", "1"},
-            transitions={
-                "q0": {"0": "q0", "1": "q1"},
-                "q1": {"0": "q1", "1": "q2"},
-                "q2": {"0": "q2", "1": "q3"},
-                "q3": {"0": "q3", "1": "q4"},
-                "q4": {"0": "q4", "1": "q4"},
-            },
-            initial_state="q0",
-            final_states={"q4"},
-        )
-
         # This DFA accepts all binary strings except the empty string
         at_most_one_symbol = DFA(
             states={"q0", "q1", "q2"},
@@ -2008,7 +1944,7 @@ class TestDFA(test_fa.TestFA):
             final_states=set(),
         )
 
-        self.assertEqual(at_least_four_ones.maximum_word_length(), None)
+        self.assertEqual(self.at_least_four_ones.maximum_word_length(), None)
         self.assertEqual(self.no_consecutive_11_dfa.maximum_word_length(), None)
         self.assertEqual(at_most_one_symbol.maximum_word_length(), 1)
         with self.assertRaises(exceptions.EmptyLanguageException):

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -270,7 +270,12 @@ class TestGNFA(test_fa.TestFA):
             input_symbols={"a", "b"},
             initial_state=0,
             final_states={4},
-            transitions={0: {"a": 1, "b": 2}, 1: {"a": 2, "b": 2}, 2: {"b": 4}},
+            transitions={
+                0: {"a": 1, "b": 2},
+                1: {"a": 2, "b": 2},
+                2: {"b": 4},
+                4: {},
+            },
             allow_partial=True,
         )
 


### PR DESCRIPTION
@eliotwrobson @caleb531 Please do not review it because the code is not ready yet. This is just a draft to book progress on the allow_partial support.

If you go with the definition that DFAs are sets of words, then all operations are well-defined and relatively easy to implement. Most of the times the only required change is to replace loops like:

```Python
for symbol in input_symbols:
    tgt_a = transitions_a[symbol]
```
By the code:
```Python
for symbol in input_symbols:
    tgt_a = transitions_a.get(tgt_a, None)
```

I made the code such that it adds no overhead for complete DFAs compared to the current implementation. For partial DFAs, if the DFAs are sparse, then you will get a large performance boost, while if they are dense you will pay some penalty (but most of the times negligible).

I feel like we still need to discuss a few things:

1. ~~Reserve something (probably None) to represent the trap state. Basically, we add the invariant that if None is part of the set of states, then it *must* be a trap state. This is already implicitly assumed in `_get_next_current_state` and greatly simplifies the implementation logic~~. Because network graph does not allow for states labeled None, we replaced it with automatically generated integers
2. We could think of making this allow_partial thing invisible to the users. Instead of passing allow_partial as a parameter, we compute internally the flag "is_partial". I go by the principle that we should not restrict our API unless it would lead to misuse.
3. Now that support for partial DFAs is there, it is straightforward to extend operations to support DFAs with different alphabets

**Missing:**
- [ ] Adjust/add tests
- [ ] Add benchmarks