### PR TITLE
Fixed MNTM's implementation of read_input_as_ntm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automata-lib"
-version = "8.3.0"
+version = "8.4.0"
 description = "A Python library for simulating finite automata, pushdown automata, and Turing machines"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_mntm.py
+++ b/tests/test_mntm.py
@@ -4,6 +4,7 @@
 import math
 import random
 import types
+from typing import Set, cast
 from unittest.mock import MagicMock, patch
 
 from frozendict import frozendict
@@ -407,7 +408,7 @@ class TestMNTM(test_tm.TestTM):
             # Test that it doesn't throw a RejectionException
             self.assertTrue(mntm.accepts_input(input_str))
             configs = list(mntm.read_input_stepwise(input_str))
-            final_mntm_config = configs[-1].pop()
+            final_mntm_config = cast(Set, configs[-1]).pop()
 
             # Test that the final tape of the MNTM is the same as the final tape of the
             # MNTM ran as an NTM.
@@ -429,7 +430,7 @@ class TestMNTM(test_tm.TestTM):
 
             # Now, run the MNTM as an NTM
             configs = list(mntm.read_input_as_ntm(input_str))
-            final_ntm_config = configs[-1].pop()
+            final_ntm_config = cast(Set, configs[-1]).pop()
 
             # e.g., 0110#^_11#^_ for self.mntm1 with input 0110 as a result of:
             # TMConfiguration('q1', TMTape('0110#^_11#^_', '#', 11))


### PR DESCRIPTION
Completed also `test_read_input_as_ntm()` to be able to detect whether the tapes are different after running an MNTM normally and as an NTM (which would have detected that both `mntm.accepts_input(input_str))` and `mntm.read_input_stepwise(input_str)` weren't working in unison.

Now, the following code does work:

```
from automata.tm.mntm import MNTM

# MNTM which accepts all strings of the form ww, where w is in {0, 1}*
mntm = MNTM(
    states={"q0", "q1", "q2", "q3", "q4"},
    input_symbols={"0", "1"},
    tape_symbols={"0", "1", "$", "#"},
    n_tapes=3,
    transitions={
        "q0": {
            ("0", "#", "#"): [("q1", (("0", "N"), ("$", "R"), ("$", "R")))],
            ("1", "#", "#"): [("q1", (("1", "N"), ("$", "R"), ("$", "R")))],
        },
        "q1": {
            ("0", "#", "#"): [
                ("q1", (("0", "R"), ("0", "R"), ("#", "N"))),
                ("q2", (("0", "R"), ("#", "N"), ("0", "R"))),
            ],
            ("1", "#", "#"): [
                ("q1", (("1", "R"), ("1", "R"), ("#", "N"))),
                ("q2", (("1", "R"), ("#", "N"), ("1", "R"))),
            ],
        },
        "q2": {
            ("0", "#", "#"): [("q2", (("0", "R"), ("#", "N"), ("0", "R")))],
            ("1", "#", "#"): [("q2", (("1", "R"), ("#", "N"), ("1", "R")))],
            ("#", "#", "#"): [("q3", (("#", "N"), ("#", "L"), ("#", "L")))],
        },
        "q3": {
            ("#", "0", "0"): [("q3", (("#", "N"), ("0", "L"), ("0", "L")))],
            ("#", "1", "1"): [("q3", (("#", "N"), ("1", "L"), ("1", "L")))],
            ("#", "$", "$"): [("q4", (("#", "N"), ("$", "N"), ("$", "N")))],
        },
    },
    initial_state="q0",
    blank_symbol="#",
    final_states={"q4"},
)

print(mntm.accepts_input("0101"))  # This correctly returns True
for conf in mntm.read_input_as_ntm("0101"):  # This previously threw the exception
    final_config = conf.pop()
    print(final_config)
```

The final NTM output is the following: `TMConfiguration('q4', TMTape('0101#^_$^01#_$^01#_', '#', 18))`
Whereas the final MNTM output is: `MTMConfiguration('q4', (TMTape('0101#', '#', 4), TMTape('$01#', '#', 0), TMTape('$01#', '#', 0)))`.

If we concatenate either of them, we get: `0101#^_$^01#_$^01#_` (which is what `test_read_input_as_ntm()` now tests).