### PR TITLE
Skip relevant tests if optional dependencies are missing

### DIFF
--- a/tests/optional.py
+++ b/tests/optional.py
@@ -1,0 +1,32 @@
+"""Test helpers for optional dependencies.
+
+Provides a VISUAL_OK flag indicating whether visualization extras are
+importable (pygraphviz, coloraide). Use in tests to conditionally skip
+diagram-related tests on environments lacking these extras.
+"""
+
+from __future__ import annotations
+
+# Shared skip reason for tests that require visualization extras
+VISUAL_SKIP_REASON = "visual extras (pygraphviz, coloraide) not available"
+
+PYGRAPHVIZ_OK = False
+COLORAIDE_OK = False
+
+try:  # Try importing pygraphviz, catching linkage errors too
+    import pygraphviz as pgv  # type: ignore  # noqa: F401
+
+    # Access an attribute to ensure the extension module is importable/linked
+    _ = getattr(pgv, "AGraph", None)
+    PYGRAPHVIZ_OK = True
+except Exception:
+    PYGRAPHVIZ_OK = False
+
+try:
+    import coloraide  # type: ignore  # noqa: F401
+
+    COLORAIDE_OK = True
+except Exception:
+    COLORAIDE_OK = False
+
+VISUAL_OK: bool = PYGRAPHVIZ_OK and COLORAIDE_OK

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -5,6 +5,7 @@ import os.path
 import random
 import tempfile
 import types
+import unittest
 from itertools import permutations, product
 from typing import Iterable, Tuple, TypeVar, cast
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,7 @@ import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa
 from automata.fa.dfa import DFA
 from automata.fa.nfa import NFA
+from tests.optional import VISUAL_OK, VISUAL_SKIP_REASON
 
 ArgT = TypeVar("ArgT")
 
@@ -1532,6 +1534,7 @@ class TestDFA(test_fa.TestFA):
         )
         self.assertEqual(dfa.read_input("aa"), "aa")
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_initial_final_different(self) -> None:
         """
         Should construct the diagram for a DFA whose initial state
@@ -1568,6 +1571,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dest, self.dfa.initial_state)
         self.assertTrue(source not in self.dfa.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input(self) -> None:
         """
         Should construct the diagram for a DFA reading input.
@@ -1588,6 +1592,7 @@ class TestDFA(test_fa.TestFA):
             ]
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_initial_final_same(self) -> None:
         """
         Should construct the diagram for a DFA whose initial state
@@ -1625,6 +1630,7 @@ class TestDFA(test_fa.TestFA):
         self.assertEqual(dest, dfa.initial_state)
         self.assertTrue(source not in dfa.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a DFA
@@ -1640,6 +1646,7 @@ class TestDFA(test_fa.TestFA):
         self.assertTrue(os.path.exists(diagram_path))
         os.remove(diagram_path)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_repr_mimebundle_same(self) -> None:
         """
         Check that the mimebundle is the same.
@@ -1651,6 +1658,7 @@ class TestDFA(test_fa.TestFA):
         second_repr = self.dfa.show_diagram()._repr_mimebundle_()
         self.assertEqual(first_repr, second_repr)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_orientations(self) -> None:
         graph = self.dfa.show_diagram()
         self.assertEqual(graph.graph_attr["rankdir"], "LR")
