### PR TITLE
Fix {0} quantifier accepting one occurrence

### DIFF
--- a/automata/regex/parser.py
+++ b/automata/regex/parser.py
@@ -256,7 +256,7 @@ class NFARegexBuilder:
 
         new_final_states = set()
 
-        if lower_bound <= 1:
+        if lower_bound <= 1 and upper_bound != 0:
             new_final_states.update(self._final_states)
 
         # Loop around if lower bound is 0

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -192,6 +192,11 @@ class TestRegex(unittest.TestCase):
             re.isequal("a{,4}", "a?|aa|aaa|aaaa", input_symbols=input_symbols)
         )
 
+        # {0} matches the empty string only, not one occurrence (parity with re)
+        self.assertTrue(re.isequal("a{0}", "()", input_symbols=input_symbols))
+        self.assertTrue(re.isequal("a{0,0}", "()", input_symbols=input_symbols))
+        self.assertTrue(re.isequal("(ab){0}", "()", input_symbols=input_symbols))
+
         # More complex equivalences
         self.assertTrue(re.isequal("ba{,1}", "ba?", input_symbols=input_symbols))
         self.assertTrue(


### PR DESCRIPTION
## Problem

The `{0}` quantifier accepts one occurrence of its sub-pattern in addition to the empty string, so `a{0}` matches `"a"`:

```python
import re
from automata.fa.nfa import NFA

nfa = NFA.from_regex("a{0}", input_symbols=set("a"))
nfa.accepts_input("a")    # True  -- should be False
nfa.accepts_input("")     # True  -- correct

re.fullmatch("a{0}", "a") # None  (re: no match)
re.fullmatch("a{0}", "")  # match (re: empty only)
```

This reproduces for `a{0}`, `(ab){0}`, `ba{0}b`, `[ab]{0}` and `a{0,0}`. Control cases (`{0,2}`, `{0,}`, `{1}`, `{2,3}`, `*`, `?`) all already match Python `re`, so the bug is specific to the degenerate `{0,0}` bound. I found it by differential testing `from_regex` against the standard library `re` module.

## Cause

In `NFARegexBuilder.repeat()` (`automata/regex/parser.py`), the sub-pattern's final states — which accept one occurrence — are added whenever `lower_bound <= 1`. For `{0,0}` that branch fires *and* the separate `lower_bound == 0` branch adds the empty path, so the NFA accepts both zero and one occurrence.

## Fix

Exclude the degenerate `upper_bound == 0` case from the final-states branch, so `{0,0}` contributes only the empty path:

```python
if lower_bound <= 1 and upper_bound != 0:
    new_final_states.update(self._final_states)
```

`{0,}` (`upper_bound is None`) and every other bound are unaffected. After the change, `X{0}` matches the empty string only, matching Python `re` and the standard regex semantics the docs reference ("similar to the Python `re` module").

## Tests

Added `{0}` / `{0,0}` equivalence assertions to `test_quantifier` (`a{0}` ≡ `()`, the empty string). They are RED without the fix and GREEN with it; the full suite passes (418 passed, 32 skipped).

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
