### PR TITLE
Add word cache reset function

### DIFF
--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -63,6 +63,9 @@ class Automaton(metaclass=abc.ABCMeta):
         #   because __setattr__ is disabled due to immutability
         self.__init__(**d)  # type: ignore
 
+    def __contains__(self, item: str) -> bool:
+        return self.accepts_input(item)
+
     @abc.abstractmethod
     def read_input_stepwise(self, input_str: str) -> Generator[Any, None, None]:
         """Return a generator that yields each step while reading input."""

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -63,9 +63,6 @@ class Automaton(metaclass=abc.ABCMeta):
         #   because __setattr__ is disabled due to immutability
         self.__init__(**d)  # type: ignore
 
-    def __contains__(self, item: str) -> bool:
-        return self.accepts_input(item)
-
     @abc.abstractmethod
     def read_input_stepwise(self, input_str: str) -> Generator[Any, None, None]:
         """Return a generator that yields each step while reading input."""

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -151,6 +151,10 @@ class Automaton(metaclass=abc.ABCMeta):
         )
         return f"{self.__class__.__qualname__}({values})"
 
-    def __contains__(self, input_str: str) -> bool:
+    def __contains__(self, item: Any) -> bool:
         """Returns whether the word is accepted by the automaton."""
-        return self.accepts_input(input_str)
+
+        if not isinstance(item, str):
+            return False
+
+        return self.accepts_input(item)

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -84,9 +84,9 @@ class DFA(fa.FA):
             _digraph=self._get_digraph(transitions),
         )
 
-        self.reset_word_cache()
+        self.reset_cache()
 
-    def reset_word_cache(self) -> None:
+    def reset_cache(self) -> None:
         """Resets the word and count caches. Can be called if too much memory is being used."""
         object.__setattr__(self, "_word_cache", [])
         object.__setattr__(self, "_count_cache", [])

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -62,6 +62,7 @@ class DFA(fa.FA):
     allow_partial: bool
     _word_cache: List[DefaultDict[DFAStateT, List[str]]]
     _count_cache: List[DefaultDict[DFAStateT, int]]
+    _digraph: nx.DiGraph
 
     def __init__(
         self,

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -307,17 +307,6 @@ class DFA(fa.FA):
                 "the DFA stopped on a non-final state ({})".format(current_state)
             )
 
-    @cached_method
-    def _get_digraph(self) -> nx.DiGraph:
-        """Return a digraph corresponding to this DFA with transition symbols ignored"""
-        return nx.DiGraph(
-            (
-                (start_state, end_state)
-                for start_state, transition in self.transitions.items()
-                for end_state in transition.values()
-            )
-        )
-
     def read_input_stepwise(
         self, input_str: str, ignore_rejection: bool = False
     ) -> Generator[AbstractSet[DFAStateT], None, None]:
@@ -335,6 +324,17 @@ class DFA(fa.FA):
 
         if not ignore_rejection:
             self._check_for_input_rejection(current_state)
+
+    @cached_method
+    def _get_digraph(self) -> nx.DiGraph:
+        """Return a digraph corresponding to this DFA with transition symbols ignored"""
+        return nx.DiGraph(
+            (
+                (start_state, end_state)
+                for start_state, transition in self.transitions.items()
+                for end_state in transition.values()
+            )
+        )
 
     def minify(self, retain_names: bool = False) -> Self:
         """

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -83,6 +83,11 @@ class DFA(fa.FA):
             allow_partial=allow_partial,
             _digraph=self._get_digraph(transitions),
         )
+
+        self.reset_word_cache()
+
+    def reset_word_cache(self) -> None:
+        """Resets the word and count caches. Can be called if too much memory is being used."""
         object.__setattr__(self, "_word_cache", [])
         object.__setattr__(self, "_count_cache", [])
 
@@ -90,11 +95,11 @@ class DFA(fa.FA):
     def _get_digraph(transitions: DFATransitionsT) -> nx.DiGraph:
         """Return a digraph corresponding to this DFA with transition symbols ignored"""
         return nx.DiGraph(
-            [
+            (
                 (start_state, end_state)
                 for start_state, transition in transitions.items()
                 for end_state in transition.values()
-            ]
+            )
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -760,6 +760,7 @@ class DFA(fa.FA):
             lambda state: iter(self.transitions[state].items()),
         )
 
+    @cached_method
     def isfinite(self) -> bool:
         """
         Returns True if the DFA accepts a finite language, False otherwise.
@@ -1005,6 +1006,7 @@ class DFA(fa.FA):
                     }
                 )
 
+    @cached_method
     def cardinality(self) -> int:
         """Returns the cardinality of the language represented by the DFA."""
         try:
@@ -1018,6 +1020,7 @@ class DFA(fa.FA):
             )
         return sum(self.count_words_of_length(j) for j in range(i, limit + 1))
 
+    @cached_method
     def minimum_word_length(self) -> int:
         """
         Returns the length of the shortest word in the language represented by the DFA
@@ -1037,6 +1040,7 @@ class DFA(fa.FA):
             "The language represented by the DFA is empty"
         )
 
+    @cached_method
     def maximum_word_length(self) -> Optional[int]:
         """
         Returns the length of the longest word in the language represented by the DFA
