### PR TITLE
fix: Fix bug in minify edge case

### DIFF
--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -625,7 +625,9 @@ class DFA(fa.FA):
                                 x for x in count(-1, -1) if x not in reachable_states
                             )
                             for trap_symbol in input_symbols:
-                                transition_back_map[trap_symbol][trap_state] = [trap_state]
+                                transition_back_map[trap_symbol][trap_state] = [
+                                    trap_state
+                                ]
 
                             reachable_states.add(trap_state)
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -682,6 +682,11 @@ class DFA(fa.FA):
             if trap_state not in eq
         }
 
+        # If only one equivalence class with the trap state,
+        # return empty language.
+        if not back_map:
+            return cls.empty_language(input_symbols)
+
         new_input_symbols = input_symbols
         new_states = frozenset(back_map.values())
         new_initial_state = back_map[initial_state]

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -625,7 +625,7 @@ class DFA(fa.FA):
                                 x for x in count(-1, -1) if x not in reachable_states
                             )
                             for trap_symbol in input_symbols:
-                                transition_back_map[trap_symbol][trap_state] = []
+                                transition_back_map[trap_symbol][trap_state] = [trap_state]
 
                             reachable_states.add(trap_state)
 

--- a/automata/fa/dfa.py
+++ b/automata/fa/dfa.py
@@ -338,6 +338,7 @@ class DFA(fa.FA):
             An equivalent complete DFA.
 
         """
+
         if not self.allow_partial:
             return self.copy()
 
@@ -1707,13 +1708,18 @@ class DFA(fa.FA):
 
         states = frozenset(transitions.keys())
         final_states = {last_state}
+
+        is_partial = any(
+            len(lookup) != len(input_symbols) for lookup in transitions.values()
+        )
+
         return cls(
             states=states,
             input_symbols=input_symbols,
             transitions=transitions,
             initial_state=0,
             final_states=final_states if contains else states - final_states,
-            allow_partial=as_partial,
+            allow_partial=is_partial,
         )
 
     @classmethod

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -295,8 +295,8 @@ class TestDFA(test_fa.TestFA):
 
     def test_to_complete_no_extra_state(self) -> None:
         """Should not add an extra state if DFA is complete."""
-        alphabet = ['d','e','g','h','i','k','o','t','x']
-        substring = 'ti'
+        alphabet = ["d", "e", "g", "h", "i", "k", "o", "t", "x"]
+        substring = "ti"
         dfa = DFA.from_prefix(set(alphabet), substring, contains=False)
         self.assertEqual(dfa.states, dfa.to_complete().states)
 
@@ -314,6 +314,29 @@ class TestDFA(test_fa.TestFA):
         """Should be equivalent after minify."""
         minimal_dfa = self.no_consecutive_11_dfa.minify()
         self.assertEqual(self.no_consecutive_11_dfa, minimal_dfa)
+
+        other_dfa = DFA(
+            states={0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+            input_symbols={"a", "c", "b"},
+            transitions={
+                0: {"b": 1, "a": 2},
+                1: {"b": 3, "a": 4, "c": 5},
+                2: {"b": 6, "c": 5, "a": 4},
+                3: {"b": 7, "c": 8},
+                4: {"b": 9, "c": 10},
+                5: {"b": 9, "c": 10},
+                6: {"b": 9, "c": 10},
+                7: {"b": 7, "c": 8},
+                8: {"b": 9, "c": 10},
+                9: {"c": 10, "b": 9},
+                10: {"c": 10, "b": 9},
+            },
+            initial_state=0,
+            final_states={2, 7, 8, 9, 10},
+            allow_partial=True,
+        )
+
+        self.assertEqual(other_dfa, other_dfa.minify())
 
     def test_equivalence_two_non_minimal(self) -> None:
         """Should be equivalent even though they are non minimal."""

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -293,6 +293,13 @@ class TestDFA(test_fa.TestFA):
         with self.assertRaises(exceptions.InvalidStateError):
             self.partial_dfa.to_complete(0)
 
+    def test_to_complete_no_extra_state(self) -> None:
+        """Should not add an extra state if DFA is complete."""
+        alphabet = ['d','e','g','h','i','k','o','t','x']
+        substring = 'ti'
+        dfa = DFA.from_prefix(set(alphabet), substring, contains=False)
+        self.assertEqual(dfa.states, dfa.to_complete().states)
+
     def test_equivalence_not_equal(self) -> None:
         """Should not be equal."""
         self.assertNotEqual(self.no_consecutive_11_dfa, self.zero_or_one_1_dfa)


### PR DESCRIPTION
Fixes small bug in the minify function for partial DFAs and the as_partial check for a DFA creation function.

I think this raises the question, @caleb531 should the allow_partial be a computed property in the constructor if it is manually set by the user? i.e., if client code sets this property to true, should it be set to `False` if the transition dictionary is not partial.