### PR TITLE
Updated settings.json + ms-python.isort as recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "ms-python.black-formatter",
+    "ms-python.isort",
     "matangover.mypy",
     "ms-python.flake8"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.rulers": [88],
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }


### PR DESCRIPTION
Since we're using Flake8 and black, we should put the 88-line ruler, which is black's default maximum line length, so I added `"editor.rulers": [88]` to `.vscode/settings.json`.

![image](https://github.com/user-attachments/assets/d76a4c35-93ac-42e9-8124-613ddfecc7d3)

 On the other hand, `"isort.args"` is only available if we install [ms-python.isort](https://marketplace.visualstudio.com/items?itemName=ms-python.isort), which is why I added it to `.vscode/extensions.json`.