@@ -1509,7 +1513,7 @@ class DFA(fa.FA):
 
         # equivalent DFA states states
         nfa_initial_states = frozenset(
-            target_nfa._lambda_closures[target_nfa.initial_state]
+            target_nfa._get_lambda_closures()[target_nfa.initial_state]
         )
         dfa_initial_state = get_name(nfa_initial_states)
         dfa_final_states = set()

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -86,9 +86,9 @@ class DFA(fa.FA):
             allow_partial=allow_partial,
         )
 
-        self.reset_cache()
+        self.clear_cache()
 
-    def reset_cache(self) -> None:
+    def clear_cache(self) -> None:
         """
         Resets the word and count caches.
         Can be called if too much memory is being used.

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -88,7 +88,10 @@ class DFA(fa.FA):
         self.reset_cache()
 
     def reset_cache(self) -> None:
-        """Resets the word and count caches. Can be called if too much memory is being used."""
+        """
+        Resets the word and count caches.
+        Can be called if too much memory is being used.
+        """
         object.__setattr__(self, "_word_cache", [])
         object.__setattr__(self, "_count_cache", [])
 

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -72,8 +72,9 @@ class NFA(fa.FA):
             _lambda_closures=self._compute_lambda_closures(states, transitions),
         )
 
+    @staticmethod
     def _compute_lambda_closures(
-        self, states: AbstractSet[NFAStateT], transitions: NFATransitionsT
+        states: AbstractSet[NFAStateT], transitions: NFATransitionsT
     ) -> Mapping[NFAStateT, FrozenSet[NFAStateT]]:
         """
         Computes a dictionary of the lambda closures for this NFA, where each

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -89,13 +89,13 @@ class NFA(fa.FA):
         lambda_graph = nx.DiGraph()
         lambda_graph.add_nodes_from(states)
         lambda_graph.add_edges_from(
-            [
+            (
                 (start_state, end_state)
                 for start_state, transition in transitions.items()
                 for char, end_states in transition.items()
                 if char == ""
                 for end_state in end_states
-            ]
+            )
         )
 
         return frozendict(

--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -309,7 +309,7 @@ for word in dfa:
     print(word)
 ```
 
-## DFA.reset_word_cache(self)
+## DFA.reset_cache(self)
 
 Resets the word and count caches. Can be called if too much memory is being used.
 

--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -309,6 +309,14 @@ for word in dfa:
     print(word)
 ```
 
+## DFA.reset_word_cache(self)
+
+Resets the word and count caches. Can be called if too much memory is being used.
+
+```python
+dfa.reset_word_cache()
+```
+
 ## DFA.cardinality(self)
 
 Returns the cardinality of the language represented by the DFA. Raises an

--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -309,12 +309,12 @@ for word in dfa:
     print(word)
 ```
 
-## DFA.reset_cache(self)
+## DFA.clear_cache(self)
 
 Resets the word and count caches. Can be called if too much memory is being used.
 
 ```python
-dfa.reset_word_cache()
+dfa.clear_cache()
 ```
 
 ## DFA.cardinality(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ exclude = ["build"]
 module = [
   "setuptools.*",
   "networkx.*",
-  "pygraphviz.*"
+  "pygraphviz.*",
+  "cached_method.*"
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ maintainers = [
 dependencies = [
     "networkx>=2.6.2",
     "frozendict>=2.3.4",
-    "typing-extensions>=4.5.0"
+    "typing-extensions>=4.5.0",
+    "cached_method>=0.1.0"
 ]
 
 # Per https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==23.3.0
+cached_method==0.1.0
 click==8.1.3
 coloraide==1.8.2
 coverage[toml]==6.4.4

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -172,10 +172,12 @@ class TestDFA(test_fa.TestFA):
     def test_accepts_input_true(self) -> None:
         """Should return True if DFA input is accepted."""
         self.assertTrue(self.dfa.accepts_input("0111"))
+        self.assertIn("0111", self.dfa)
 
     def test_accepts_input_false(self) -> None:
         """Should return False if DFA input is rejected."""
         self.assertFalse(self.dfa.accepts_input("011"))
+        self.assertNotIn("011", self.dfa)
 
     def test_read_input_step(self) -> None:
         """Should return validation generator if step flag is supplied."""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -2518,6 +2518,6 @@ class TestDFA(test_fa.TestFA):
         self.assertGreater(len(list(dfa.words_of_length(max_len))), 0)
         self.assertGreater(len(dfa._word_cache), 0)
 
-        dfa.reset_cache()
+        dfa.clear_cache()
         self.assertEqual(len(dfa._word_cache), 0)
         self.assertEqual(len(dfa._count_cache), 0)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -2506,15 +2506,18 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(dfa.isempty())
 
     def test_reset_word_cache(self) -> None:
-        dfa = DFA.of_length(set("01"), min_length=0, max_length=4)
+        max_len = 4
+        dfa = DFA.of_length(set("01"), min_length=0, max_length=max_len)
 
-        self.assertEqual(dfa._word_cache, 0)
-        self.assertEqual(dfa._word_cache, 0)
+        self.assertEqual(len(dfa._word_cache), 0)
+        self.assertEqual(len(dfa._count_cache), 0)
 
         self.assertGreater(dfa.cardinality(), 0)
-        self.assertGreater(dfa._word_cache, 0)
-        self.assertGreater(dfa._word_cache, 0)
+        self.assertGreater(len(dfa._count_cache), 0)
 
-        dfa.reset_word_cache()
-        self.assertEqual(dfa._word_cache, 0)
-        self.assertEqual(dfa._word_cache, 0)
+        self.assertGreater(len(list(dfa.words_of_length(max_len))), 0)
+        self.assertGreater(len(dfa._word_cache), 0)
+
+        dfa.reset_cache()
+        self.assertEqual(len(dfa._word_cache), 0)
+        self.assertEqual(len(dfa._count_cache), 0)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -2504,3 +2504,17 @@ class TestDFA(test_fa.TestFA):
 
         dfa = DFA.empty_language({"0", "1", "a", "b"})
         self.assertTrue(dfa.isempty())
+
+    def test_reset_word_cache(self) -> None:
+        dfa = DFA.of_length(set("01"), min_length=0, max_length=4)
+
+        self.assertEqual(dfa._word_cache, 0)
+        self.assertEqual(dfa._word_cache, 0)
+
+        self.assertGreater(dfa.cardinality(), 0)
+        self.assertGreater(dfa._word_cache, 0)
+        self.assertGreater(dfa._word_cache, 0)
+
+        dfa.reset_word_cache()
+        self.assertEqual(dfa._word_cache, 0)
+        self.assertEqual(dfa._word_cache, 0)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -178,6 +178,7 @@ class TestDFA(test_fa.TestFA):
         """Should return False if DFA input is rejected."""
         self.assertFalse(self.dfa.accepts_input("011"))
         self.assertNotIn("011", self.dfa)
+        self.assertNotIn(1, self.nfa)
 
     def test_read_input_step(self) -> None:
         """Should return validation generator if step flag is supplied."""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -2507,7 +2507,7 @@ class TestDFA(test_fa.TestFA):
 
     def test_reset_word_cache(self) -> None:
         max_len = 4
-        dfa = DFA.of_length(set("01"), min_length=0, max_length=max_len)
+        dfa = DFA.of_length({"0", "1"}, min_length=0, max_length=max_len)
 
         self.assertEqual(len(dfa._word_cache), 0)
         self.assertEqual(len(dfa._count_cache), 0)

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -437,7 +437,9 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa1.transitions, nfa2.transitions)
         self.assertEqual(nfa1.final_states, nfa2.final_states)
         self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
-        self.assertNotEqual(nfa1._lambda_closures, original_nfa._lambda_closures)
+        self.assertNotEqual(
+            nfa1._get_lambda_closures(), original_nfa._get_lambda_closures()
+        )
 
     def test_eliminate_lambda_other(self) -> None:
         original_nfa = NFA(
@@ -463,7 +465,9 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(nfa1.transitions, nfa2.transitions)
         self.assertEqual(nfa1.final_states, nfa2.final_states)
         self.assertEqual(nfa1.input_symbols, nfa2.input_symbols)
-        self.assertNotEqual(nfa1._lambda_closures, original_nfa._lambda_closures)
+        self.assertNotEqual(
+            nfa1._get_lambda_closures(), original_nfa._get_lambda_closures()
+        )
 
     def test_eliminate_lambda_regex(self) -> None:
         nfa = NFA.from_regex(

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -233,6 +233,7 @@ class TestNFA(test_fa.TestFA):
         """Should return False if NFA input is rejected."""
         self.assertFalse(self.nfa.accepts_input("abba"))
         self.assertNotIn("abba", self.nfa)
+        self.assertNotIn(1, self.nfa)
 
     def test_cyclic_lambda_transitions(self) -> None:
         """Should traverse NFA containing cyclic lambda transitions."""

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -227,10 +227,12 @@ class TestNFA(test_fa.TestFA):
     def test_accepts_input_true(self) -> None:
         """Should return True if NFA input is accepted."""
         self.assertTrue(self.nfa.accepts_input("aba"))
+        self.assertIn("aba", self.nfa)
 
     def test_accepts_input_false(self) -> None:
         """Should return False if NFA input is rejected."""
         self.assertFalse(self.nfa.accepts_input("abba"))
+        self.assertNotIn("abba", self.nfa)
 
     def test_cyclic_lambda_transitions(self) -> None:
         """Should traverse NFA containing cyclic lambda transitions."""


### PR DESCRIPTION
See title, adds a word cache reset function and precomputes the digraph used by the DFA. Resolves #148 

In looking at this, I thought about using a cached property for some of the methods that return fixed information about the given DFAs. However, switching these to cached properties (with the decorator) requires using a slightly different API. @caleb531 what are your thoughts about changing this? Is there a way to provide this caching without changing the API? It would be great if there were a way to do this cleanly.