### PR TITLE
Changed excludes in docs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,10 @@ plugins:
         python:
           options:
             show_source: false
+            docstring_style: "numpy"
+            filters:
+            - "!^_"
+            - "!^__"
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
Dummy PR for changing config file in the mkdocs branch. Docs now ignore methods that start with an underscore, as these are usually not part of the public interface.