### PR TITLE
Unicode characters support in regex

### DIFF
--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -209,7 +209,7 @@ class NFA(fa.FA):
             The regex to construct an equivalent NFA for.
         input_symbols : Optional[AbstractSet[str]], default: None
             The set of input symbols to create the NFA over. If not
-            set, defaults to all letters found in the regex.
+            set, defaults to all non-reserved characters found in the regex.
 
         Returns
         ------

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -2,7 +2,6 @@
 """Classes and methods for working with nondeterministic finite automata."""
 from __future__ import annotations
 
-import string
 from collections import deque
 from itertools import chain, count, product, repeat
 from typing import (

--- a/automata/fa/nfa.py
+++ b/automata/fa/nfa.py
@@ -37,7 +37,6 @@ NFAStateT = fa.FAStateT
 NFAPathT = Mapping[str, AbstractSet[NFAStateT]]
 NFATransitionsT = Mapping[NFAStateT, NFAPathT]
 InputPathListT = List[Tuple[NFAStateT, NFAStateT, str]]
-DEFAULT_REGEX_SYMBOLS = frozenset(chain(string.ascii_letters, string.digits))
 
 
 class NFA(fa.FA):
@@ -211,7 +210,7 @@ class NFA(fa.FA):
             The regex to construct an equivalent NFA for.
         input_symbols : Optional[AbstractSet[str]], default: None
             The set of input symbols to create the NFA over. If not
-            set, defaults to all ascii letters and digits.
+            set, defaults to all letters found in the regex.
 
         Returns
         ------
@@ -220,7 +219,7 @@ class NFA(fa.FA):
         """
 
         if input_symbols is None:
-            input_symbols = DEFAULT_REGEX_SYMBOLS
+            input_symbols = frozenset(regex) - RESERVED_CHARACTERS
         else:
             conflicting_symbols = RESERVED_CHARACTERS & input_symbols
             if conflicting_symbols:

--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -542,9 +542,6 @@ def get_regex_lexer(
 
     lexer.register_token(LeftParen.from_match, r"\(")
     lexer.register_token(RightParen.from_match, r"\)")
-    lexer.register_token(
-        lambda match: StringToken(match.group(), state_name_counter), r"[A-Za-z0-9]"
-    )
     lexer.register_token(UnionToken.from_match, r"\|")
     lexer.register_token(IntersectionToken.from_match, r"\&")
     lexer.register_token(ShuffleToken.from_match, r"\^")
@@ -555,6 +552,9 @@ def get_regex_lexer(
     lexer.register_token(
         lambda match: WildcardToken(match.group(), input_symbols, state_name_counter),
         r"\.",
+    )
+    lexer.register_token(
+        lambda match: StringToken(match.group(), state_name_counter), r"\S"
     )
 
     return lexer

--- a/automata/regex/regex.py
+++ b/automata/regex/regex.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """
 A set of tools for working with regular expressions. Can recognize regular expressions
-over the alphabet of ascii letters (lower and upper case), ascii digits, and subsets of
-these.
+over the alphabet of unicode characters and subsets of these, excluding blanks.
 
 A regular expression with the following operations only are supported in this library:
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -47,6 +47,11 @@ class TestRegex(unittest.TestCase):
         """Should pass validation for regular expressions with unicode characters."""
         re.validate("(µ|🤖ù)*")
 
+    def test_unicode_input_symbols(self) -> None:
+        """Should have correct unicode input symbols."""
+        nfa = NFA.from_regex("(µ🔥|🔥✨?)*")
+        self.assertEqual(nfa.input_symbols, {"µ", "🔥", "✨"})
+
     def test_isequal(self) -> None:
         """Should correctly check equivalence of two regular expressions"""
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -43,6 +43,10 @@ class TestRegex(unittest.TestCase):
         """Should pass validation for valid regular expression"""
         self.assertFalse(re._validate("a(|)"))
 
+    def test_validate_unicode_characters(self) -> None:
+        """Should pass validation for regular expressions with unicode characters."""
+        re.validate("(µ|🤖ù)*")
+
     def test_isequal(self) -> None:
         """Should correctly check equivalence of two regular expressions"""
 


### PR DESCRIPTION
Linked to #232.

Changed the order in which the tokens are registered in the regex lexer to process the rule about recognizing letters last, and changed that rule to account for all non-blank characters (as specified per python's `re` library with `\S`).

Added a test to check for the support of non-ascii characters.

This is my very first pull request ever so feel free to guide me.