### PR TITLE
Update copyright notice of docs index page

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2023 Caleb Evans
+Copyright (c) 2016-2024 Caleb Evans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automata
 
-*Copyright 2016-2023 Caleb Evans*  
+*Copyright 2016-2024 Caleb Evans*  
 *Released under the MIT license*
 
 [![PyPI version](https://badge.fury.io/py/automata-lib.svg)](https://badge.fury.io/py/automata-lib)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Automata
 
-*Copyright 2016-2023 Caleb Evans*  
+*Copyright 2016-2024 Caleb Evans*  
 *Released under the MIT license*
 
 [![tests](https://github.com/caleb531/automata/actions/workflows/tests.yml/badge.svg)](https://github.com/caleb531/automata/actions/workflows/tests.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Automata
 
-_Copyright 2016-2022 Caleb Evans_
-_Released under the MIT license_
+*Copyright 2016-2023 Caleb Evans*  
+*Released under the MIT license*
 
 [![tests](https://github.com/caleb531/automata/actions/workflows/tests.yml/badge.svg)](https://github.com/caleb531/automata/actions/workflows/tests.yml)
 [![Coverage Status](https://coveralls.io/repos/caleb531/automata/badge.svg?branch=main)](https://coveralls.io/r/caleb531/automata?branch=main)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,7 @@ extra:
 #   - stylesheets/extra.css
 # extra_javascript:
 #   - javascripts/extra.js
-copyright: Copyright &copy; 2016 - 2023 Caleb Evans
+copyright: Copyright &copy; 2016 - 2024 Caleb Evans
 nav:
   - Introduction:
       - index.md


### PR DESCRIPTION
@eliotwrobson Just something I noticed and wanted to correct. I didn't change anything else, since it makes sense to me to remove the irrelevant README badges for the documentation site. Same for the links to the other documentation pages, as the links would probably break / navigate to the incorrect files anyway (we want to keep the user in the documentation site, after all).

One other thing: does `automata-lib[visual]` really require quotes to install?

```sh
pip install 'automata-lib[visual]'
```

...versus just:

```sh
pip install automata-lib[visual]
```