### PR TITLE
Added `show_diagram` method for Push Down Automata

### DIFF
--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -30,7 +30,7 @@ class Automaton(metaclass=abc.ABCMeta):
     @staticmethod
     def _get_state_name(state_data: Any) -> str:
         """
-        Get an string representation of a state. This is used for displaying and
+        Get a string representation of a state. This is used for displaying and
         uses `str` for any unsupported python data types.
         """
         if isinstance(state_data, str):

--- a/automata/base/automaton.py
+++ b/automata/base/automaton.py
@@ -27,6 +27,33 @@ class Automaton(metaclass=abc.ABCMeta):
     transitions: AutomatonTransitionsT
     input_symbols: AbstractSet[str]
 
+    @staticmethod
+    def _get_state_name(state_data: Any) -> str:
+        """
+        Get an string representation of a state. This is used for displaying and
+        uses `str` for any unsupported python data types.
+        """
+        if isinstance(state_data, str):
+            if state_data == "":
+                return "λ"
+
+            return state_data
+
+        elif isinstance(state_data, (frozenset, tuple)):
+            inner = ", ".join(
+                Automaton._get_state_name(sub_data) for sub_data in state_data
+            )
+            if isinstance(state_data, frozenset):
+                if state_data:
+                    return "{" + inner + "}"
+                else:
+                    return "∅"
+
+            elif isinstance(state_data, tuple):
+                return "(" + inner + ")"
+
+        return str(state_data)
+
     def __init__(self, **kwargs: Any) -> None:
         if not global_config.allow_mutable_automata:
             for attr_name, attr_value in kwargs.items():

--- a/automata/base/exceptions.py
+++ b/automata/base/exceptions.py
@@ -87,3 +87,9 @@ class InfiniteLanguageException(AutomatonException):
     """The operation cannot be performed because the language is infinite"""
 
     pass
+
+
+class DiagramException(Exception):
+    """The diagram cannot be produced"""
+
+    pass

--- a/automata/base/exceptions.py
+++ b/automata/base/exceptions.py
@@ -89,7 +89,7 @@ class InfiniteLanguageException(AutomatonException):
     pass
 
 
-class DiagramException(Exception):
+class DiagramException(AutomatonException):
     """The diagram cannot be produced"""
 
     pass

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -17,6 +17,7 @@ from typing import (
     Literal,
     Set,
     Tuple,
+    TypeAlias,
     TypeVar,
     Union,
 )
@@ -30,6 +31,10 @@ except ImportError:
     _visual_imports = False
 else:
     _visual_imports = True
+finally:
+    # create a type for type checker
+    # irrespective of whether the imports were successful
+    GraphT: TypeAlias = "pgv.AGraph"
 
 
 LayoutMethod = Literal["neato", "dot", "twopi", "circo", "fdp", "nop"]
@@ -81,7 +86,7 @@ def create_graph(
     reverse_orientation: bool = False,
     fig_size: Union[Tuple[float, float], Tuple[float], None] = None,
     state_separation: float = 0.5,
-) -> pgv.AGraph:
+) -> GraphT:
     """Creates and returns a graph object
     Args:
         - horizontal (bool, optional): Direction of node layout. Defaults
@@ -118,7 +123,7 @@ def create_graph(
 
 
 def save_graph(
-    graph: pgv.AGraph,
+    graph: GraphT,
     path: Union[str, os.PathLike],
 ) -> None:
     """Write `graph` to file given by `path`. PNG, SVG, etc.

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -1,11 +1,36 @@
 #!/usr/bin/env python3
 """Miscellaneous utility functions and classes."""
 
+import os
+import pathlib
 from collections import defaultdict
 from itertools import count, tee, zip_longest
-from typing import Any, Callable, Dict, Generic, Iterable, List, Set, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Literal,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from frozendict import frozendict
+
+# Optional imports for use with visual functionality
+try:
+    import pygraphviz as pgv
+except ImportError:
+    _visual_imports = False
+else:
+    _visual_imports = True
+
+
+LayoutMethod = Literal["neato", "dot", "twopi", "circo", "fdp", "nop"]
 
 
 def freeze_value(value: Any) -> Any:
@@ -39,6 +64,66 @@ def get_renaming_function(counter: count) -> Callable[[Any], int]:
     """
 
     return defaultdict(counter.__next__).__getitem__
+
+
+def create_graph(
+    horizontal: bool = True,
+    reverse_orientation: bool = False,
+    fig_size: Union[Tuple[float, float], Tuple[float], None] = None,
+    state_separation: float = 0.5,
+) -> pgv.AGraph:
+    """Creates and returns a graph object
+    Args:
+        - horizontal (bool, optional): Direction of node layout. Defaults
+            to True.
+        - reverse_orientation (bool, optional): Reverse direction of node
+            layout. Defaults to False.
+        - fig_size (tuple, optional): Figure size. Defaults to None.
+        - state_separation (float, optional): Node distance. Defaults to 0.5.
+    Returns:
+        AGraph with the given configuration.
+    """
+    if not _visual_imports:
+        raise ImportError(
+            "Missing visualization packages; "
+            "please install coloraide and pygraphviz."
+        )
+
+    # Defining the graph.
+    graph = pgv.AGraph(strict=False, directed=True)
+
+    if fig_size is not None:
+        graph.graph_attr.update(size=", ".join(map(str, fig_size)))
+
+    graph.graph_attr.update(ranksep=str(state_separation))
+
+    if horizontal:
+        rankdir = "RL" if reverse_orientation else "LR"
+    else:
+        rankdir = "BT" if reverse_orientation else "TB"
+
+    graph.graph_attr.update(rankdir=rankdir)
+
+    return graph
+
+
+def save_graph(
+    graph: pgv.AGraph,
+    path: Union[str, os.PathLike],
+) -> pgv.AGraph:
+    """Write `graph` to file given by `path`. PNG, SVG, etc.
+    Returns the same graph."""
+
+    save_path_final: pathlib.Path = pathlib.Path(path)
+
+    format = save_path_final.suffix.split(".")[1] if save_path_final.suffix else None
+
+    graph.draw(
+        path=save_path_final,
+        format=format,
+    )
+
+    return graph
 
 
 T = TypeVar("T")

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Miscellaneous utility functions and classes."""
+from __future__ import annotations
 
 import os
 import pathlib
@@ -17,7 +18,6 @@ from typing import (
     Literal,
     Set,
     Tuple,
-    TypeAlias,
     TypeVar,
     Union,
 )
@@ -31,10 +31,6 @@ except ImportError:
     _visual_imports = False
 else:
     _visual_imports = True
-finally:
-    # create a type for type checker
-    # irrespective of whether the imports were successful
-    GraphT: TypeAlias = "pgv.AGraph"
 
 
 LayoutMethod = Literal["neato", "dot", "twopi", "circo", "fdp", "nop"]