@@ -1661,6 +1669,7 @@ class TestDFA(test_fa.TestFA):
         graph = self.dfa.show_diagram(horizontal=False, reverse_orientation=True)
         self.assertEqual(graph.graph_attr["rankdir"], "BT")
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_fig_size(self) -> None:
         """
         Testing figure size. Just need to make sure it matches the input

--- a/tests/test_dpda.py
+++ b/tests/test_dpda.py
@@ -1,6 +1,7 @@
 """Classes and functions for testing the behavior of DPDAs."""
 
 import os
+import unittest
 
 from frozendict import frozendict
 
@@ -10,6 +11,7 @@ import tests.test_pda as test_pda
 from automata.pda.configuration import PDAConfiguration
 from automata.pda.dpda import DPDA
 from automata.pda.stack import PDAStack
+from tests.optional import VISUAL_OK, VISUAL_SKIP_REASON
 
 
 class TestDPDA(test_pda.TestPDA):
@@ -321,6 +323,7 @@ class TestDPDA(test_pda.TestPDA):
         )
         self.assertTrue(dpda.accepts_input(""))
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram(self) -> None:
         """Should construct the diagram for a DPDA"""
         graph = self.dpda.show_diagram()
@@ -353,6 +356,7 @@ class TestDPDA(test_pda.TestPDA):
         self.assertEqual(dest, self.dpda.initial_state)
         self.assertTrue(source not in self.dpda.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_exception(self) -> None:
         """Should raise exception"""
 
@@ -364,6 +368,7 @@ class TestDPDA(test_pda.TestPDA):
             with_stack=False,
         )
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input_machine_only(self) -> None:
         """
         Should construct the diagram with machine only for a DPDA reading input.
@@ -384,6 +389,7 @@ class TestDPDA(test_pda.TestPDA):
             ]
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input_stack_only(self) -> None:
         """
         Should construct the diagram with stack only for a DPDA reading input.
@@ -414,6 +420,7 @@ class TestDPDA(test_pda.TestPDA):
             self.assertEqual(nodes, stack_content)
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a DPDA
@@ -429,6 +436,7 @@ class TestDPDA(test_pda.TestPDA):
         self.assertTrue(os.path.exists(diagram_path))
         os.remove(diagram_path)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_orientations(self) -> None:
         graph = self.dpda.show_diagram()
         self.assertEqual(graph.graph_attr["rankdir"], "LR")
@@ -439,6 +447,7 @@ class TestDPDA(test_pda.TestPDA):
         graph = self.dpda.show_diagram(horizontal=False, reverse_orientation=True)
         self.assertEqual(graph.graph_attr["rankdir"], "BT")
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_fig_size(self) -> None:
         """
         Testing figure size. Just need to make sure it matches the input

--- a/tests/test_gnfa.py
+++ b/tests/test_gnfa.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import unittest
 from unittest.mock import MagicMock, patch
 
 import automata.base.exceptions as exceptions
@@ -9,6 +10,7 @@ import tests.test_fa as test_fa
 from automata.fa.dfa import DFA
 from automata.fa.gnfa import GNFA
 from automata.fa.nfa import NFA
+from tests.optional import VISUAL_OK, VISUAL_SKIP_REASON
 
 
 class TestGNFA(test_fa.TestFA):
@@ -422,6 +424,7 @@ class TestGNFA(test_fa.TestFA):
             regex = starting_gnfa.to_regex()
             self.assertEqual("(0(12(12)*(30|0)|30)*(12(12)*(3|1?)|(3|1?)))?", regex)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram(self) -> None:
         """
         Should construct the diagram for a GNFA.
@@ -460,6 +463,7 @@ class TestGNFA(test_fa.TestFA):
         self.assertEqual(dest, self.gnfa.initial_state)
         self.assertTrue(source not in self.gnfa.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a NFA

--- a/tests/test_nfa.py
+++ b/tests/test_nfa.py
@@ -4,6 +4,7 @@ import os
 import string
 import tempfile
 import types
+import unittest
 from itertools import product
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,7 @@ import automata.base.exceptions as exceptions
 import tests.test_fa as test_fa
 from automata.fa.dfa import DFA
 from automata.fa.nfa import NFA
+from tests.optional import VISUAL_OK, VISUAL_SKIP_REASON
 
 
 class TestNFA(test_fa.TestFA):
@@ -585,6 +587,7 @@ class TestNFA(test_fa.TestFA):
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "a(*)")
         self.assertRaises(exceptions.InvalidRegexError, NFA.from_regex, "ab(|)")
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_initial_final_same(self) -> None:
         """
         Should construct the diagram for a NFA whose initial state
