### PR TITLE
Use official Flake8 VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "EditorConfig.EditorConfig",
     "ms-python.black-formatter",
     "matangover.mypy",
-    "kevinglasson.cornflakes-linter"
+    "ms-python.flake8"
   ]
 }


### PR DESCRIPTION
@eliotwrobson Just a small quality-of-life improvement, but with a small caveat, and so want your feedback.

This commit switches the third-party cornflakes-linter VS Code extension
to the official Flake8 extension by Microsoft. I'm hoping this should fix an issue I've encountered with the former extension where files
within the virtualenv or within Python stdlib were linted when they
should have been ignored. I haven't tested that the new extension fixes this, but given that it's first-party, I'm optimistic that it's less buggy.

The catch with this change is that anyone who has installed the official Flake8 extension should uninstall cornflakes-linter (or disable it for the workspace) lest they see duplicate errors in the Problems panel (or otherwise experience other unforeseen conflicts between the extensions).