### PR TITLE
Do not exclude any lines/branches from coverage report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ increased from 79 characters to 120 characters.
 2. Whether you are introducing a bug fix or a new feature, you *must* add tests
 to verify that your code additions function correctly and break nothing else.
 
-3. Please run `coverage run -m nose2 && coverage report` to ensure that code
-coverage remains close to 100%.
+3. Please run `coverage run -m nose2 && coverage report` and ensure that your
+changes are covered.
 
 4. If you are adding a new feature or changing behavior, I ask that you please
 update the README appropriately with the relevant documentation.

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -1259,7 +1259,7 @@ class DFA(fa.FA):
             total = self._count_cache[remaining][state]
             choice = rng.randint(0, total - 1)
             transition = self.transitions[state]
-            for symbol, next_state in transition.items():  # pragma: no branch
+            for symbol, next_state in transition.items():
                 next_state_count = self._count_cache[remaining - 1][next_state]
                 if choice < next_state_count:
                     result.append(symbol)

--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -146,8 +146,8 @@ class GNFA(fa.FA):
         for state in target_dfa.final_states:
             new_gnfa_transitions[state][new_final_state] = ""
 
-        for state in gnfa_states - {new_final_state}:  # pragma: no branch
-            if gnfa_states - new_gnfa_transitions[state].keys():  # pragma: no branch
+        for state in gnfa_states - {new_final_state}:
+            if gnfa_states - new_gnfa_transitions[state].keys():
                 for leftover_state in gnfa_states - new_gnfa_transitions[state].keys():
                     if leftover_state is not new_initial_state:
                         new_gnfa_transitions[state][leftover_state] = None
@@ -217,8 +217,8 @@ class GNFA(fa.FA):
         for state in target_nfa.final_states:
             new_gnfa_transitions[state][new_final_state] = ""
 
-        for state in gnfa_states - {new_final_state}:  # pragma: no branch
-            if gnfa_states - new_gnfa_transitions[state].keys():  # pragma: no branch
+        for state in gnfa_states - {new_final_state}:
+            if gnfa_states - new_gnfa_transitions[state].keys():
                 for leftover_state in gnfa_states - new_gnfa_transitions[state].keys():
                     if leftover_state is not new_initial_state:
                         new_gnfa_transitions[state][leftover_state] = None
@@ -252,7 +252,7 @@ class GNFA(fa.FA):
     ) -> None:
         """Raise an error if transition end states are invalid or missing"""
         if start_state == self.final_state:
-            if len(paths) != 0:  # pragma: no branch
+            if len(paths) != 0:
                 raise exceptions.InvalidStateError(
                     "No transitions should be defined for "
                     "final state {}".format(start_state)
@@ -275,7 +275,7 @@ class GNFA(fa.FA):
                     start_state, str(self.states - paths.keys() - {self.initial_state})
                 )
             )
-        for end_state in paths.keys():  # pragma: no branch
+        for end_state in paths.keys():
             if end_state not in self.states:
                 raise exceptions.InvalidStateError(
                     "end state {} for transition on {} is "

--- a/automata/tm/tape.py
+++ b/automata/tm/tape.py
@@ -88,7 +88,7 @@ class TMTape:
             new_position += 1
         elif direction == "N":
             pass
-        elif direction == "L":  # pragma: no branch
+        elif direction == "L":
             new_position -= 1
         # Make sure that the cursor doesn't run off the end of the tape.
         if new_position == -1:


### PR DESCRIPTION
@eliotwrobson With recent projects, I have had a change of perspective with regard to coverage. Rather than trying to achieve an often-unattainable 100% coverage score (even by excluding lines/branches that logically cannot be covered), I have reasoned it is better to give an honest and accurate score.

Because, of course, anyone can achieve a 100% code coverage score by ignoring lines/branches, and I would prefer to have the coverage scores in my projects be accurate reflections of the analysis, rather than cutting corners in the interest of "perfection".

Therefore, this PR removes all `# pragma: no cover` and `# pragma: no branch` directives, and updates the Contributing guide to remove any strict (or even implied requirement) for exact 100% coverage. Of course, we want as much to be covered as possible, but just as much as what can be achieved without ignoring lines/branches.

Anyway, that's my spiel. But I wanted to get your thoughts before adopting this change.