@@ -621,6 +624,7 @@ class TestNFA(test_fa.TestFA):
         self.assertEqual(dest, self.nfa.initial_state)
         self.assertTrue(source not in self.nfa.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input(self) -> None:
         """
         Should construct the diagram for a NFA reading input.
@@ -642,6 +646,7 @@ class TestNFA(test_fa.TestFA):
 
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a NFA

--- a/tests/test_npda.py
+++ b/tests/test_npda.py
@@ -1,6 +1,7 @@
 """Classes and functions for testing the behavior of NPDAs."""
 
 import os
+import unittest
 
 from frozendict import frozendict
 
@@ -10,6 +11,7 @@ import tests.test_pda as test_pda
 from automata.pda.configuration import PDAConfiguration
 from automata.pda.npda import NPDA
 from automata.pda.stack import PDAStack
+from tests.optional import VISUAL_OK, VISUAL_SKIP_REASON
 
 
 class TestNPDA(test_pda.TestPDA):
@@ -392,6 +394,7 @@ class TestNPDA(test_pda.TestPDA):
         """Should return False if NPDA input is rejected."""
         self.assertFalse(self.npda.accepts_input("aaba"))
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram(self) -> None:
         """Should construct the diagram for a NPDA"""
         graph = self.npda.show_diagram()
@@ -460,6 +463,7 @@ class TestNPDA(test_pda.TestPDA):
         self.assertEqual(dest, self.npda.initial_state)
         self.assertTrue(source not in self.npda.states)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input_machine_only(self) -> None:
         """
         Should construct the diagram with machine only for a NPDA reading input.
@@ -480,6 +484,7 @@ class TestNPDA(test_pda.TestPDA):
             ]
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_read_input_stack_only(self) -> None:
         """
         Should construct the diagram with stack only for a NPDA reading input.
@@ -508,6 +513,7 @@ class TestNPDA(test_pda.TestPDA):
             self.assertEqual(nodes, stack_content)
             self.assertEqual(edge_pairs, colored_edges)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_write_file(self) -> None:
         """
         Should construct the diagram for a NPDA
@@ -523,6 +529,7 @@ class TestNPDA(test_pda.TestPDA):
         self.assertTrue(os.path.exists(diagram_path))
         os.remove(diagram_path)
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_orientations(self) -> None:
         graph = self.npda.show_diagram()
         self.assertEqual(graph.graph_attr["rankdir"], "LR")
@@ -533,6 +540,7 @@ class TestNPDA(test_pda.TestPDA):
         graph = self.npda.show_diagram(horizontal=False, reverse_orientation=True)
         self.assertEqual(graph.graph_attr["rankdir"], "BT")
 
+    @unittest.skipIf(not VISUAL_OK, VISUAL_SKIP_REASON)
     def test_show_diagram_fig_size(self) -> None:
         """
         Testing figure size. Just need to make sure it matches the input


### PR DESCRIPTION
@eliotwrobson I was dialoguing with GitHub Copilot / GPT-5 today trying to troubleshoot an installation error with `manim` on my local machine. I ended up getting it resolved—the issue was mostly due to version mismatch between the project pygraphviz and my system graphviz installations.

Interestingly, Copilot suggested that, in order to reduce impact of installation errors like this, to update the tests so that optional dependencies are imported lazily in a way that skips the visual tests if optional dependencies are not installed. So I had it make these changes to see how it would look, and the result is this PR.

I'm a bit on the fence about whether this is the right approach to take.
1. On one hand, it could be argued that _all_ of our tests should run every time.
2. But then again, for contributors who don't need to interact with the visualization features, the failing visual tests (due to system installation errors) would probably get in the way of their local development.

What do you think?