### PR TITLE
Fix bug: Replace * with *? in QuantifierToken regex pattern

### DIFF
--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -551,7 +551,7 @@ def get_regex_lexer(
     lexer.register_token(KleeneStarToken.from_match, r"\*")
     lexer.register_token(KleenePlusToken.from_match, r"\+")
     lexer.register_token(OptionToken.from_match, r"\?")
-    lexer.register_token(QuantifierToken.from_match, r"\{(.*),(.*)\}")
+    lexer.register_token(QuantifierToken.from_match, r"\{(.*?),(.*?)\}")
     lexer.register_token(
         lambda match: WildcardToken(match.group(), input_symbols, state_name_counter),
         r"\.",


### PR DESCRIPTION
Greedy matching for the QuantifierToken appears to cause issues for patterns with more than one quantifier.