### PR TITLE
Add Python 3.12 to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-
-    - name: Install Python 3
+    - name: Install Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.11"
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      - name: Install Python 3
+      - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Python 3
       uses: actions/setup-python@v3
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Install Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ cached_method==0.1.0
 click==8.1.3
 coloraide==1.8.2
 coverage==6.4.4
-flake8==6.0.0
+flake8==7.0.0
 flake8-black==0.3.6
-flake8-isort==6.0.0
+flake8-isort==6.1.1
 Flake8-pyproject==1.2.3
 frozendict==2.3.4
 isort==5.10.1
@@ -18,9 +18,9 @@ nose2==0.12.0
 packaging==23.0
 pathspec==0.11.1
 platformdirs==3.2.0
-pycodestyle==2.10.0
+pycodestyle==2.11.1
 pydot==1.4.2
-pyflakes==3.0.1
+pyflakes==3.2.0
 pygraphviz==1.10
 pyparsing==3.0.9
 pyproject_hooks==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ pyparsing==3.0.9
 pyproject_hooks==1.0.0
 tomli==2.0.1
 types-frozendict==2.0.9
-typing_extensions==4.5.0
+typing_extensions==4.9.0


### PR DESCRIPTION
@eliotwrobson This PR updates the CI jobs to run against GitHub Actions. It also adds runs the build and lint commands against multiple Python versions to ensure we aren't relying on any type features added since Python 3.8.

I _think_ I implemented everything correctly. It took a few tries to get CI working, but the issues were mostly fixed by upgrading certain dependencies in the toolchain.