### PR TITLE
Correct typo in allow_mutable_automata documentation

### DIFF
--- a/docs/class-automaton.md
+++ b/docs/class-automaton.md
@@ -57,7 +57,7 @@ initialization that turns mutable parameters (such as sets or dicts) into their
 immutable counterparts (frozensets/frozendicts).
 
 If your application requires maximum performance, you can disable this
-conversion via the `enable_mutable_automata` global configuration option. If
+conversion via the `allow_mutable_automata` global configuration option. If
 enabled, the user must ensure that their automaton instances are never modified,
 otherwise correct behavior cannot be guaranteed.
 


### PR DESCRIPTION
Changed 'enable_mutable_automata' global configuration to 'allow_mutable_automata' as mentioned in base/config.py