### PR TITLE
Determinized regex ordering

### DIFF
--- a/automata/fa/gnfa.py
+++ b/automata/fa/gnfa.py
@@ -340,7 +340,7 @@ class GNFA(fa.FA):
                     if to_state != final_state:
                         state_degree[to_state] += 1
 
-        return min(state_degree, key=lambda x: state_degree.get(x, -1))
+        return min(state_degree, key=lambda x: (state_degree.get(x, -1), x))
 
     def to_regex(self) -> str:
         """


### PR DESCRIPTION
Resolves #231 by determinizing the order that nodes get removed in the GNFA algorithm, and adds a corresponding test.