@@ -86,7 +82,7 @@ def create_graph(
     reverse_orientation: bool = False,
     fig_size: Union[Tuple[float, float], Tuple[float], None] = None,
     state_separation: float = 0.5,
-) -> GraphT:
+) -> pgv.AGraph:
     """Creates and returns a graph object
     Args:
         - horizontal (bool, optional): Direction of node layout. Defaults
@@ -123,7 +119,7 @@ def create_graph(
 
 
 def save_graph(
-    graph: GraphT,
+    graph: pgv.AGraph,
     path: Union[str, os.PathLike],
 ) -> None:
     """Write `graph` to file given by `path`. PNG, SVG, etc.

--- a/automata/base/utils.py
+++ b/automata/base/utils.py
@@ -3,6 +3,8 @@
 
 import os
 import pathlib
+import random
+import uuid
 from collections import defaultdict
 from itertools import count, tee, zip_longest
 from typing import (
@@ -66,6 +68,14 @@ def get_renaming_function(counter: count) -> Callable[[Any], int]:
     return defaultdict(counter.__next__).__getitem__
 
 
+def create_unique_random_id() -> str:
+    # To be able to set the random seed, took code from:
+    # https://nathanielknight.ca/articles/consistent_random_uuids_in_python.html
+    return str(
+        uuid.UUID(bytes=bytes(random.getrandbits(8) for _ in range(16)), version=4)
+    )
+
+
 def create_graph(
     horizontal: bool = True,
     reverse_orientation: bool = False,
@@ -110,7 +120,7 @@ def create_graph(
 def save_graph(
     graph: pgv.AGraph,
     path: Union[str, os.PathLike],
-) -> pgv.AGraph:
+) -> None:
     """Write `graph` to file given by `path`. PNG, SVG, etc.
     Returns the same graph."""
 
@@ -122,8 +132,6 @@ def save_graph(
         path=save_path_final,
         format=format,
     )
-
-    return graph
 
 
 T = TypeVar("T")

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -20,7 +20,9 @@ try:
     import coloraide
     import pygraphviz as pgv
 except ImportError:
-    pass
+    _visual_imports = False
+else:
+    _visual_imports = True
 
 
 FAStateT = AutomatonStateT
@@ -72,6 +74,12 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         Returns:
             AGraph corresponding to the given automaton.
         """
+
+        if not _visual_imports:
+            raise ImportError(
+                "Missing visualization packages; "
+                "please install coloraide and pygraphviz."
+            )
 
         # Defining the graph.
         graph = create_graph(

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import abc
 import os
-import random
-import uuid
 from collections import defaultdict
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 from automata.base.automaton import Automaton, AutomatonStateT
-from automata.base.utils import LayoutMethod, create_graph, save_graph
+from automata.base.utils import (
+    LayoutMethod,
+    create_graph,
+    create_unique_random_id,
+    save_graph,
+)
 
 # Optional imports for use with visual functionality
 try:
@@ -78,13 +81,9 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         font_size_str = str(font_size)
         arrow_size_str = str(arrow_size)
 
-        # we use a random uuid to make sure that the null node has a
-        # unique id to avoid colliding with other states.
-        # To be able to set the random seed, took code from:
-        # https://nathanielknight.ca/articles/consistent_random_uuids_in_python.html
-        null_node = str(
-            uuid.UUID(bytes=bytes(random.getrandbits(8) for _ in range(16)), version=4)
-        )
+        # create unique id to avoid colliding with other states
+        null_node = create_unique_random_id()
+
         graph.add_node(
             null_node,
             label="",
@@ -159,7 +158,7 @@ class FA(Automaton, metaclass=abc.ABCMeta):
 
         # Write diagram to file
         if path is not None:
-            graph = save_graph(graph, path)
+            save_graph(graph, path)
 
         return graph
 

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -44,6 +44,10 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         of the form (from_state, to_state, symbol)
         """
 
+        raise NotImplementedError(
+            f"iter_transitions is not implemented for {self.__class__}"
+        )
+
     def show_diagram(
         self,
         input_str: Optional[str] = None,

--- a/automata/fa/fa.py
+++ b/automata/fa/fa.py
@@ -4,57 +4,29 @@ from __future__ import annotations
 
 import abc
 import os
-import pathlib
 import random
 import uuid
 from collections import defaultdict
-from typing import Any, Dict, Generator, List, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 from automata.base.automaton import Automaton, AutomatonStateT
+from automata.base.utils import LayoutMethod, create_graph, save_graph
 
 # Optional imports for use with visual functionality
 try:
     import coloraide
     import pygraphviz as pgv
 except ImportError:
-    _visual_imports = False
-else:
-    _visual_imports = True
+    pass
 
 
 FAStateT = AutomatonStateT
-LayoutMethod = Literal["neato", "dot", "twopi", "circo", "fdp", "nop"]
 
 
 class FA(Automaton, metaclass=abc.ABCMeta):
     """An abstract base class for finite automata."""
 
     __slots__ = tuple()
-
-    @staticmethod
-    def _get_state_name(state_data: FAStateT) -> str:
-        """
-        Get an string representation of a state. This is used for displaying and
-        uses `str` for any unsupported python data types.
-        """
-        if isinstance(state_data, str):
-            if state_data == "":
-                return "λ"
-
-            return state_data
-
-        elif isinstance(state_data, (frozenset, tuple)):
-            inner = ", ".join(FA._get_state_name(sub_data) for sub_data in state_data)
-            if isinstance(state_data, frozenset):
-                if state_data:
-                    return "{" + inner + "}"
-                else:
-                    return "∅"
-
-            elif isinstance(state_data, tuple):
-                return "(" + inner + ")"
-
-        return str(state_data)
 
     @staticmethod
     def _get_edge_name(symbol: str) -> str:
@@ -83,7 +55,7 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         """
         Generates the graph associated with the given DFA.
         Args:
-            input_str (str, optional): String list of input symbols. Defaults to None.
+            - input_str (str, optional): String list of input symbols. Defaults to None.
             - path (str or os.PathLike, optional): Path to output file. If
               None, the output will not be saved.
             - horizontal (bool, optional): Direction of node layout. Defaults
@@ -98,28 +70,13 @@ class FA(Automaton, metaclass=abc.ABCMeta):
             AGraph corresponding to the given automaton.
         """
 
-        if not _visual_imports:
-            raise ImportError(
-                "Missing visualization packages; "
-                "please install coloraide and pygraphviz."
-            )
-
         # Defining the graph.
-        graph = pgv.AGraph(strict=False, directed=True)
+        graph = create_graph(
+            horizontal, reverse_orientation, fig_size, state_separation
+        )
 
-        if fig_size is not None:
-            graph.graph_attr.update(size=", ".join(map(str, fig_size)))
-
-        graph.graph_attr.update(ranksep=str(state_separation))
         font_size_str = str(font_size)
         arrow_size_str = str(arrow_size)
-
-        if horizontal:
-            rankdir = "RL" if reverse_orientation else "LR"
-        else:
-            rankdir = "BT" if reverse_orientation else "TB"
-
-        graph.graph_attr.update(rankdir=rankdir)
 
         # we use a random uuid to make sure that the null node has a
         # unique id to avoid colliding with other states.
@@ -200,18 +157,9 @@ class FA(Automaton, metaclass=abc.ABCMeta):
         # Set layout
         graph.layout(prog=layout_method)
 
-        # Write diagram to file. PNG, SVG, etc.
+        # Write diagram to file
         if path is not None:
-            save_path_final: pathlib.Path = pathlib.Path(path)
-
-            format = (
-                save_path_final.suffix.split(".")[1] if save_path_final.suffix else None
-            )
-
-            graph.draw(
-                path=save_path_final,
-                format=format,
-            )
+            graph = save_graph(graph, path)
 
         return graph
 

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -34,10 +34,8 @@ class PDAConfiguration:
         if not isinstance(other, PDAConfiguration):
             return NotImplemented
 
-        if (
+        return (
             self.state == other.state
             and self.remaining_input == other.remaining_input
             and self.stack == other.stack
-        ):
-            return True
-        return False
+        )

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -2,6 +2,7 @@
 """Classes and methods for working with PDA configurations."""
 
 from dataclasses import dataclass
+from typing import Any
 
 from automata.base.automaton import AutomatonStateT
 from automata.pda.stack import PDAStack
@@ -27,3 +28,16 @@ class PDAConfiguration:
         return "{}({!r}, {!r}, {!r})".format(
             self.__class__.__name__, self.state, self.remaining_input, self.stack
         )
+
+    def __eq__(self, other: Any) -> bool:
+        """Return True if two PDAConfiguration are equivalent"""
+        if not isinstance(other, PDAConfiguration):
+            raise NotImplemented
+
+        if (
+            self.state == other.state
+            and self.remaining_input == other.remaining_input
+            and self.stack == other.stack
+        ):
+            return True
+        return False

--- a/automata/pda/configuration.py
+++ b/automata/pda/configuration.py
@@ -32,7 +32,7 @@ class PDAConfiguration:
     def __eq__(self, other: Any) -> bool:
         """Return True if two PDAConfiguration are equivalent"""
         if not isinstance(other, PDAConfiguration):
-            raise NotImplemented
+            return NotImplemented
 
         if (
             self.state == other.state

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Classes and methods for working with deterministic pushdown automata."""
 
-from typing import AbstractSet, Generator, Mapping, Optional, Set, Tuple, Union
+from typing import AbstractSet, Generator, List, Mapping, Optional, Set, Tuple, Union
 
 import automata.base.exceptions as exceptions
 import automata.pda.exceptions as pda_exceptions
 import automata.pda.pda as pda
+from automata.base.utils import pairwise
 from automata.pda.configuration import PDAConfiguration
 from automata.pda.stack import PDAStack
 
@@ -160,6 +161,31 @@ class DPDA(pda.PDA):
             self._replace_stack_top(old_config.stack, new_stack_top),
         )
         return new_config
+
+    def _get_input_path(
+        self, input_str: str
+    ) -> Tuple[List[Tuple[PDAConfiguration, PDAConfiguration]], bool]:
+        """
+        Calculate the path taken by input.
+
+        Args:
+            input_str (str): The input string to run on the DPDA.
+
+        Returns:
+            tuple[list[tuple[PDAConfiguration, PDAConfiguration], bool]]: A list
+            of all transitions taken in each step and a boolean indicating
+            whether the DPDA accepted the input.
+
+        """
+
+        state_history = list(self.read_input_stepwise(input_str))
+
+        path = list(pairwise(state_history))
+
+        last_state = state_history[-1] if state_history else self.initial_state
+        accepted = last_state in self.final_states
+
+        return path, accepted
 
     def read_input_stepwise(
         self, input_str: str

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -53,6 +53,16 @@ class DPDA(pda.PDA):
             acceptance_mode=acceptance_mode,
         )
 
+    def iter_transitions(
+        self,
+    ) -> Generator[Tuple[DPDAStateT, DPDAStateT, Tuple[str, str, str]], None, None]:
+        return (
+            (from_, to_, (input_symbol, stack_symbol, "".join(stack_push)))
+            for from_, input_lookup in self.transitions.items()
+            for input_symbol, stack_lookup in input_lookup.items()
+            for stack_symbol, (to_, stack_push) in stack_lookup.items()
+        )
+
     def _validate_transition_invalid_symbols(
         self, start_state: DPDAStateT, paths: DPDATransitionsT
     ) -> None:

--- a/automata/pda/dpda.py
+++ b/automata/pda/dpda.py
@@ -172,7 +172,7 @@ class DPDA(pda.PDA):
             input_str (str): The input string to run on the DPDA.
 
         Returns:
-            tuple[list[tuple[PDAConfiguration, PDAConfiguration], bool]]: A list
+            Tuple[List[Tuple[PDAConfiguration, PDAConfiguration]], bool]: A list
             of all transitions taken in each step and a boolean indicating
             whether the DPDA accepted the input.
 

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -153,13 +153,9 @@ class NPDA(pda.PDA):
                 continue
 
             for curr_step in step:
-                for next_step in self._get_next_configurations(curr_step):
-                    if next_step == path[-1]:
-                        path.append(curr_step)
-                        break
-                else:
-                    continue
-                break
+                if path[-1] in self._get_next_configurations(curr_step):
+                    path.append(curr_step)
+                    break
 
         return list(pairwise(reversed(path))), accepted
 

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -147,12 +147,12 @@ class NPDA(pda.PDA):
 
         accepted = path[0] in self.final_states
 
-        for i in range(len(steps) - 1, -1, -1):
-            if len(steps[i]) == 1:
-                path.append(steps[i].pop())
+        for i in reversed(steps):
+            if len(i) == 1:
+                path.append(i.pop())
                 continue
 
-            for curr_step in steps[i]:
+            for curr_step in i:
                 for next_step in self._get_next_configurations(curr_step):
                     if next_step == path[-1]:
                         path.append(curr_step)

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -147,12 +147,12 @@ class NPDA(pda.PDA):
 
         accepted = path[0] in self.final_states
 
-        for i in reversed(steps):
-            if len(i) == 1:
-                path.append(i.pop())
+        for step in reversed(steps):
+            if len(step) == 1:
+                path.append(step.pop())
                 continue
 
-            for curr_step in i:
+            for curr_step in step:
                 for next_step in self._get_next_configurations(curr_step):
                     if next_step == path[-1]:
                         path.append(curr_step)

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Classes and methods for working with nondeterministic pushdown automata."""
 
-from collections import deque
-from typing import AbstractSet, Deque, Generator, List, Mapping, Set, Tuple, Union
+from typing import AbstractSet, Generator, List, Mapping, Set, Tuple, Union
 
 import automata.base.exceptions as exceptions
 import automata.pda.pda as pda

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -135,7 +135,7 @@ class NPDA(pda.PDA):
             input_str (str): The input string to run on the NPDA.
 
         Returns:
-            tuple[list[tuple[PDAConfiguration, PDAConfiguration], bool]]: A list
+            Tuple[List[Tuple[PDAConfiguration, PDAConfiguration]], bool]: A list
             of all transitions taken in each step and a boolean indicating
             whether the NPDA accepted the input.
 

--- a/automata/pda/npda.py
+++ b/automata/pda/npda.py
@@ -55,6 +55,17 @@ class NPDA(pda.PDA):
             acceptance_mode=acceptance_mode,
         )
 
+    def iter_transitions(
+        self,
+    ) -> Generator[Tuple[NPDAStateT, NPDAStateT, Tuple[str, str, str]], None, None]:
+        return (
+            (from_, to_, (input_symbol, stack_symbol, "".join(stack_push)))
+            for from_, input_lookup in self.transitions.items()
+            for input_symbol, stack_lookup in input_lookup.items()
+            for stack_symbol, op_ in stack_lookup.items()
+            for (to_, stack_push) in op_
+        )
+
     def _validate_transition_invalid_symbols(
         self, start_state: NPDAStateT, paths: NPDATransitionsT
     ) -> None:

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -33,7 +33,9 @@ try:
     import coloraide
     import pygraphviz as pgv
 except ImportError:
-    pass
+    _visual_imports = False
+else:
+    _visual_imports = True
 
 PDAStateT = AutomatonStateT
 PDATransitionsT = AutomatonTransitionsT
@@ -133,6 +135,12 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
         Returns:
             AGraph corresponding to the given automaton.
         """
+
+        if not _visual_imports:
+            raise ImportError(
+                "Missing visualization packages; "
+                "please install coloraide and pygraphviz."
+            )
 
         # Defining the graph.
         graph = create_graph(

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -137,7 +137,7 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
 
         is_edge_drawn: EdgeDrawnDictT = defaultdict(lambda: False)
         if input_str is not None:
-            input_path, is_accepted = self._get_input_path(input_str=input_str)
+            input_path, is_accepted = self._get_input_path(input_str)
 
             start_color = coloraide.Color("#ff0")
             end_color = (

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Classes and methods for working with all pushdown automata."""
+from __future__ import annotations
 
 import abc
 import os
@@ -167,11 +168,11 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
 
             if with_machine:
                 # initialize diagram with all states
-                graph = self._add_states_diagram(graph, arrow_size_str, font_size_str)
+                self._add_states_diagram(graph, arrow_size_str, font_size_str)
 
                 # add required transitions to show execution of the
                 # PDA for the given input string
-                graph = self._create_transitions_for_input_diagram(
+                self._create_transitions_for_input_diagram(
                     graph,
                     input_path,
                     is_edge_drawn,
@@ -182,13 +183,13 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
                 )
 
                 # add all the necessary transitions between states
-                graph = self._add_transitions_diagram(
+                self._add_transitions_diagram(
                     graph, is_edge_drawn, arrow_size_str, font_size_str
                 )
 
             if with_stack:
                 # add the stack transitions
-                graph = self._create_stack_diagram(
+                self._create_stack_diagram(
                     input_path,
                     graph,
                     start_color,
@@ -198,10 +199,10 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
                 )
         else:
             # initialize diagram with all states
-            graph = self._add_states_diagram(graph, arrow_size_str, font_size_str)
+            self._add_states_diagram(graph, arrow_size_str, font_size_str)
 
             # add all the necessary transitions between states
-            graph = self._add_transitions_diagram(
+            self._add_transitions_diagram(
                 graph, is_edge_drawn, arrow_size_str, font_size_str
             )
 
@@ -222,7 +223,7 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
         end_color: coloraide.Color,
         font_size: str,
         arrow_size: str,
-    ) -> pgv.AGraph:
+    ) -> None:
         """
         Constructs stack for all the transitions in the `input_path` and
         adds the constructed stacks into `graph`. Returns the same `graph`
@@ -275,7 +276,7 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
         end_color: coloraide.Color,
         arrow_size: str,
         font_size: str,
-    ) -> pgv.AGraph:
+    ) -> None:
         """
         Add transitions to show execution of the PDA for the given input string
         """
@@ -302,15 +303,13 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
                 penwidth="2.5",
             )
 
-        return graph
-
     def _add_transitions_diagram(
         self,
         graph: pgv.AGraph,
         is_edge_drawn: EdgeDrawnDictT,
         arrow_size: str,
         font_size: str,
-    ) -> pgv.AGraph:
+    ) -> None:
         """
         Add transitions to between states
         """
@@ -334,14 +333,12 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
                 fontsize=font_size,
             )
 
-        return graph
-
     def _add_states_diagram(
         self,
         graph: pgv.AGraph,
         arrow_size: str,
         font_size: str,
-    ) -> pgv.AGraph:
+    ) -> None:
         """
         Add all the states of the PDA
         """
@@ -368,8 +365,6 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
         final_states = map(self._get_state_name, self.final_states)
         graph.add_nodes_from(nonfinal_states, shape="circle", fontsize=font_size)
         graph.add_nodes_from(final_states, shape="doublecircle", fontsize=font_size)
-
-        return graph
 
     def _validate_transition_invalid_input_symbols(
         self, start_state: PDAStateT, input_symbol: str

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -103,8 +103,9 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
         self,
     ) -> Generator[Tuple[PDAStateT, PDAStateT, Tuple[str, str, str]], None, None]:
         """
-        Iterate over all transitions in the automaton. Each transition is a tuple
-        of the form (from_state, to_state, (input_symbol, stack_top_symbol, stack_push_symbols))
+        Iterate over all transitions in the automaton.
+        Each transition is a tuple of the form
+        (from_state, to_state, (input_symbol, stack_top_symbol, stack_push_symbols))
         """
 
     def show_diagram(
@@ -207,12 +208,13 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
                 color = interpolation(transition_index / len(input_path))
 
                 symbol = self._get_symbol_configuration(from_state, to_state)
+                label = self._get_edge_name(*symbol)
 
                 is_edge_drawn[from_state.state, to_state.state, symbol] = True
                 graph.add_edge(
                     self._get_state_name(from_state.state),
                     self._get_state_name(to_state.state),
-                    label=f"<{self._get_edge_name(*symbol)} <b>[<i>#{transition_index}</i>]</b>>",
+                    label=f"<{label} <b>[<i>#{transition_index}</i>]</b>>",
                     arrowsize=arrow_size_str,
                     fontsize=font_size_str,
                     color=color.to_string(hex=True),

--- a/automata/pda/pda.py
+++ b/automata/pda/pda.py
@@ -2,7 +2,12 @@
 """Classes and methods for working with all pushdown automata."""
 
 import abc
-from typing import AbstractSet, Literal
+import os
+import pathlib
+import random
+import uuid
+from collections import defaultdict
+from typing import AbstractSet, Generator, Literal, Optional, Tuple, Union
 
 import automata.base.exceptions as exceptions
 import automata.pda.exceptions as pda_exceptions
@@ -10,9 +15,20 @@ from automata.base.automaton import Automaton, AutomatonStateT, AutomatonTransit
 from automata.pda.configuration import PDAConfiguration
 from automata.pda.stack import PDAStack
 
+# Optional imports for use with visual functionality
+try:
+    import coloraide
+    import pygraphviz as pgv
+except ImportError:
+    _visual_imports = False
+else:
+    _visual_imports = True
+
 PDAStateT = AutomatonStateT
 PDATransitionsT = AutomatonTransitionsT
 PDAAcceptanceModeT = Literal["final_state", "empty_stack", "both"]
+
+LayoutMethod = Literal["neato", "dot", "twopi", "circo", "fdp", "nop"]
 
 
 class PDA(Automaton, metaclass=abc.ABCMeta):
@@ -23,6 +39,171 @@ class PDA(Automaton, metaclass=abc.ABCMeta):
     stack_symbols: AbstractSet[str]
     initial_stack_symbol: str
     acceptance_mode: PDAAcceptanceModeT
+
+    @staticmethod
+    def _get_state_name(state_data: PDAStateT) -> str:
+        """
+        Get an string representation of a state. This is used for displaying and
+        uses `str` for any unsupported python data types.
+        """
+        if isinstance(state_data, str):
+            if state_data == "":
+                return "λ"
+
+            return state_data
+
+        elif isinstance(state_data, (frozenset, tuple)):
+            inner = ", ".join(PDA._get_state_name(sub_data) for sub_data in state_data)
+            if isinstance(state_data, frozenset):
+                if state_data:
+                    return "{" + inner + "}"
+                else:
+                    return "∅"
+
+            elif isinstance(state_data, tuple):
+                return "(" + inner + ")"
+
+        return str(state_data)
+
+    @staticmethod
+    def _get_edge_name(
+        input_symbol: str = "", stack_top_symbol: str = "", stack_push: str = ""
+    ) -> str:
+        return (
+            ("ε" if input_symbol == "" else str(input_symbol))
+            + ", "
+            + ("ε" if stack_top_symbol == "" else str(stack_top_symbol))
+            + " | "
+            + ("ε" if stack_push == "" else str(stack_push))
+        )
+
+    @abc.abstractmethod
+    def iter_transitions(
+        self,
+    ) -> Generator[Tuple[PDAStateT, PDAStateT, Tuple[str, str, str]], None, None]:
+        """
+        Iterate over all transitions in the automaton. Each transition is a tuple
+        of the form (from_state, to_state, (input_symbol, stack_top_symbol, stack_push_symbols))
+        """
+
+    def show_diagram(
+        self,
+        path: Union[str, os.PathLike, None] = None,
+        *,
+        layout_method: LayoutMethod = "dot",
+        horizontal: bool = True,
+        reverse_orientation: bool = False,
+        fig_size: Union[Tuple[float, float], Tuple[float], None] = None,
+        font_size: float = 14.0,
+        arrow_size: float = 0.85,
+        state_separation: float = 0.5,
+    ) -> pgv.AGraph:
+        """
+        Generates the graph associated with the given PDA.
+        Args:
+            input_str (str, optional): String list of input symbols. Defaults to None.
+            - path (str or os.PathLike, optional): Path to output file. If
+              None, the output will not be saved.
+            - horizontal (bool, optional): Direction of node layout. Defaults
+              to True.
+            - reverse_orientation (bool, optional): Reverse direction of node
+              layout. Defaults to False.
+            - fig_size (tuple, optional): Figure size. Defaults to None.
+            - font_size (float, optional): Font size. Defaults to 14.0.
+            - arrow_size (float, optional): Arrow head size. Defaults to 0.85.
+            - state_separation (float, optional): Node distance. Defaults to 0.5.
+        Returns:
+            AGraph corresponding to the given automaton.
+        """
+
+        if not _visual_imports:
+            raise ImportError(
+                "Missing visualization packages; "
+                "please install coloraide and pygraphviz."
+            )
+
+        # Defining the graph.
+        graph = pgv.AGraph(strict=False, directed=True)
+
+        if fig_size is not None:
+            graph.graph_attr.update(size=", ".join(map(str, fig_size)))
+
+        graph.graph_attr.update(ranksep=str(state_separation))
+        font_size_str = str(font_size)
+        arrow_size_str = str(arrow_size)
+
+        if horizontal:
+            rankdir = "RL" if reverse_orientation else "LR"
+        else:
+            rankdir = "BT" if reverse_orientation else "TB"
+
+        graph.graph_attr.update(rankdir=rankdir)
+
+        # we use a random uuid to make sure that the null node has a
+        # unique id to avoid colliding with other states.
+        # To be able to set the random seed, took code from:
+        # https://nathanielknight.ca/articles/consistent_random_uuids_in_python.html
+        null_node = str(
+            uuid.UUID(bytes=bytes(random.getrandbits(8) for _ in range(16)), version=4)
+        )
+        graph.add_node(
+            null_node,
+            label="",
+            tooltip=".",
+            shape="point",
+            fontsize=font_size_str,
+        )
+        initial_node = self._get_state_name(self.initial_state)
+        graph.add_edge(
+            null_node,
+            initial_node,
+            tooltip="->" + initial_node,
+            arrowsize=arrow_size_str,
+        )
+
+        nonfinal_states = map(self._get_state_name, self.states - self.final_states)
+        final_states = map(self._get_state_name, self.final_states)
+        graph.add_nodes_from(nonfinal_states, shape="circle", fontsize=font_size_str)
+        graph.add_nodes_from(final_states, shape="doublecircle", fontsize=font_size_str)
+
+        is_edge_drawn = defaultdict(lambda: False)
+
+        edge_labels = defaultdict(list)
+        for from_state, to_state, symbol in self.iter_transitions():
+            if is_edge_drawn[from_state, to_state, symbol]:
+                continue
+
+            from_node = self._get_state_name(from_state)
+            to_node = self._get_state_name(to_state)
+            label = self._get_edge_name(*symbol)
+            edge_labels[from_node, to_node].append(label)
+
+        for (from_node, to_node), labels in edge_labels.items():
+            graph.add_edge(
+                from_node,
+                to_node,
+                label="\n".join(sorted(labels)),
+                arrowsize=arrow_size_str,
+                fontsize=font_size_str,
+            )
+
+        # Set layout
+        graph.layout(prog=layout_method)
+
+        # Write diagram to file. PNG, SVG, etc.
+        if path is not None:
+            save_path_final: pathlib.Path = pathlib.Path(path)
+
+            format = (
+                save_path_final.suffix.split(".")[1] if save_path_final.suffix else None
+            )
+
+            graph.draw(
+                path=save_path_final,
+                format=format,
+            )
+
+        return graph
 
     def _validate_transition_invalid_input_symbols(
         self, start_state: PDAStateT, input_symbol: str

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterator, Sequence, Tuple
+from typing import Any, Iterator, Sequence, Tuple
 
 
 @dataclass(frozen=True)
@@ -49,10 +49,17 @@ class PDAStack:
         """Return an interator for the stack."""
         return iter(self.stack)
 
-    def __getitem__(self, key: int) -> str:
+    def __getitem__(self, key: int | slice) -> str | Sequence[str]:
         """Return the stack element at the given index"""
         return self.stack[key]
 
     def __repr__(self) -> str:
         """Return a string representation of the stack."""
         return "{}({})".format(self.__class__.__name__, self.stack)
+
+    def __eq__(self, other: Any) -> bool:
+        """Return True if two PDAConfiguration are equivalent"""
+        if not isinstance(other, PDAStack):
+            return NotImplemented
+
+        return self.stack == other.stack

--- a/automata/pda/stack.py
+++ b/automata/pda/stack.py
@@ -46,12 +46,16 @@ class PDAStack:
         return len(self.stack)
 
     def __iter__(self) -> Iterator[str]:
-        """Return an interator for the stack."""
+        """Return an iterator for the stack."""
         return iter(self.stack)
 
     def __getitem__(self, key: int | slice) -> str | Sequence[str]:
         """Return the stack element at the given index"""
         return self.stack[key]
+
+    def __reversed__(self) -> Iterator[str]:
+        """Return an iterator for the stack in reversed order"""
+        return reversed(self.stack)
 
     def __repr__(self) -> str:
         """Return a string representation of the stack."""

--- a/docs/base-exception-classes.md
+++ b/docs/base-exception-classes.md
@@ -78,6 +78,9 @@ language is empty.
 Raised if the attempted operation cannot be performed because the associated
 language is infinite.
 
+## class DiagramException(AutomatonException)
+Raised if a diagram cannot be produced for an automaton.
+
 ------
 
 [Table of Contents](README.md)

--- a/docs/pda/class-pda.md
+++ b/docs/pda/class-pda.md
@@ -7,10 +7,12 @@ inherit. It can be found under `automata/pda/pda.py`.
 
 The `PDA` class has the following abstract methods:
 
-## PDA.show_diagram(self, input_str = None, path = None):
+## PDA.show_diagram(self, input_str = None, with_machine = True, with_stack = True, path = None):
 
 Constructs and returns a pygraphviz `AGraph` corresponding to this PDA. If `input_str` is
-set, then shows execution of the PDA on `input_str`. If `path` is
+set, then shows execution of the PDA on `input_str`. `with_machine` and `with_stack`
+flags can be used to construct the state machine and transitions only or the stack and
+its operations only. They are ignored if `input_str` is None. If `path` is
 set, then an image of the diagram is written to the corresponding file. Other
 customization options are available, see function signature for more
 details.

--- a/docs/pda/class-pda.md
+++ b/docs/pda/class-pda.md
@@ -9,7 +9,7 @@ The `PDA` class has the following abstract methods:
 
 ## PDA.show_diagram(self, input_str = None, path = None):
 
-Constructs and returns a pygraphviz `AGraph` corresponding to this PAD. If `input_str` is
+Constructs and returns a pygraphviz `AGraph` corresponding to this PDA. If `input_str` is
 set, then shows execution of the PDA on `input_str`. If `path` is
 set, then an image of the diagram is written to the corresponding file. Other
 customization options are available, see function signature for more

--- a/docs/pda/class-pda.md
+++ b/docs/pda/class-pda.md
@@ -5,6 +5,20 @@
 The `PDA` class is an abstract base class from which all pushdown automata
 inherit. It can be found under `automata/pda/pda.py`.
 
+The `PDA` class has the following abstract methods:
+
+## PDA.show_diagram(self, input_str = None, path = None):
+
+Constructs and returns a pygraphviz `AGraph` corresponding to this PAD. If `input_str` is
+set, then shows execution of the PDA on `input_str`. If `path` is
+set, then an image of the diagram is written to the corresponding file. Other
+customization options are available, see function signature for more
+details.
+
+```python
+pda.show_diagram(path='./pda.png')
+```
+
 ## Subclasses
 
 ### [DPDA (Deterministic Pushdown Automaton)](class-dpda.md)

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of DPDAs."""
 
+import os
+
 from frozendict import frozendict
 
 import automata.base.exceptions as exceptions
@@ -319,3 +321,121 @@ class TestDPDA(test_pda.TestPDA):
             acceptance_mode="both",
         )
         self.assertTrue(dpda.accepts_input(""))
+
+    def test_show_diagram(self) -> None:
+        """Should construct the diagram for a DPDA"""
+        graph = self.dpda.show_diagram()
+        node_names = {node.get_name() for node in graph.nodes()}
+        self.assertTrue(set(self.dpda.states).issubset(node_names))
+        self.assertEqual(len(self.dpda.states) + 1, len(node_names))
+
+        for state in self.dpda.states:
+            node = graph.get_node(state)
+            expected_shape = (
+                "doublecircle" if state in self.dpda.final_states else "circle"
+            )
+            self.assertEqual(node.attr["shape"], expected_shape)
+
+        expected_transitions = {
+            ("q0", "a, 0 | 10", "q1"),
+            ("q1", "a, 1 | 11", "q1"),
+            ("q1", "b, 1 | ε", "q2"),
+            ("q2", "b, 1 | ε", "q2"),
+            ("q2", "ε, 0 | 0", "q3"),
+        }
+        seen_transitions = {
+            (edge[0], edge.attr["label"], edge[1]) for edge in graph.edges()
+        }
+        self.assertTrue(expected_transitions.issubset(seen_transitions))
+        self.assertEqual(len(expected_transitions) + 1, len(seen_transitions))
+
+        source, symbol, dest = list(seen_transitions - expected_transitions)[0]
+        self.assertEqual(symbol, "")
+        self.assertEqual(dest, self.dpda.initial_state)
+        self.assertTrue(source not in self.dpda.states)
+
+    def test_show_diagram_read_input_machine_only(self) -> None:
+        """
+        Should construct the diagram with machine only for a DPDA reading input.
+        """
+        input_strings = ["ab", "aabb", "aaabbb"]
+
+        for input_string in input_strings:
+            graph = self.dpda.show_diagram(input_str=input_string, with_stack=False)
+
+            # Get edges corresponding to input path
+            colored_edges = [
+                edge for edge in graph.edges() if "color" in dict(edge.attr)
+            ]
+
+            edge_pairs = [
+                (edge[0].state, edge[1].state)
+                for edge in self.dpda._get_input_path(input_string)[0]
+            ]
+            self.assertEqual(edge_pairs, colored_edges)
+
+    def test_show_diagram_read_input_stack_only(self) -> None:
+        """
+        Should construct the diagram with stack only for a DPDA reading input.
+        """
+        input_strings = ["ab", "aabb", "aaabbb"]
+
+        for input_string in input_strings:
+            graph = self.dpda.show_diagram(input_str=input_string, with_machine=False)
+
+            # Get edges corresponding to input path
+            colored_edges = [
+                edge for edge in graph.edges() if "color" in dict(edge.attr)
+            ]
+
+            edge_pairs = [
+                (str(edge[0]), str(edge[1]))
+                for edge in self.dpda._get_input_path(input_string)[0]
+            ]
+
+            # Get stack content corresponding to input path
+            nodes = [node.attr["label"] for node in graph.nodes()]
+
+            stack_content = [
+                " | " + " | ".join(reversed(edge.stack))
+                for edge in list(self.dpda.read_input_stepwise(input_string))
+            ]
+
+            self.assertEqual(nodes, stack_content)
+            self.assertEqual(edge_pairs, colored_edges)
+
+    def test_show_diagram_write_file(self) -> None:
+        """
+        Should construct the diagram for a DPDA
+        and write it to the specified file.
+        """
+        diagram_path = os.path.join(self.temp_dir_path, "test_dpda.png")
+        try:
+            os.remove(diagram_path)
+        except OSError:
+            pass
+        self.assertFalse(os.path.exists(diagram_path))
+        self.dpda.show_diagram(path=diagram_path)
+        self.assertTrue(os.path.exists(diagram_path))
+        os.remove(diagram_path)
+
+    def test_show_diagram_orientations(self) -> None:
+        graph = self.dpda.show_diagram()
+        self.assertEqual(graph.graph_attr["rankdir"], "LR")
+        graph = self.dpda.show_diagram(horizontal=False)
+        self.assertEqual(graph.graph_attr["rankdir"], "TB")
+        graph = self.dpda.show_diagram(reverse_orientation=True)
+        self.assertEqual(graph.graph_attr["rankdir"], "RL")
+        graph = self.dpda.show_diagram(horizontal=False, reverse_orientation=True)
+        self.assertEqual(graph.graph_attr["rankdir"], "BT")
+
+    def test_show_diagram_fig_size(self) -> None:
+        """
+        Testing figure size. Just need to make sure it matches the input
+        (the library handles the rendering).
+        """
+        graph = self.dpda.show_diagram(fig_size=(1.1, 2))
+        self.assertEqual(graph.graph_attr["size"], "1.1, 2")
+
+        graph = self.dpda.show_diagram(fig_size=(3.3,))
+        self.assertEqual(graph.graph_attr["size"], "3.3")

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -354,6 +354,17 @@ class TestDPDA(test_pda.TestPDA):
         self.assertEqual(dest, self.dpda.initial_state)
         self.assertTrue(source not in self.dpda.states)
 
+    def test_show_diagram_exception(self) -> None:
+        """Should raise exception"""
+
+        self.assertRaises(
+            exceptions.DiagramException,
+            self.dpda.show_diagram,
+            "ab",
+            with_machine=False,
+            with_stack=False,
+        )
+
     def test_show_diagram_read_input_machine_only(self) -> None:
         """
         Should construct the diagram with machine only for a DPDA reading input.

--- a/tests/test_fa.py
+++ b/tests/test_fa.py
@@ -63,6 +63,14 @@ class TestFAAbstract(unittest.TestCase):
     def test_abstract_methods_not_implemented(self) -> None:
         """Should raise NotImplementedError when calling abstract methods."""
 
+        abstract_methods = {
+            "iter_transitions": (FA,),
+            "_get_input_path": (FA, ""),
+        }
+        for method_name, method_args in abstract_methods.items():
+            with self.assertRaises(NotImplementedError):
+                getattr(FA, method_name)(*method_args)
+
         with self.assertRaises(NotImplementedError):
             getattr(FA, "_get_input_path")(FA, "")
 

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -443,10 +443,16 @@ class TestNPDA(test_pda.TestPDA):
                 "q2",
             ),
         }
+
         seen_transitions = {
-            (edge[0], frozenset(edge.attr["label"].split("\n")), edge[1])
+            (
+                edge[0],
+                frozenset(map(str.strip, edge.attr["label"].split("\n"))),
+                edge[1],
+            )
             for edge in graph.edges()
         }
+
         self.assertTrue(expected_transitions.issubset(seen_transitions))
         self.assertEqual(len(expected_transitions) + 1, len(seen_transitions))
 

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of NPDAs."""
 
+import os
+
 from frozendict import frozendict
 
 import automata.base.exceptions as exceptions
@@ -390,3 +392,149 @@ class TestNPDA(test_pda.TestPDA):
     def test_accepts_input_false(self) -> None:
         """Should return False if NPDA input is rejected."""
         self.assertFalse(self.npda.accepts_input("aaba"))
+
+    def test_show_diagram(self) -> None:
+        """Should construct the diagram for a NPDA"""
+        graph = self.npda.show_diagram()
+        node_names = {node.get_name() for node in graph.nodes()}
+        self.assertTrue(set(self.npda.states).issubset(node_names))
+        self.assertEqual(len(self.npda.states) + 1, len(node_names))
+
+        for state in self.npda.states:
+            node = graph.get_node(state)
+            expected_shape = (
+                "doublecircle" if state in self.npda.final_states else "circle"
+            )
+            self.assertEqual(node.attr["shape"], expected_shape)
+
+        expected_transitions = {
+            ("q0", frozenset({"a, A | ε", "b, B | ε"}), "q1"),
+            (
+                "q0",
+                frozenset(
+                    {
+                        "ε, # | #",
+                    }
+                ),
+                "q2",
+            ),
+            (
+                "q0",
+                frozenset(
+                    {
+                        "a, # | A#",
+                        "a, A | AA",
+                        "a, B | AB",
+                        "b, # | B#",
+                        "b, A | BA",
+                        "b, B | BB",
+                    }
+                ),
+                "q0",
+            ),
+            ("q1", frozenset({"a, A | ε", "b, B | ε"}), "q1"),
+            (
+                "q1",
+                frozenset(
+                    {
+                        "ε, # | #",
+                    }
+                ),
+                "q2",
+            ),
+        }
+        seen_transitions = {
+            (edge[0], frozenset(edge.attr["label"].split("\n")), edge[1])
+            for edge in graph.edges()
+        }
+        self.assertTrue(expected_transitions.issubset(seen_transitions))
+        self.assertEqual(len(expected_transitions) + 1, len(seen_transitions))
+
+        source, symbol, dest = list(seen_transitions - expected_transitions)[0]
+        self.assertEqual(symbol, frozenset({""}))
+        self.assertEqual(dest, self.npda.initial_state)
+        self.assertTrue(source not in self.npda.states)
+
+    def test_show_diagram_read_input_machine_only(self) -> None:
+        """
+        Should construct the diagram with machine only for a NPDA reading input.
+        """
+        input_strings = ["abba", "aabbaa", "aabaabaa", ""]
+
+        for input_string in input_strings:
+            graph = self.npda.show_diagram(input_str=input_string, with_stack=False)
+
+            # Get edges corresponding to input path
+            colored_edges = [
+                edge for edge in graph.edges() if "color" in dict(edge.attr)
+            ]
+
+            edge_pairs = [
+                (edge[0].state, edge[1].state)
+                for edge in self.npda._get_input_path(input_string)[0]
+            ]
+            self.assertEqual(edge_pairs, colored_edges)
+
+    def test_show_diagram_read_input_stack_only(self) -> None:
+        """
+        Should construct the diagram with stack only for a NPDA reading input.
+        """
+        input_strings = ["abba", "aabbaa", "aabaabaa", ""]
+
+        for input_string in input_strings:
+            graph = self.npda.show_diagram(input_str=input_string, with_machine=False)
+
+            # Get edges corresponding to input path
+            colored_edges = [
+                edge for edge in graph.edges() if "color" in dict(edge.attr)
+            ]
+
+            input_path = self.npda._get_input_path(input_string)[0]
+
+            edge_pairs = [(str(edge[0]), str(edge[1])) for edge in input_path]
+
+            # Get stack content corresponding to input path
+            nodes = [node.attr["label"] for node in graph.nodes()]
+
+            stack_content = [
+                " | " + " | ".join(reversed(edge[0].stack)) for edge in input_path
+            ] + [" | " + " | ".join(reversed(input_path[-1][1].stack))]
+
+            self.assertEqual(nodes, stack_content)
+            self.assertEqual(edge_pairs, colored_edges)
+
+    def test_show_diagram_write_file(self) -> None:
+        """
+        Should construct the diagram for a NPDA
+        and write it to the specified file.
+        """
+        diagram_path = os.path.join(self.temp_dir_path, "test_npda.png")
+        try:
+            os.remove(diagram_path)
+        except OSError:
+            pass
+        self.assertFalse(os.path.exists(diagram_path))
+        self.npda.show_diagram(path=diagram_path)
+        self.assertTrue(os.path.exists(diagram_path))
+        os.remove(diagram_path)
+
+    def test_show_diagram_orientations(self) -> None:
+        graph = self.npda.show_diagram()
+        self.assertEqual(graph.graph_attr["rankdir"], "LR")
+        graph = self.npda.show_diagram(horizontal=False)
+        self.assertEqual(graph.graph_attr["rankdir"], "TB")
+        graph = self.npda.show_diagram(reverse_orientation=True)
+        self.assertEqual(graph.graph_attr["rankdir"], "RL")
+        graph = self.npda.show_diagram(horizontal=False, reverse_orientation=True)
+        self.assertEqual(graph.graph_attr["rankdir"], "BT")
+
+    def test_show_diagram_fig_size(self) -> None:
+        """
+        Testing figure size. Just need to make sure it matches the input
+        (the library handles the rendering).
+        """
+        graph = self.npda.show_diagram(fig_size=(1.1, 2))
+        self.assertEqual(graph.graph_attr["size"], "1.1, 2")
+
+        graph = self.npda.show_diagram(fig_size=(3.3,))
+        self.assertEqual(graph.graph_attr["size"], "3.3")

--- a/tests/test_pda.py
+++ b/tests/test_pda.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Classes and functions for testing the behavior of PDAs."""
 
+import tempfile
 import unittest
 
 from automata.pda.dpda import DPDA
@@ -12,6 +13,8 @@ class TestPDA(unittest.TestCase):
 
     dpda: DPDA
     npda: NPDA
+
+    temp_dir_path = tempfile.gettempdir()
 
     def setUp(self) -> None:
         """Reset test automata before every test function."""

--- a/tests/test_pda.py
+++ b/tests/test_pda.py
@@ -6,6 +6,7 @@ import unittest
 
 from automata.pda.dpda import DPDA
 from automata.pda.npda import NPDA
+from automata.pda.pda import PDA
 
 
 class TestPDA(unittest.TestCase):
@@ -76,3 +77,15 @@ class TestPDA(unittest.TestCase):
             final_states={"q2"},
             acceptance_mode="final_state",
         )
+
+
+class TestPDAAbstract(unittest.TestCase):
+    def test_abstract_methods_not_implemented(self) -> None:
+        """Should raise NotImplementedError when calling abstract methods."""
+        abstract_methods = {
+            "iter_transitions": (PDA,),
+            "_get_input_path": (PDA, ""),
+        }
+        for method_name, method_args in abstract_methods.items():
+            with self.assertRaises(NotImplementedError):
+                getattr(PDA, method_name)(*method_args)

--- a/tests/test_pdaconfiguration.py
+++ b/tests/test_pdaconfiguration.py
@@ -22,3 +22,14 @@ class TestPDAConfiguration(test_pda.TestPDA):
             repr(config),
             "PDAConfiguration('q0', 'ab', PDAStack(('a', 'b')))",  # noqa
         )
+
+    def test_config_equality(self) -> None:
+        """Should only be equal for equal configurations."""
+        config = PDAConfiguration("q0", "ab", PDAStack(["a", "b"]))
+
+        self.assertEqual(config, config)
+        self.assertEqual(config, PDAConfiguration("q0", "ab", PDAStack(["a", "b"])))
+
+        self.assertNotEqual(config, "")
+        self.assertNotEqual(config, PDAConfiguration("q1", "ab", PDAStack(["a", "b"])))
+        self.assertNotEqual(config, PDAConfiguration("q0", "ab", PDAStack(["b", "b"])))

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -28,3 +28,13 @@ class TestPDAStack(test_pda.TestPDA):
     def test_stack_repr(self) -> None:
         """Should create proper string representation of PDA stack."""
         self.assertEqual(repr(self.stack), "PDAStack(('a', 'b'))")
+
+    def test_stack_equality(self) -> None:
+        """Should only be equal for equal configurations."""
+        stack = PDAStack(["a", "b"])
+
+        self.assertEqual(stack, stack)
+        self.assertEqual(stack, PDAStack(["a", "b"]))
+
+        self.assertNotEqual(stack, PDAStack(["a", "a"]))
+        self.assertNotEqual(stack, PDAStack(["b", "b"]))

--- a/tests/test_pdastack.py
+++ b/tests/test_pdastack.py
@@ -36,5 +36,6 @@ class TestPDAStack(test_pda.TestPDA):
         self.assertEqual(stack, stack)
         self.assertEqual(stack, PDAStack(["a", "b"]))
 
+        self.assertNotEqual(stack, "")
         self.assertNotEqual(stack, PDAStack(["a", "a"]))
         self.assertNotEqual(stack, PDAStack(["b", "b"]))


### PR DESCRIPTION
Implemented the `show_diagram` method for Push Down Automata.
I have just adapted the `FA.show_diagram` (Finite Automata) code for `PDA.show_diagram`.

I have not yet implemented `show_diagram` with `input_str`. I will require some suggestions here. Should I also show the operations performed on the stack, or only the state transitions are sufficient?

I have not tested the code, except for `DPDA` and `NPDA` in the docs. I have attached the images below.

DPDA:
![image](https://github.com/caleb531/automata/assets/55694469/f6a4a5ed-9b76-46f9-a507-f060641a5219)

NPDA:
![image](https://github.com/caleb531/automata/assets/55694469/4fd11709-de3f-41df-a5b1-e9ae540ba3b7)

Reminder for myself and the maintainer: I should also update the docs to reflect the new feature, before merging this PR.

Hope this is helpful. Please let me know if any changes are required.

---

Edited:

I have implemented the construction of the diagram with an `input_str`.

DPDA from docs with `input_str = "aabb"`:
![image](https://github.com/caleb531/automata/assets/55694469/b229746a-6ba5-480d-9852-077a0f77fedb)

NPDA from docs with `input_str = "abba"`:
![image](https://github.com/caleb531/automata/assets/55694469/cce6a1d8-5edd-466f-bc38-19e6837dd797)

I have updated the docs. I should now write down some test cases.