### PR TITLE
Add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+# Based on https://squidfunk.github.io/mkdocs-material/publishing-your-site/
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install -r requirements.docs.txt
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop # TODO remove once we have the first version of the docs up.
 permissions:
   contents: write
 jobs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "isort.args": [


### PR DESCRIPTION
One of the last PRs for #160! I think all that needs to be done is set the publish source branch for this page is `gh-pages` (per the instructions here: https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions).

I haven't played around with this too much, so I can't quite verify that it works. I think the way to handle it might be to have the workflow run on pushes to develop, then check that the github pages is working as expected. Then, we can remove that trigger once everything is set up. @caleb531 what are your thoughts? This might require some fiddling on your end.