### PR TITLE
Add internal minify call to to_partial function

### DIFF
--- a/docs/fa/class-dfa.md
+++ b/docs/fa/class-dfa.md
@@ -90,10 +90,11 @@ else:
 dfa.copy()  # returns deep copy of dfa
 ```
 
-## DFA.to_partial(self)
+## DFA.to_partial(self, retain_names = False, minify = True)
 
 Creates an equivalent partial DFA with all unnecessary transitions removed. If the DFA is
-already partial, just returns a copy.
+already partial, just returns a copy. Will minify the input DFA if `minify` is `True`,
+and retain names during this if `retain_names` is `True`.
 
 ```python
 dfa.to_partial()  # returns deep copy of dfa


### PR DESCRIPTION
Adds an optional (defaulted to on) minify step to the `to_partial` function. Required some small changes to the `_minify` logic so it wouldn't complain about missing end states in the transition dictionary passed in.