### PR TITLE
docs: Add more badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 [![PyPI version](https://badge.fury.io/py/automata-lib.svg)](https://badge.fury.io/py/automata-lib)
 [![tests](https://github.com/caleb531/automata/actions/workflows/tests.yml/badge.svg)](https://github.com/caleb531/automata/actions/workflows/tests.yml)
+[![docs](https://github.com/caleb531/automata/actions/workflows/docs.yml/badge.svg)](https://github.com/caleb531/automata/actions/workflows/docs.yml)
 [![Coverage Status](https://coveralls.io/repos/caleb531/automata/badge.svg?branch=main)](https://coveralls.io/r/caleb531/automata?branch=main)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![](https://img.shields.io/badge/python-3.8+-blue.svg)](https://pypi.org/project/automata-lib/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/automata-lib)
 [![status](https://joss.theoj.org/papers/fe4d8521383598038e38bc0c948718af/status.svg)](https://joss.theoj.org/papers/fe4d8521383598038e38bc0c948718af)
 
 - **Documentation**: https://caleb531.github.io/automata/


### PR DESCRIPTION
Added a dynamic badge to display supported Python versions and a docs building badge (since this was something requested as part of the ongoing review): https://github.com/pyOpenSci/software-submission/issues/152#issuecomment-2016551272