### PR TITLE
docs: add teaching example

### DIFF
--- a/docs/examples/teaching-examples.md
+++ b/docs/examples/teaching-examples.md
@@ -1,0 +1,77 @@
+# Teaching example
+
+This example demonstrate how `automata` can be easily used for teaching purpose.
+We adopt [this introduction to finite automata](https://www.geeksforgeeks.org/introduction-of-finite-automata/) to show how `automata` can be incorporated into the material.
+
+## Deterministic finite automaton
+
+We start by building and visualizing the deterministic finite automaton in the tutorial, which accepts any string ending in "a".
+
+```python
+from automata.fa.dfa import DFA
+
+dfa = DFA(
+    states={"q0", "q1"},
+    input_symbols={"a", "b"},
+    transitions={"q0": {"a": "q1", "b": "q0"}, "q1": {"a": "q1", "b": "q0"}},
+    initial_state="q0",
+    final_states={"q1"},
+)
+dfa.show_diagram()
+```
+
+To verify whether our automaton is functioning properly, we supply a list of input strings and check if they're accepted by the automaton.
+
+```python
+inputs = [
+    "a",
+    "aa",
+    "aaa",
+    "aaaaa",
+    "ba",
+    "bba",
+    "bbbaa",
+    "aba",
+    "abba",
+    "aaba",
+    "abaa",
+    "bb",
+    "bbbbb",
+    "bab",
+    "baab",
+    "bbab",
+    "babb",
+]
+for in_str in inputs:
+    if dfa.accepts_input(in_str):
+        print("Accepted: {}".format(in_str))
+    else:
+        print("Rejected: {}".format(in_str))
+```
+
+## Nondeterministic finite automaton
+
+We then build a nondeterministic finite automaton in the tutorial that's equivalent to the previous one.
+
+```python
+from automata.fa.nfa import NFA
+
+nfa = NFA(
+    states={"q0", "q1"},
+    input_symbols={"a", "b"},
+    transitions={"q0": {"a": {"q0", "q1"}, "b": {"q0"}}},
+    initial_state="q0",
+    final_states={"q1"},
+)
+nfa.show_diagram()
+```
+
+We can verify that they're equivalent by checking with the same list of input strings:
+
+```python
+for in_str in inputs:
+    if nfa.accepts_input(in_str):
+        print("Accepted: {}".format(in_str))
+    else:
+        print("Rejected: {}".format(in_str))
+```


### PR DESCRIPTION
I have never taken a formal CS class so it's a bit hard for me to imagine how `automata` can actually be used in class. Since one of the major purpose of this package is for education, I feel it's beneficial to include some examples of the most basic usage of the package in the context of teaching. I have included an initial draft illustrating this idea in the PR.

I think it's also a good idea to expand this to include all major functionality of the package, preferably in a continuous pipeline rather than isolated snippets. I've included building, running and visualizing the automaton so far, but it will be great to have other examples cover other use cases I missed. Right now the examples in the documentation feels like a short list of specific interesting functions you can play with, and it's hard for me to grasp in general the breadth of stuff I can do with `automata` package.